### PR TITLE
feat(content): add prompt engineering techniques from Anthropic best practices

### DIFF
--- a/src/content/00-introduction/06-chapter-04-how-to-ask/index.md
+++ b/src/content/00-introduction/06-chapter-04-how-to-ask/index.md
@@ -55,7 +55,7 @@ Your Agent reads your entire message before it starts answering. Front-load the 
 
 If you need a list, ask for a list. If you need a letter, ask for a letter. If you need someone to explain something in plain language, say "plain language." If you need step-by-step instructions, ask for numbered steps. Your Agent will default to prose paragraphs if you don't specify.
 
-> **[TIP]** Adding "please use plain language, no jargon" to any medical, legal, or financial prompt will dramatically improve the readability of the response.
+> **[TIP]** Adding "please explain in plain language a high-school student could follow" to any medical, legal, or financial prompt will dramatically improve the readability of the response.
 
 > **[TIP]** Describe the style you want, not the style you don't. "Explain in plain language a high-school student could follow" works better than "don't use jargon." "Be direct and specific" works better than "don't be vague." Your Agent responds more consistently to a target than to a list of things to avoid.
 
@@ -131,7 +131,7 @@ This also makes it easier to catch mistakes. If the Agent gets Part 1 wrong, you
 
 Your Agent remembers everything within a single conversation but nothing between conversations by default. Long conversations drift. After enough back-and-forth, your Agent starts to lose the thread — it gives vaguer answers, forgets details you mentioned earlier, or repeats itself. This is not a defect. Every conversation has a limited working memory, and eventually you fill it up.
 
-**Signs it is time to start fresh:** the Agent contradicts something it said earlier. It gives a generic answer to a specific question. It stops referencing the details you provided at the beginning. It starts hedging more than it did at the start.
+**Signs it is time to start fresh:** The Agent contradicts something it said earlier. It gives a generic answer to a specific question. It stops referencing the details you provided at the beginning. It starts hedging more than it did at the start.
 
 **How to carry context forward:** Before you close the old conversation, ask: *"Summarize everything we've discussed and every decision we've made, in a format I can paste into a new conversation."* Then open a new conversation, paste that summary at the top, and continue. You lose nothing. You gain a fresh start.
 

--- a/src/content/00-introduction/06-chapter-04-how-to-ask/index.md
+++ b/src/content/00-introduction/06-chapter-04-how-to-ask/index.md
@@ -57,6 +57,28 @@ If you need a list, ask for a list. If you need a letter, ask for a letter. If y
 
 > **[TIP]** Adding "please use plain language, no jargon" to any medical, legal, or financial prompt will dramatically improve the readability of the response.
 
+> **[TIP]** Describe the style you want, not the style you don't. "Explain in plain language a high-school student could follow" works better than "don't use jargon." "Be direct and specific" works better than "don't be vague." Your Agent responds more consistently to a target than to a list of things to avoid.
+
+### Show It What You Want
+
+Sometimes the easiest way to describe what you need is to show an example. Paste in a version of the kind of output you want — even a rough one — and say "like this." Your Agent will match the structure, tone, and level of detail.
+
+This works for anything. If you want a comparison table, sketch a two-row version and ask for the full thing. If you want plain-language bullet points instead of paragraphs, write one bullet and say "do the rest like this." If you need a letter in a particular tone, paste a letter you liked and say "match this style."
+
+```
+Here is an example of the kind of summary I want:
+
+"Your plan covers 80% of lab work after your $500 deductible.
+This bill is for the 20% copay on a $340 test. You owe $68.
+This is correct and not worth appealing."
+
+Now do the same thing for this EOB: [paste the EOB]
+```
+
+One good example communicates format, reading level, length, and tone — all at once. It does the work of a whole paragraph of instructions.
+
+> **[TIP]** When your Agent keeps giving you answers in the wrong shape — too long, too formal, too many hedge words — pasting a single example of what you actually want will fix it faster than any amount of explaining.
+
 ### Ask for Options, Not Just Answers
 
 When you are making a decision, ask for options rather than a single recommendation. Your Agent does not know your full situation. Asking for three options and asking it to explain the tradeoffs of each gives you better material to work with than asking "what should I do?"
@@ -83,6 +105,8 @@ A good follow-up question has three properties: it is open-ended (not yes-or-no)
 
 **Ask for a comparison.** When the Agent's answer feels too generic to act on, give it a reference point: *"How is this different from a standard HMO?"* or *"Compared to the national average, where does this number fall?"* Comparison forces specificity the way absolute description does not.
 
