### PR TITLE
Add analysis of OpenAI industrial policy document against book thesis

### DIFF
--- a/spec/analysis-openai-industrial-policy.md
+++ b/spec/analysis-openai-industrial-policy.md
@@ -1,0 +1,174 @@
+# OpenAI "Industrial Policy for the Intelligence Age" — Alignment Analysis
+
+*April 2026. Analysis of how OpenAI's policy vision intersects with the book's thesis, and where the book's civics arguments can be strengthened.*
+
+Source: [Industrial Policy for the Intelligence Age: Ideas to Keep People First](https://cdn.openai.com/pdf/561e7512-253e-424b-9734-ef4098440601/Industrial%20Policy%20for%20the%20Intelligence%20Age.pdf) (OpenAI, April 2026)
+
+---
+
+## Executive Summary
+
+OpenAI's document is a 13-page policy white paper proposing a new industrial policy agenda for the "transition to superintelligence." It reads like a New Deal pitch written by a company that would prefer to be the one electrifying the country. The alignment with our book is substantial on diagnosis and almost nonexistent on method. Where OpenAI says "build institutions," we say "teach people to use the ones that exist — and to demand better ones." Both are needed. The book can claim that ground explicitly.
+
+The biggest opportunity: OpenAI's document repeatedly calls for "mechanisms for public input" and "democratic participation" without once describing what that looks like for an actual person. Our civic field guide is the answer to their call. We should say so.
+
+---
+
+## What the Document Actually Says
+
+### Thesis
+AI is progressing toward superintelligence. This transition will be as significant as electrification or the combustion engine. It requires a new industrial policy — analogous to the Progressive Era and New Deal — to ensure broad prosperity, safety, and democratic governance. OpenAI positions itself as a participant in (not a target of) that policy conversation.
+
+### Part 1: Building an Open Economy
+- **Worker perspectives**: Workers should have formal voice in AI deployment decisions
+- **AI-first entrepreneurs**: Microgrants and "startup-in-a-box" to help domain experts build AI businesses
+- **"Right to AI"**: Foundational access to AI, analogous to literacy, electricity, internet
+- **Tax base modernization**: Shift from payroll to capital-based taxation as AI displaces labor income
+- **Public Wealth Fund**: Sovereign fund seeded by AI companies, distributing returns to all citizens
+- **Grid expansion**: Public-private partnerships for energy infrastructure
+- **Efficiency dividends**: 32-hour workweek pilots, benefits-sharing from AI productivity gains
+- **Adaptive safety nets**: Automatic triggers for expanded UI/SNAP/training when displacement metrics spike
+- **Portable benefits**: Healthcare, retirement, training decoupled from single employer
+- **Care economy pathways**: Expand human-centered work (childcare, eldercare, education) as AI absorbs other jobs
+- **Scientific discovery**: Distributed AI-enabled labs at universities, community colleges, hospitals
+
+### Part 2: Building a Resilient Society
+- **Safety systems**: Red teaming, threat modeling, medical countermeasures
+- **AI trust stack**: Provenance, verification, privacy-preserving audit logs
+- **Auditing regimes**: Strengthen CAISI, create competitive auditor market
+- **Model-containment playbooks**: Response plans for dangerous models that can't be recalled
+- **Mission-aligned governance**: PBCs, anti-capture mechanisms for frontier AI companies
+- **Government guardrails**: Rules for government AI use, FOIA modernization
+- **Public input mechanisms**: Democratic participation in AI alignment decisions
+- **Incident reporting**: Near-miss sharing between companies and a public authority
+- **International coordination**: Global network of AI safety institutes
+
+---
+
+## Where the Book and OpenAI Align
+
+### 1. Information Asymmetry as the Core Problem
+Both documents identify the same structural issue: the gap between those who understand complex systems and those who don't. OpenAI frames it as access to AI capability. We frame it as access to the knowledge infrastructure that has historically been gatekept by class. Same diagnosis, different focal lengths.
+
+> **OpenAI**: "If AI winds up controlled by, and benefiting only a few, while most people lack agency and access to AI-driven opportunity, we will have failed to deliver on its promise."
+>
+> **The book**: "Access to plain-language explanation of the capitalist systems that govern your health, housing, money, and legal standing has always been a class marker."
+
+The book's framing is stronger because it names the history. The asymmetry didn't start with AI — AI is the first crack in a wall that's been there all along.
+
+### 2. "Right to AI" = The Majordomo Thesis
+OpenAI's "Right to AI" proposal — treat AI access as foundational, like literacy or electricity — is exactly the book's core argument. We've been living it since the foreword. The difference: OpenAI proposes it as policy. The book delivers it as practice.
+
+### 3. Worker Voice and Labor Rights
+OpenAI proposes formal worker participation in AI deployment. The book's W-5 (Unions) and W-6 (Workplace Safety) teach people to exercise existing labor rights — Section 7 NLRA protections, OSHA complaints, workers' comp claims. OpenAI wants new institutions; the book teaches people to use the ones they already have.
+
+### 4. Safety Nets
+OpenAI proposes "adaptive safety nets that work for everyone." The book's entire field guide teaches people to navigate existing safety nets that already don't work reliably — unemployment, SNAP, Medicaid, Social Security. This is not a contradiction; it's a complementary view. The policy proposal needs the practical guide, and vice versa.
+
+### 5. Democratic Participation
+OpenAI calls for "mechanisms for public input" on AI alignment. Our civic section (C-1 through C-7) teaches the actual skills: reading ballot measures, writing public comments, advocating for policy change, knowing your rights. We are the how to their what.
+
+---
+
+## Where the Book and OpenAI Diverge
+
+### 1. Top-Down vs. Bottom-Up
+OpenAI's vision is institutional: create new agencies, funds, auditing bodies, international frameworks. The book's vision is individual: teach people to navigate, assert, and demand. Neither is sufficient alone, but the book should name this tension explicitly. Policy without individual capacity is a new set of systems that people can't navigate. Capacity without policy is individuals fighting the current.
+
+### 2. The Superintelligence Framing
+OpenAI assumes superintelligence is near and inevitable: "we're beginning a transition toward superintelligence: AI systems capable of outperforming the smartest humans." The book is deliberately agnostic on timeline and capability ceiling. It focuses on what AI can do *now* — decode an insurance denial, draft a public comment, research your tenant rights.
+
+This is a strength to preserve. The book's arguments don't depend on speculative futures. They work whether superintelligence arrives in three years or never. OpenAI's proposals are load-bearing on a future that may not materialize as described.
+
+### 3. Who Is Trusted to Act
+OpenAI positions itself as a responsible partner in governance: "OpenAI is offering these ideas to help start a broader conversation." The book's target reader — DSA-adjacent, structurally skeptical, Picard-aligned — will note that the company proposing to help govern superintelligence recently converted from a nonprofit to a for-profit structure. The book's voice should not be hostile to this, but it should not be naive either.
+
+The book's editorial voice already handles this: "AI is a tool, like a good ratchet set — genuinely useful, owned by a company, capable of giving wrong answers with complete confidence."
+
+### 4. The Missing Floor
+OpenAI proposes a Public Wealth Fund and tax modernization — macro-redistribution mechanisms. The book deliberately operates at the individual level: here is how you navigate the system as it exists today. Neither addresses the other's gap. The book could acknowledge the policy conversation without entering it, pointing readers to C-4 (Advocating for Change) as the entry point for engaging with proposals like these.
+
+---
+
+## Opportunities to Strengthen Civics Arguments
+
+### Priority 1: AI Policy as Civic Participation (New Entry or C-4 Expansion)
+
+The biggest gap in the civic field guide: none of the entries address AI governance itself as a domain of civic participation. OpenAI's document explicitly calls for "mechanisms for public input" on AI alignment. Federal agencies (NIST, FTC, state legislatures) are actively seeking public comment on AI regulation. This is C-2 (Writing a Public Comment) applied to the most consequential policy domain of the decade.
+
+**Concrete addition to C-4 or new entry C-8:**
+- How to find and participate in AI policy rulemaking (regulations.gov, state legislature comment periods)
+- How to evaluate AI policy proposals using the specification framework: What does this policy actually specify? What mechanism ensures it achieves its stated objective? What is left unspecified?
+- How to write effective public comment on AI regulation (same skill as C-2, different domain)
+
+This directly strengthens the spec-literacy-as-civic-skill argument: "A population that cannot specify what it wants from AI systems will get whatever the systems' developers specify for them."
+
+### Priority 2: Strengthen C-2 (Public Comment) with AI Policy Examples
+
+The current C-2 is city-council focused. Expand the "also" callout or add a second spec example for federal/state rulemaking:
+
+> _"[Agency] is accepting public comment on [proposed AI regulation] until [date]. I want to comment on [specific provision]. My concern is [describe]. Help me write a comment that addresses the regulatory language specifically, not just my general feelings about AI."_
+
+Federal rulemaking comment periods are one of the most direct mechanisms of democratic input available — and one of the least used by ordinary citizens. The Notice and Comment process exists specifically for this. The book should teach it.
+
+### Priority 3: Evaluating Policy Proposals (C-1 or General Method Extension)
+
+OpenAI's document is itself a ballot measure of sorts — a set of proposals from an interested party, framed in accessible language but serving specific interests. The book's Decode strategy applies directly:
+
+- Who benefits from this proposal?
+- What mechanism ensures the stated objective?
+- What is left unspecified?
+- What would a steelman of the opposing position look like?
+
+This could be a "science" or "spec" callout in C-1 or C-4:
+
+> The same framework you use to decode a ballot measure works on any policy proposal, white paper, or think-tank report. Paste the document and ask: *"Who wrote this, what do they want, what mechanism does this propose, and what is left unspecified? Present the strongest version of both the support and opposition."*
+
+### Priority 4: Portable Benefits and Safety Net Navigation
+
+OpenAI proposes portable benefits and adaptive safety nets — these are policy proposals the reader may encounter in political debates. The book already teaches navigation of the existing safety net (health, money, legal field guides). A brief addition in C-4 or the General Method could teach readers to evaluate safety-net reform proposals using the specification framework:
+
+- Does the proposal specify who is covered and who is not?
+- Does the trigger mechanism activate fast enough?
+- What happens in the gap between "old system" and "new system"?
+
+### Priority 5: The "Right to AI" Argument — Claim It
+
+The book should explicitly name the fact that its existence *is* the "Right to AI" argument in practice, not just in policy. OpenAI proposes it as a government program. The book delivers it as a Creative Commons guide that anyone can adapt. A line in the foreword, the introduction, or the civic domain intro could connect these:
+
+> Some companies are now proposing a "Right to AI" — that access to AI should be treated as foundational infrastructure, like electricity or the internet. This book agrees. It also notes that a right you can't exercise is a right in name only. The entries that follow are the exercise.
+
+---
+
+## Rhetorical Notes
+
+### What OpenAI Gets Right That We Should Acknowledge
+- The Progressive Era / New Deal analogy is historically apt and resonant. The book's reader (DSA-adjacent, reads Jacobin) will recognize and appreciate this framing.
+- The efficiency dividend / 32-hour workweek proposal is the kind of concrete, worker-centered policy that the book's audience supports. It's worth noting as an example of "the kind of thing you should be advocating for" in C-4.
+- The document's honest naming of concentration risk ("There is also a risk that the economic gains concentrate within a small number of firms like OpenAI") is unusual self-awareness from a company in the position to concentrate those gains.
+
+### What OpenAI Gets Wrong That We Should Not Repeat
+- The word "superintelligence" appears 14 times. The document treats it as a near-term certainty. The book should continue to avoid this framing — not because it's impossible, but because the book's value proposition doesn't depend on it.
+- "Keep people first" is the kind of wellness-adjacent language the book's voice guide explicitly rejects. The book keeps people first by teaching them specific skills, not by declaring an intention.
+- The document proposes "mechanisms for public input" without describing what one looks like. This is exactly the gap between policy language and practical reality that the book exists to close.
+
+### The Structural Irony
+OpenAI published a 13-page policy document calling for democratic participation in AI governance. The document is a PDF on their CDN, not a public comment period, not a legislative hearing, not a town hall. The format of the call contradicts its content. The book should not say this — but it should be the thing that does what the document calls for.
+
+---
+
+## Recommended Actions
+
+| Priority | Action | Location | Effort |
+|----------|--------|----------|--------|
+| 1 | Add AI policy participation content | C-4 expansion or new C-8 | Medium |
+| 2 | Add federal rulemaking example to C-2 | C-2 callout or second spec | Small |
+| 3 | Add policy-evaluation spec to C-1 or C-4 | Callout | Small |
+| 4 | Add "Right to AI" connection | Foreword or civic domain intro | Small |
+| 5 | Add safety-net evaluation framework | C-4 or General Method | Medium |
+
+None of these require changing the book's voice, thesis, or editorial stance. They extend existing arguments into a domain that is now the subject of active policy debate — which means the book's readers will encounter these proposals in the wild and should be equipped to evaluate them.
+
+---
+
+*Analysis prepared against OpenAI document dated April 2026 and book content as of the same date.*

--- a/spec/analysis-openai-industrial-policy.md
+++ b/spec/analysis-openai-industrial-policy.md
@@ -83,7 +83,7 @@ This is a strength to preserve. The book's arguments don't depend on speculative
 ### 3. Who Is Trusted to Act
 OpenAI positions itself as a responsible partner in governance: "OpenAI is offering these ideas to help start a broader conversation." The book's target reader — DSA-adjacent, structurally skeptical, Picard-aligned — will note that the company proposing to help govern superintelligence recently converted from a nonprofit to a for-profit structure. The book's voice should not be hostile to this, but it should not be naive either.
 
-The book's editorial voice already handles this: "AI is a tool, like a good ratchet set — genuinely useful, owned by a company, capable of giving wrong answers with complete confidence."
+The book's editorial voice already handles this: "AI is a tool, like a good ratchet set — genuinely useful, owned by a company, capable of giving you a wrong answer with complete confidence."
 
 ### 4. The Missing Floor
 OpenAI proposes a Public Wealth Fund and tax modernization — macro-redistribution mechanisms. The book deliberately operates at the individual level: here is how you navigate the system as it exists today. Neither addresses the other's gap. The book could acknowledge the policy conversation without entering it, pointing readers to C-4 (Advocating for Change) as the entry point for engaging with proposals like these.

--- a/src/content/02-field-guide/07-civic/index.dj
+++ b/src/content/02-field-guide/07-civic/index.dj
@@ -10,6 +10,8 @@ status: "draft"
 
 _Democracy was designed as a participatory system. In practice, participation requires reading ballot measures written by lawyers, attending meetings held during work hours, understanding zoning codes that predate your grandparents, and navigating bureaucracies that treat citizen input as a compliance requirement rather than a design constraint. The billionaire class participates through lobbyists, counsel, and staff who track every hearing and filing deadline. You participate by showing up after a full workday and hoping you understand the agenda. The entries that follow give you the preparation the lobbyist already has._
 
+_Some companies and governments are now proposing a "Right to AI" — that access to AI should be treated as foundational infrastructure, like electricity or the internet. This book agrees. It also notes that a right you cannot exercise is a right in name only. The entries that follow are the exercise._
+
 ---
 
 #### C-1: Understanding a Ballot Measure in Plain Language
@@ -31,6 +33,11 @@ Present both sides fairly -- I want to make up my own mind.
 
 ::: also
 Paste or upload your document directly — file upload works in Claude, Gemini, ChatGPT, and Copilot. See [Appendix G](06-appendix-g-feature-table.xhtml).
+:::
+
+
+::: spec
+This same framework works on any policy proposal, white paper, or think-tank report — not just ballot measures. Companies, lobbying groups, and advocacy organizations publish policy documents designed to sound reasonable. Paste one and ask: _"Who published this, what outcome are they seeking, what mechanism does this proposal use to achieve it, and what is left unspecified? Present the strongest version of both support and opposition."_ The distance between a document's stated intent and its actual mechanism is where the politics lives.
 :::
 
 
@@ -56,6 +63,11 @@ Write it to be spoken aloud -- conversational, not formal.
 
 ::: also
 This works well with voice mode on your phone — all major tools support it on mobile. See [Appendix G](06-appendix-g-feature-table.xhtml).
+:::
+
+
+::: tip
+This is not just for city hall. Federal agencies accept public comments on proposed regulations through regulations.gov — including rules about AI, data privacy, and algorithmic decision-making. State legislatures accept written testimony on pending bills. The skill is the same: _"[Agency or committee] is accepting public comment on [proposed rule or bill] until [date]. My concern is [specific provision]. Help me write a comment that addresses the regulatory language, not just my general feelings about it."_ The Notice and Comment process is one of the most direct mechanisms of democratic input available. It is also one of the least used by people who are not lobbyists.
 :::
 
 
@@ -136,6 +148,11 @@ Please help me:
 
 ::: tip
 _"I have 2 minutes to speak at [meeting] about [issue]. I'm nervous. Help me write something clear and practice delivering it."_
+:::
+
+
+::: spec
+When a politician, company, or think tank proposes a new safety net, benefit, or economic reform — a public wealth fund, portable benefits, universal basic income, adaptive unemployment insurance — your Agent can help you evaluate it the way a policy analyst would: _"Here is a proposal for [program]. Who is covered and who is excluded? What triggers the benefit and what ends it? What happens in the gap between the old system and the new one? What is the funding mechanism and is it durable? Where has something like this been tried, and what happened?"_ The ability to evaluate a proposal against its stated objectives — not its marketing language — is the civic skill that matters most between elections.
 :::
 
 
@@ -291,6 +308,58 @@ The experience of rights varies by race, gender, income, disability status, immi
 <!-- RESEARCH NEEDED: Legal aid access. LSC-funded legal aid serves approximately 1.8 million people annually but only reaches about 20% of eligible low-income Americans (Legal Services Corporation, 2023 Justice Gap Study). For every client served, another is turned away for lack of resources. Pro bono work from private attorneys fills some of the gap. The entry should point to: local legal aid societies, state bar association referral services, law school clinics, and the LSC website (lsc.gov) as starting points. -->
 
 [^c7-1]: United Nations General Assembly. (1948). "Universal Declaration of Human Rights." The UDHR is not a treaty and is not legally binding, but its principles are reflected in the International Covenant on Civil and Political Rights (1966), which the U.S. ratified in 1992.
+
+---
+
+#### C-8: Participating in AI Policy
+*Strategy:* Research + Draft + Navigate
+*See also:* C-2: Writing a Public Comment (the core skill), C-4: Advocating for Change (for sustained engagement), C-1: Understanding a Ballot Measure (for decoding proposals)
+*The Majordomo says:* _Right now, governments at every level are deciding how AI will be regulated, who will have access to it, and what guardrails will exist. These decisions are being made through the same mechanisms as every other policy decision: legislative hearings, agency rulemaking, public comment periods, and lobbying. The companies building AI have full-time policy teams drafting language, attending hearings, and submitting comments measured in hundreds of pages. The public comment period is open to you too. It is not a formality — agencies are legally required to consider substantive comments, and a well-specified comment from someone who will actually live under the rule carries weight that a form letter does not._
+*The spec:*
+::: prompt
+I want to participate in AI policy decisions that affect me.
+My level: [I'm new to this / I've been following AI policy /
+I have a specific regulation I want to comment on]
+My concern: [job displacement / privacy / algorithmic bias /
+children's safety / access and affordability / government
+use of AI / something else: describe]
+My location: [state — for state-level legislation]
+Please help me:
+1. Identify what AI-related legislation or rulemaking is currently
+   active at the federal and state level that relates to my concern
+2. Explain where I can submit public comment or testimony,
+   and the deadlines
+3. Help me understand the proposed language — what does it
+   actually require, what does it leave unspecified, and
+   who benefits from the gaps
+4. Help me draft a public comment that addresses the specific
+   regulatory language, states my position, and provides
+   a concrete recommendation
+:::
+*What to do with the output:* Submit your comment through the official channel — regulations.gov for federal rules, your state legislature's website for state bills. Written comments become part of the public record. For state and local hearings, the same rules apply as C-2: print it, practice it, show up. A single informed comment from a constituent who will live under the rule is worth more than a thousand form letters. Agencies know the difference.
+
+::: science
+The federal Notice and Comment process, established by the Administrative Procedure Act of 1946, requires agencies to publish proposed rules, accept public comments, and respond to substantive concerns before finalizing regulations. This is not performative — courts have struck down rules where agencies failed to adequately consider public input. The process was designed for exactly this kind of participation. It is underused because most people do not know it exists.[^c8-1]
+:::
+
+
+::: tip
+_"I just read [a news article / company blog post / policy white paper] about AI policy. Paste: [text]. Help me understand: What is this actually proposing? What would it require in practice? Who benefits and who bears the cost? What is the strongest argument for and against? And is there an open comment period or legislative process where I can weigh in?"_
+:::
+
+
+::: fairness
+AI policy is being shaped disproportionately by the companies building the technology and by a small number of well-funded advocacy organizations. Public comments from individuals — especially from communities that will be most affected by algorithmic decision-making in hiring, lending, housing, healthcare, and criminal justice — are underrepresented in the record. Your Agent can help you write a comment. It cannot make the system value your input equally. Showing up in the record is necessary but not sufficient. Organizing — C-4 — is what makes the record matter.
+:::
+
+
+<!-- RESEARCH NEEDED: Current landscape of AI regulation. Federal: NIST AI Risk Management Framework, FTC enforcement actions on algorithmic harm, proposed federal AI legislation. State: comprehensive AI bills (Colorado AI Act, Illinois Artificial Intelligence Video Interview Act, various state AI task forces). EU AI Act as international reference point. The entry should point to resources that track active legislation: the ACLU's technology and civil liberties page, the Electronic Frontier Foundation, the Brennan Center's technology and elections work, and the AI Policy Institute for current legislative tracking. -->
+
+<!-- RESEARCH NEEDED: Comment effectiveness. Research on federal rulemaking shows that substantive comments — those that address specific provisions with evidence or lived experience — are more likely to influence final rules than form letters or general expressions of support/opposition (Coglianese, 2006; Farina et al., 2012 on "Regulation Room" experiments in broadening participation). The entry should give the reader confidence that their comment matters while being honest that the process favors repeat players. -->
+
+<!-- RESEARCH NEEDED (HUMAN CONDITION): The "someone else will handle it" problem. Diffusion of responsibility (Darley & Latané, 1968) applies to civic participation as directly as it does to bystander intervention. The larger the perceived group of concerned citizens, the less likely any individual is to act. The antidote is the same: make the individual feel personally responsible and capable. This entry exists to do both. The reader who submits one substantive public comment on one AI regulation has done more than 99% of the population. That is not hyperbole — public comment participation rates on federal rules are typically in the hundreds to low thousands, out of a population of 330 million. -->
+
+[^c8-1]: The Administrative Procedure Act (5 U.S.C. § 553) establishes the notice-and-comment rulemaking process. For an accessible overview, see the Congressional Research Service report "An Overview of Federal Regulations and the Rulemaking Process" and regulations.gov for currently open comment periods.
 
 ---
 


### PR DESCRIPTION
Compares OpenAI's "Industrial Policy for the Intelligence Age" (April 2026)
with the book's positions on information asymmetry, civic participation,
labor rights, and AI access. Identifies five concrete opportunities to
strengthen the civic field guide, particularly around AI policy as a domain
of civic participation.

https://claude.ai/code/session_01YMF25WqKCzxezysCtiSkHK