### PR TITLE
fix(content): create Ch 34 Al Borland art brief sidecar

### DIFF
--- a/src/content/03-general-method/04-chapter-34-teaching/epigraph-ch34-al-borland.art.md
+++ b/src/content/03-general-method/04-chapter-34-teaching/epigraph-ch34-al-borland.art.md
@@ -1,0 +1,8 @@
+---
+format: png
+size: margin
+alt: >
+  An 8-bit pixel art rendering of Al Borland from Home Improvement, holding a clipboard and looking patient.
+---
+
+Al Borland in 8-bit pixel art, approximately 32x48 pixels scaled up. Standing pose with flannel shirt and beard. Holding a clipboard at chest height — the specification document Tim never reads. Patient, competent expression. 4-color palette: flannel red/black plaid, skin tone, beard brown, clipboard white. Colored in ballpoint over pencil grid. Transparent background.

--- a/src/content/03-general-method/04-chapter-34-teaching/epigraph-ch34-al-borland.art.md
+++ b/src/content/03-general-method/04-chapter-34-teaching/epigraph-ch34-al-borland.art.md
@@ -2,7 +2,7 @@
 format: png
 size: margin
 alt: >
-  An 8-bit pixel art rendering of Al Borland from Home Improvement, holding a clipboard and looking patient.
+  Al Borland as the patient assistant, holding the specification document.
 ---
 
-Al Borland in 8-bit pixel art, approximately 32x48 pixels scaled up. Standing pose with flannel shirt and beard. Holding a clipboard at chest height — the specification document Tim never reads. Patient, competent expression. 4-color palette: flannel red/black plaid, skin tone, beard brown, clipboard white. Colored in ballpoint over pencil grid. Transparent background.
+Al Borland in 8-bit pixel art, approximately 32x48 pixels scaled up. Standing pose with flannel shirt and beard. Holding a clipboard at chest height—the specification document Tim never reads. Patient, competent expression. 4-color palette: flannel red/black plaid, skin tone, beard brown, clipboard white. Colored in ballpoint over pencil grid. Transparent background.

--- a/src/content/03-general-method/04-chapter-34-teaching/index.dj
+++ b/src/content/03-general-method/04-chapter-34-teaching/index.dj
@@ -13,12 +13,7 @@ _— [George Bernard Shaw](https://en.wikipedia.org/wiki/Man%5Fand%5FSuperman), 
 
 _(He was wrong. With specification literacy, doing and teaching are the same act.)_
 
-<!-- art
-file: epigraph-ch34-al-borland.png
-size: margin
-alt: An 8-bit pixel art rendering of Al Borland from Home Improvement, holding a clipboard and looking patient.
-brief: Al Borland in 8-bit pixel art, approximately 32x48 pixels scaled up. Standing pose with flannel shirt and beard. Holding a clipboard at chest height — the specification document Tim never reads. Patient, competent expression. 4-color palette: flannel red/black plaid, skin tone, beard brown, clipboard white. Colored in ballpoint over pencil grid. Transparent background.
--->
+[epigraph-ch34-al-borland]{.art}
 
 ---
 


### PR DESCRIPTION
## Summary
- Extracts the inline HTML comment art spec in Ch 34 into a proper `.art.md` sidecar file (`epigraph-ch34-al-borland.art.md`)
- Replaces the HTML comment in the chapter with the standard Djot `[epigraph-ch34-al-borland]{.art}` reference
- Follows the same format as other epigraph art briefs (e.g., `epigraph-ch1-picard.art.md`)

Resolves TODO item "Part 3: Ch 34 Art Brief".

## Test plan
- [ ] Verify `npm run build` still produces the chapter with the art placeholder
- [ ] Confirm the `.art.md` sidecar is picked up by the art-briefs filter

https://claude.ai/code/session_014aaUzXEF79QoY1EjxCUKf2