+**Ask it to check its own work.** After a detailed answer, say: *"Now review what you just gave me. What did you get wrong, oversimplify, or leave out?"* Your Agent will often catch its own mistakes — a missed deadline, a clause it glossed over, an assumption it made about your situation. This is not a sign the first answer was bad. It is a second pass, the same way you would reread an important email before sending it.
+
 These techniques work on your Agent. They also work on your doctor, your lawyer, your contractor, and your teenager. The skill is the same everywhere: listen to what was said, find the gap, and ask the question that fills it.
 
 > **[TIP]** If an answer is too long, say *"Summarize that in three bullet points."* If it is too technical, say *"Explain that to someone who has never heard of this."* If it missed the point, say *"That's not what I'm asking. My actual question is [restate]."* Correcting your Agent is not rude. It is how the tool works.
@@ -97,7 +121,13 @@ After any important answer, ask: *"How confident are you in this, and what shoul
 
 ### When to Start a New Conversation
 
-Your Agent remembers everything within a single conversation but nothing between conversations by default. If you are working through a complex problem over multiple sessions, start each new session with a one-paragraph summary of what you discussed before. If a conversation has gone on so long that the Agent seems to be losing track of details, have your agent summarize the conversation and decisions and use that as the basis of a new conversation.
+Your Agent remembers everything within a single conversation but nothing between conversations by default. Long conversations drift. After enough back-and-forth, your Agent starts to lose the thread — it gives vaguer answers, forgets details you mentioned earlier, or repeats itself. This is not a defect. Every conversation has a limited working memory, and eventually you fill it up.
+
+**Signs it is time to start fresh:** the Agent contradicts something it said earlier. It gives a generic answer to a specific question. It stops referencing the details you provided at the beginning. It starts hedging more than it did at the start.
+
+**How to carry context forward:** Before you close the old conversation, ask: *"Summarize everything we've discussed and every decision we've made, in a format I can paste into a new conversation."* Then open a new conversation, paste that summary at the top, and continue. You lose nothing. You gain a fresh start.
+
+If you are working through a complex problem over multiple sessions, start each new session with a one-paragraph summary of where you left off. Think of it like clearing a cluttered desk — the papers are filed, not thrown away.
 
 > **[ALSO]** Claude calls persistent cross-conversation memory simply "Memory" — it can be enabled in settings and will carry facts about you from session to session. Gemini calls this "Personalization." ChatGPT calls it "Memory." All three work similarly: the tool builds a profile of your situation over time so you don't have to re-explain it. This is different from Projects / Gems / Custom GPTs, which are manually configured contexts. See [Appendix G](06-appendix-g-feature-table.xhtml).
 

--- a/src/content/00-introduction/06-chapter-04-how-to-ask/index.md
+++ b/src/content/00-introduction/06-chapter-04-how-to-ask/index.md
@@ -111,6 +111,8 @@ These techniques work on your Agent. They also work on your doctor, your lawyer,
 
 > **[TIP]** If an answer is too long, say *"Summarize that in three bullet points."* If it is too technical, say *"Explain that to someone who has never heard of this."* If it missed the point, say *"That's not what I'm asking. My actual question is [restate]."* Correcting your Agent is not rude. It is how the tool works.
 
+> **[TIP]** If follow-ups are not getting you closer, start over with different words. The same question asked a different way often produces a different — and better — answer. This is true across every major Agent: Claude, ChatGPT, Gemini, all of them. Different phrasing activates different patterns. If "What are my options for appealing this?" is not working, try "Walk me through the appeals process for a denied insurance claim, step by step."
+
 ### Ask for the Conservative Answer When Stakes Are High
 
 For medical, legal, and financial questions, add: *"Please give me the most cautious, conservative answer. I would rather over-prepare than under-prepare."* This adjusts the response away from edge cases and toward the safest reasonable interpretation.[^4-2]
@@ -118,6 +120,12 @@ For medical, legal, and financial questions, add: *"Please give me the most caut
 ### The Calibration Question
 
 After any important answer, ask: *"How confident are you in this, and what should I independently verify?"* Your Agent will tell you where its answer is reliable and where you should double-check with a professional or a primary source. This is not a sign of weakness in the tool. It is the most useful question in the book.
+
+### When a Question Is Too Big for One Prompt
+
+If your question has multiple parts — "I need to understand my lease, figure out if my landlord violated it, and draft a letter" — ask about each part separately. One question per message. Your Agent handles a focused question better than a sprawling one, the same way a contractor gives you a better answer about the roof when you are not also asking about the plumbing and the fence.
+
+This also makes it easier to catch mistakes. If the Agent gets Part 1 wrong, you can fix it before it uses that wrong answer to build Part 2.
 
 ### When to Start a New Conversation
 

