### PR TITLE
fix(content): rationalize WB-* entry numbering

### DIFF
--- a/src/content/00-introduction/04-chapter-02-first-three-conversations/index.dj
+++ b/src/content/00-introduction/04-chapter-02-first-three-conversations/index.dj
@@ -71,7 +71,7 @@ a customer service bot.
 
 Where to find it: in Claude, look for *Profile* in settings. In ChatGPT, *Custom Instructions*. In Gemini, *Saved Info*. All three are in the settings menu.
 
-The difference between a generic Agent and _your_ Agent is ten minutes in that panel. For the full setup — what to put in your profile, how to manage it, and what to skip — see WB-7: Customize Your Chat Interface in the Field Guide.
+The difference between a generic Agent and _your_ Agent is ten minutes in that panel. For the full setup — what to put in your profile, how to manage it, and what to skip — see WB-3: Customize Your Chat Interface in the Field Guide.
 
 ::: science
 There are two kinds of fit: the friend you like and the co-worker who makes you better. Psychologists call them [supplementary fit and complementary fit](https://en.wikipedia.org/wiki/Person%E2%80%93environment%5Ffit) (Muchinsky & Monahan, 1987). Supplementary fit — similarity in tone, values, communication style — predicts satisfaction and trust. You keep talking to the Agent because it feels right. Complementary fit — difference in thinking style — predicts performance. The detail-oriented person who pairs with a big-picture challenger makes better decisions than two detail people agreeing with each other (Belbin, 1981; Humphrey et al., 2007). The practical version: match your Agent's _voice_ to yours for comfort, but consider setting its _thinking style_ to challenge yours. _"When I present a plan, push back on the weakest part before agreeing"_ is a custom instruction that makes your Agent a better co-worker, not a nicer friend.[^2-3]

--- a/src/content/02-field-guide/05-life/index.dj
+++ b/src/content/02-field-guide/05-life/index.dj
@@ -69,7 +69,7 @@ invent details I haven't given you.
 [phone-camera-bigfoot]{.art}
 
 *Strategy:* Create + Diagnose
-*See also:* WB-8: Learning Any App or Digital Skill, Li-5: Planning Trips (for travel photography)
+*See also:* WB-1: Learning Any App or Digital Skill, Li-5: Planning Trips (for travel photography)
 *The Majordomo says:* _A professional portrait photographer charges $200 to $500 per session. A wedding photographer charges $2,000 to $5,000. Photography courses run $500 and up. The gap between a snapshot and a good photograph is not the camera — your phone has been good enough for years. The gap is composition, light, and knowing what to leave out of the frame. These are learnable skills. The billionaire class has a personal photographer on retainer. You have a patient tutor who has studied every composition technique Annie Leibovitz ever used and will explain them in terms of the photo you are about to take._
 *The spec:*
 ::: prompt
@@ -406,7 +406,7 @@ Mullainathan & Shafir (2013) document "scarcity mindset" — financial stress re
 
 #### Li-15: Learning Visual Design
 *Strategy:* Create + Research (Expert Role)
-*See also:* Li-3: Taking Better Photos (the same compositional principles apply), WB-1: Building Your Own Website (for applying design to your site), WB-8: Learning Any App or Digital Skill (for learning design software)
+*See also:* Li-3: Taking Better Photos (the same compositional principles apply), WB-5: Building Your Own Website (for applying design to your site), WB-1: Learning Any App or Digital Skill (for learning design software)
 *The Majordomo says:* _A graphic designer charges $50 to $150 an hour. A brand identity package — logo, colors, typography, templates — runs $5,000 and up. Design school is a four-year degree that teaches principles you can learn in an afternoon and taste you develop by doing. The principles are not secret. Hierarchy, contrast, alignment, proximity, repetition — five words that govern every poster, website, business card, and yard sale flyer you have ever seen. The difference between the yard sale flyer that works and the one nobody reads is not talent. It is knowing those five words and what they mean. The billionaire class has a design team on retainer. You have your Agent, and it knows the same principles._
 *The spec:*
 ::: prompt
@@ -650,7 +650,7 @@ Habit advice assumes discretionary time. If you are working two jobs or caregivi
 [camcorder]{.art}
 
 *Strategy:* Create + Navigate
-*See also:* Li-3: Taking Better Photos (the visual skills transfer), WB-8: Learning Any App or Digital Skill (for learning the software)
+*See also:* Li-3: Taking Better Photos (the visual skills transfer), WB-1: Learning Any App or Digital Skill (for learning the software)
 *The Majordomo says:* _Film school costs six figures and takes four years. YouTube tutorials on video editing assume you already know what a “J-cut” is and why you want one. Professional editors charge $50 to $150 an hour and are booked months out. Meanwhile, the software is free — [DaVinci Resolve](https://en.wikipedia.org/wiki/DaVinci%5FResolve) does what a $100,000 Avid suite did in 1995 — but the storytelling craft of editing, the part where raw footage becomes something someone wants to watch, has not been democratized. It still lives in film schools and editing suites. Your Agent knows the craft. It can tell you why the pacing feels off, what to cut, and where the story actually starts. It is never the first clip._
 *The spec:*
 ::: prompt
@@ -763,7 +763,7 @@ Write in plain text files — `.txt` or [CommonMark](https://commonmark.org/) `.
 
 Plain text is also what your Agent reads best. A `.docx` file is a compressed archive full of XML formatting markup that eats tokens — the units that determine how much your Agent can read and respond to in one conversation. On free tiers, where every token counts, a manuscript in `.docx` can consume twice the tokens of the same words in `.txt`. Your Agent reads plain text faster, and when it rewrites a chapter, it can hand you back the entire file — no formatting to reconstruct, no track changes to untangle.
 
-You do not need to buy anything. TextEdit is already on your Mac. Notepad is already on your PC. On your phone, a free text editor is one app store search away. If you need help setting it up, that is a conversation for your Agent — see WB-7: Choosing a Device or Operating System and WB-8: Learning Any App or Digital Skill. See also WB-3: Writing in CommonMark for the two-minute upgrade from plain text to light formatting.
+You do not need to buy anything. TextEdit is already on your Mac. Notepad is already on your PC. On your phone, a free text editor is one app store search away. If you need help setting it up, that is a conversation for your Agent — see WB-1: Learning Any App or Digital Skill. See also WB-7: Writing in CommonMark for the two-minute upgrade from plain text to light formatting.
 :::
 
 

--- a/src/content/02-field-guide/10-computer-and-web/index.dj
+++ b/src/content/02-field-guide/10-computer-and-web/index.dj
@@ -28,12 +28,12 @@ The internet was supposed to be [Geocities](https://en.wikipedia.org/wiki/GeoCit
 
 ---
 
-#### WB-8: Learning Any App or Digital Skill
+#### WB-1: Learning Any App or Digital Skill
 
 <!-- image idea: #2 sketch of hypercard's icon -->
 
 *Strategy:* Decode + Navigate
-*See also:* WB-3: Writing in CommonMark (a specific digital skill), W-5: Learning a New Professional Skill
+*See also:* WB-7: Writing in CommonMark (a specific digital skill), W-5: Learning a New Professional Skill
 *The Majordomo says:* _Software manuals died in the early 2000s and were replaced by nothing. YouTube tutorials assume you already know the vocabulary. Official documentation is written for developers. The result is a population that uses about 10% of the tools they pay for — not because they are incapable of learning the other 90%, but because no one will explain it at the level they're actually at, without judgment, for as long as it takes. Your Agent will._
 *The spec:*
 ::: prompt
@@ -87,12 +87,12 @@ The digital skills gap is a class issue. The OECD's Survey of Adult Skills (2024
 
 ---
 
-#### WB-9: Automation and Script Writing
+#### WB-2: Automation and Script Writing
 
 [applescript-icon]{.art}
 
 *Strategy:* Create + Navigate
-*See also:* WB-1: Building Your Own Website (for web-scale projects), WB-3: Writing in CommonMark
+*See also:* WB-5: Building Your Own Website (for web-scale projects), WB-7: Writing in CommonMark
 *The Majordomo says:* _Programming used to require a computer science degree, or at minimum the personality type that enjoys reading documentation for fun. It does not anymore. Your Agent can write small programs — scripts — that automate the tedious parts of your digital life: renaming five hundred photos, sorting a spreadsheet, converting files from one format to another, scraping a price from a website every morning. You do not need to learn to code. You need to learn to describe what you want the code to do. Which is — and this is the point of this entire book — specification._
 *The spec:*
 ::: prompt
@@ -146,7 +146,7 @@ Write scripts for yourself, not software for others. A script that renames your 
 
 
 ::: also
-Vibe coding evolved. Professional engineers now practice _agentic coding_ — writing specifications upfront and letting AI agents build against them, with guardrails, conventions, and architectural decisions pre-written as plugins the agent follows. The spec _is_ the software. This book's companion project, [Anglesite](https://anglesite.dwk.io), is built this way: an AI webmaster that follows IndieWeb best practices to build you a static, free website on your own domain. If you want to build a website, see WB-1.
+Vibe coding evolved. Professional engineers now practice _agentic coding_ — writing specifications upfront and letting AI agents build against them, with guardrails, conventions, and architectural decisions pre-written as plugins the agent follows. The spec _is_ the software. This book's companion project, [Anglesite](https://anglesite.dwk.io), is built this way: an AI webmaster that follows IndieWeb best practices to build you a static, free website on your own domain. If you want to build a website, see WB-5.
 :::
 
 
@@ -160,10 +160,10 @@ Vibe coding evolved. Professional engineers now practice _agentic coding_ — wr
 
 ---
 
-#### WB-7: Customize Your Chat Interface
+#### WB-3: Customize Your Chat Interface
 
 *Strategy:* Specify
-*See also:* WB-10: Learn to Work Better with AI Agents, Chapter 2: Your First Three Conversations, Chapter 4: How to Ask for What You Actually Want
+*See also:* WB-4: Learn to Work Better with AI Agents, Chapter 2: Your First Three Conversations, Chapter 4: How to Ask for What You Actually Want
 *The Majordomo says:* _When the billionaire class hired a personal assistant, the first week was an audition — not of competence, but of fit. Does she send bullet points or paragraphs? Does he say "Mr. Arnault" or "Bernard"? Does she flag problems immediately or save them for the morning briefing? The assistant who survived the probation period was the one who matched the principal's communication rhythm without being told twice. Your Agent has the same capacity for customization — and unlike a human assistant, it will not take the feedback personally. The difference is that the billionaire paid for a three-month trial period. You get a settings panel and ten minutes._
 *The spec:*
 ::: prompt
@@ -226,7 +226,7 @@ The billionaire class treated the personal assistant hire like a casting call �
 
 ---
 
-#### WB-10: Learn to Work Better with AI Agents
+#### WB-4: Learn to Work Better with AI Agents
 
 [eliza-icon]{.art}
 
@@ -291,12 +291,12 @@ Research on expertise development (Ericsson et al., 1993) identifies _deliberate
 
 ---
 
-#### WB-1: Build a Website, Own Your Corner of the Internet
+#### WB-5: Build a Website, Own Your Corner of the Internet
 
 [netscape-icon]{.art}
 
 *Strategy:* Create + Navigate
-*See also:* WB-3: Writing in CommonMark (for writing your content), WB-5: Blogging and Journaling
+*See also:* WB-7: Writing in CommonMark (for writing your content), WB-8: Blogging and Journaling
 *The Majordomo says:* _The billionaire class has always had a web presence managed by professionals. The rest of us got Facebook pages and LinkedIn profiles — land we rent on platforms that can change the terms, throttle the reach, or disappear the content at any time. Owning your own website is the digital equivalent of owning your home instead of renting it. It has always been possible. It has not always been this easy. The [IndieWeb](https://indieweb.org/) is the movement that says: publish on your own site first, syndicate to the platforms second, and never lose your words because a company pivoted._
 *The spec:*
 ::: prompt
@@ -357,12 +357,12 @@ The web was designed as a decentralized system — [RFC 2616](https://en.wikiped
 
 ---
 
-#### WB-2: Stop Doomscrolling the Algorithmic Feed
+#### WB-6: Stop Doomscrolling the Algorithmic Feed
 
 [borg-bill-gates]{.art}
 
 *Strategy:* Research + Navigate
-*See also:* Li-11: Escaping Social Media (for reducing compulsive consumption), WB-1: Build a Website, Own Your Corner of the Internet
+*See also:* Li-11: Escaping Social Media (for reducing compulsive consumption), WB-5: Build a Website, Own Your Corner of the Internet
 *The Majordomo says:* _Before the algorithm, there was RSS — a protocol that let you subscribe to any website and receive its updates in a single reader, in chronological order, with no ads, no ranking, no engagement optimization, and no company deciding what you should see next. RSS still works. It never stopped working. The platforms just stopped promoting it because a protocol that gives users control does not generate advertising revenue._
 *The spec:*
 ::: prompt
@@ -418,12 +418,12 @@ The wealthy and educated have always curated their information sources — subsc
 
 ---
 
-#### WB-3: Write in CommonMark, the language of AI
+#### WB-7: Write in CommonMark, the language of AI
 
 [commonmark-logo]{.art}
 
 *Strategy:* Decode + Draft
-*See also:* WB-1: Building Your Own Website, WB-5: Blogging and Journaling
+*See also:* WB-5: Building Your Own Website, WB-8: Blogging and Journaling
 *The Majordomo says:* _[CommonMark](https://commonmark.org/) is the universal language of AI the way English is the universal language of air traffic control — not because it is the best, but because everyone agreed on it and it works. It is plain text with a few symbols that mean things. You can learn the whole language in ten minutes. This book was written in it. Your Agent thinks in it. When you write in CommonMark, you are writing in the lingua franca of every AI system on the market — which means your Agent can process, format, and transform your writing using fewer tokens and with greater precision than any other format._
 *The spec:*
 ::: prompt
@@ -466,12 +466,12 @@ In the pre-web era, citation was gatekept by publishers, editors, and academic i
 
 ---
 
-#### WB-5: Blogging and Journaling
+#### WB-8: Blogging and Journaling
 
 [composition-notebook]{.art}
 
 *Strategy:* Create + Draft
-*See also:* WB-3: Writing in CommonMark, WB-1: Build a Website, Own Your Corner of the Internet, Li-8: Wellness Coach (journaling as mental health practice)
+*See also:* WB-7: Writing in CommonMark, WB-5: Build a Website, Own Your Corner of the Internet, Li-8: Wellness Coach (journaling as mental health practice)
 *The Majordomo says:* _Every sitcom family had a room where the real conversations happened. For the [Conners](https://en.wikipedia.org/wiki/Roseanne) it was the kitchen table. For the [Seinfelds](https://en.wikipedia.org/wiki/Seinfeld) it was the apartment. For the [Simpsons](https://en.wikipedia.org/wiki/The%5FSimpsons) it was the couch. A blog is that room — except you built it yourself, you own the walls, and nobody can cancel the show. A journal is the same room with the door closed. Both are acts of thinking in public or in private, and both are more valuable than you think._
 *The spec:*
 ::: prompt
@@ -536,9 +536,9 @@ Research on [reflective practice](https://en.wikipedia.org/wiki/Reflective%5Fpra
 
 ---
 
-#### WB-6: Preservation and Legacy
+#### WB-9: Preservation and Legacy
 *Strategy:* Research + Navigate
-*See also:* WB-1: Building Your Own Website (owning vs. renting), H-7: Preparing for End-of-Life Conversations (the analog equivalent)
+*See also:* WB-5: Building Your Own Website (owning vs. renting), H-7: Preparing for End-of-Life Conversations (the analog equivalent)
 *The Majordomo says:* _The [Library of Alexandria](https://en.wikipedia.org/wiki/Library%5Fof%5FAlexandria) burned. The Dead Sea Scrolls survived in clay jars for two thousand years. MySpace lost 50 million songs in a server migration. [GeoCities](https://en.wikipedia.org/wiki/GeoCities) was deleted by Yahoo in 2009. The lesson is consistent across millennia: what survives is what someone deliberately chose to preserve. The internet remembers everything and nothing — everything that someone archived, nothing that was left on a platform that shut down, pivoted, or lost a database._
 *The spec:*
 ::: prompt

--- a/src/content/04-appendices/00-appendix-a-quick-reference/index.dj
+++ b/src/content/04-appendices/00-appendix-a-quick-reference/index.dj
@@ -153,11 +153,15 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 
 | Entry | Strategy | Spec opener |
 |---|---|---|
-| WB-1: Building Your Own Website with Your Agent | Create + Navigate | "I want to build my own personal website. I have never done this before..." |
-| WB-2: Reading Without the Algorithm | Research + Navigate | "I want to read the web on my own terms -- without algorithms..." |
-| WB-3: Writing in CommonMark | Decode + Draft | "I want to learn CommonMark so I can write content for my website..." |
-| WB-5: Blogging and Journaling | Create + Draft | "I want to start [blogging publicly / journaling privately / both]..." |
-| WB-6: Preservation and Legacy | Research + Navigate | "I want to make sure my online work -- writing, photos, creative projects -- survives..." |
+| WB-1: Learning Any App or Digital Skill | Decode + Navigate | "I want to learn [app or skill]..." |
+| WB-2: Automation and Script Writing | Create + Navigate | "I have a repetitive task I want to automate..." |
+| WB-3: Customize Your Chat Interface | Specify | "I want to set up my AI assistant's profile..." |
+| WB-4: Learn to Work Better with AI Agents | Specify + Research | "I want to get better at working with AI Agents..." |
+| WB-5: Building Your Own Website with Your Agent | Create + Navigate | "I want to build my own personal website. I have never done this before..." |
+| WB-6: Reading Without the Algorithm | Research + Navigate | "I want to read the web on my own terms -- without algorithms..." |
+| WB-7: Writing in CommonMark | Decode + Draft | "I want to learn CommonMark so I can write content for my website..." |
+| WB-8: Blogging and Journaling | Create + Draft | "I want to start [blogging publicly / journaling privately / both]..." |
+| WB-9: Preservation and Legacy | Research + Navigate | "I want to make sure my online work -- writing, photos, creative projects -- survives..." |
 
 ---
 


### PR DESCRIPTION
## Summary
- Renumbers Online Presence (WB-*) entries from non-sequential (WB-8, 9, 7, 10, 1, 2, 3, 5, 6) to sequential WB-1 through WB-9 matching chapter order
- Updates all cross-references across 4 files: Computer & Web field guide, Life field guide, Ch 2, and Appendix A
- Adds WB-1 through WB-4 to Appendix A Quick Reference (previously missing from the table)
- Removes a stale cross-reference to a nonexistent entry ("Choosing a Device or Operating System")

**Renumbering map:**

| New | Old | Title |
|-----|-----|-------|
| WB-1 | WB-8 | Learning Any App or Digital Skill |
| WB-2 | WB-9 | Automation and Script Writing |
| WB-3 | WB-7 | Customize Your Chat Interface |
| WB-4 | WB-10 | Learn to Work Better with AI Agents |
| WB-5 | WB-1 | Build a Website |
| WB-6 | WB-2 | Stop Doomscrolling the Algorithmic Feed |
| WB-7 | WB-3 | Write in CommonMark |
| WB-8 | WB-5 | Blogging and Journaling |
| WB-9 | WB-6 | Preservation and Legacy |

Resolves TODO item "Part 2: WB-* Entry Numbering".

## Test plan
- [ ] Verify all WB-* cross-references resolve to the correct entry
- [ ] Verify Appendix A table is complete and matches chapter content
- [ ] Check ePub build renders all entries correctly

https://claude.ai/code/session_014aaUzXEF79QoY1EjxCUKf2