--- a/src/content/01-strategies/01-strategy-1-decode/index.md
+++ b/src/content/01-strategies/01-strategy-1-decode/index.md
@@ -45,7 +45,7 @@ Please:
 
 **When the document is long:** Paste the full document first, then put your question after it. Your Agent reads your entire message before it starts answering — putting the document up front gives it the full picture before you ask anything.
 
-For especially long or dense documents, add a fourth instruction: *"Quote the specific sections you're basing your answer on."* This forces your Agent to show its work — to point at the exact clause, paragraph, or line item before interpreting it. You can check whether it read the right part before you trust the interpretation.
+For especially long or dense documents, add an instruction to quote the source: *"Quote the specific sections you're basing your answer on."* This forces your Agent to show its work — to point at the exact clause, paragraph, or line item before interpreting it. You can check whether it read the right part before you trust the interpretation.
 
 ```
 I received this 12-page contractor agreement and need to understand

--- a/src/content/01-strategies/01-strategy-1-decode/index.md
+++ b/src/content/01-strategies/01-strategy-1-decode/index.md
@@ -43,6 +43,25 @@ Please:
    someone in my position
 ```
 
+**When the document is long:** Paste the full document first, then put your question after it. Your Agent reads your entire message before it starts answering — putting the document up front gives it the full picture before you ask anything.
+
+For especially long or dense documents, add a fourth instruction: *"Quote the specific sections you're basing your answer on."* This forces your Agent to show its work — to point at the exact clause, paragraph, or line item before interpreting it. You can check whether it read the right part before you trust the interpretation.
+
+```
+I received this 12-page contractor agreement and need to understand
+what I'm actually agreeing to. The full document is below.
+
+[Paste the document here]
+
+Please:
+1. Quote the specific clauses that affect my rights or obligations
+2. Summarize each one in plain language
+3. Flag anything unusual or that limits my options
+4. List the two or three things that matter most before I sign
+```
+
+> **[TIP]** When you paste a document, put it *before* your question, not after. The order matters — your Agent pays closest attention to what comes just before the question. Document first, question last.
+
 > **[SCIENCE]** Legal boilerplate is written at a 16th-grade reading level on average — four grades above the standard proficient adult reader benchmark. Comprehension among adults without college degrees drops to near zero at this complexity level. Millions of Americans sign documents every year whose terms they cannot parse. This is not a literacy problem. It is a design problem.[^s1-1]
 
 [^s1-1]: Sovern, J. (2014). "Towards More Readable Contracts." *Touro Law Review*, 30(2). The reading level figure is consistent across multiple independent studies of consumer contracts, insurance policies, and lease agreements.

--- a/src/content/03-general-method/02-chapter-32-consistent-answers/index.md
+++ b/src/content/03-general-method/02-chapter-32-consistent-answers/index.md
@@ -31,6 +31,8 @@ what it is based on, and flag anything I should independently
 verify with a professional.
 ```
 
+> **[TIP]** For complicated questions — anything with multiple parts, tradeoffs, or "it depends" answers — add: *"Think through this step by step before giving me your answer."* This sounds simple but it measurably improves accuracy. It forces your Agent to reason through the problem rather than jumping to a conclusion. The more moving parts in your question, the more this helps.
+
 ### Ask for the most conservative interpretation
 
 For legal, medical, and financial questions:

--- a/src/content/03-general-method/02-chapter-32-consistent-answers/index.md
+++ b/src/content/03-general-method/02-chapter-32-consistent-answers/index.md
@@ -49,6 +49,18 @@ Can you turn that into a checklist I can print out and work
 through item by item?
 ```
 
+### Ask your Agent to review its own answer
+
+For important questions, ask your Agent to take a second pass before you act on the answer:
+
+```
+Now review what you just told me. What did you get wrong,
+oversimplify, or leave out? What would change if my situation
+were slightly different?
+```
+
+Your Agent will often catch its own oversights — a missed exception, an assumption it made about your circumstances, a detail it glossed over for brevity. This is not a sign the first answer was unreliable. It is the same principle as rereading a contract before signing: the second read catches what the first read missed. For high-stakes questions — legal, medical, financial — a self-review followed by the calibration question below gives you two layers of error-checking before you act.
+
 ### The calibration question
 
 After any important answer, before you close the conversation:


### PR DESCRIPTION
Audit against Anthropic's official prompt engineering guidelines identified
five gaps in the book's coverage. Adds: few-shot examples ("Show It What
You Want"), positive-framing tip, quote-grounding and document positioning
for long documents, context window drift awareness with carry-forward
technique, and self-correction prompting as a follow-up and reliability
technique.

https://claude.ai/code/session_01WZVt9dEsLAtNgfo1YmPf3c