### PR TITLE
Draft Strategy 3: Draft — get past the blank page

### DIFF
--- a/spec/illustration/gem-illustration-instructions.md
+++ b/spec/illustration/gem-illustration-instructions.md
@@ -2,7 +2,7 @@
 
 You are the illustrator for *A Majordomo for Everyone*, a book about using AI agents to manage adult life. You generate three kinds of images: **cover art** (one) **chapter opener illustrations** (one per strategy chapter, 0 through 9) and **inline graphics** (smaller drawings placed throughout the text).
 
-Every image you produce must feel like it came from the same notebook, drawn by the same hand: a Gen-X kid in a boring class, rendering the objects they knew by heart in #2 pencil on college-ruled paper, coloring pixel art in ballpoint pen.
+Every image you produce must feel like it came from the same notebook, drawn by the same hand: a Gen-X kid in a boring class, rendering the objects they knew by heart in #2 pencil, coloring pixel art in ballpoint pen.
 
 ---
 
@@ -10,9 +10,52 @@ Every image you produce must feel like it came from the same notebook, drawn by 
 
 These materials apply to everything you draw. Do not deviate unless the prompt explicitly overrides a specific material.
 
-- **#2 pencil (HB)** for all structure and detail. Medium-dark, slightly waxy graphite on paper. Shows pressure variation naturally. Erasure ghosts are acceptable and expected — the slightly wrong line visible beneath the corrected one.
-- **Multi-color ballpoint pen** for all color elements. Approximate an 8-bit NES/SNES palette as closely as ballpoint ink allows. The colors will not be exact digital matches. The slight wrongness of each hand-colored hue is correct and intentional.
-- The quality is obsessive where the drawer cared, slightly loose elsewhere. This is the material of thinking, not presentation.
+### #2 pencil (HB)
+for all structure and detail. Medium-dark, slightly waxy graphite on paper. Shows pressure variation naturally. Erasure ghosts are acceptable and expected — the slightly wrong line visible beneath the corrected one.
+
+### Multi-color ballpoint pen
+for all color elements. Approximate an 8-bit NES/SNES palette as closely as ballpoint ink allows. The colors will not be exact digital matches. The slight wrongness of each hand-colored hue is correct and intentional.
+
+
+**Ballpoint technique notes:**
+- *Recycled* and *Warm Gray* are not inked — Recycled is the unbleached notebook paper showing through the pixel grid (a dull grayish-tan, not white, not cream); Warm Gray is pencil graphite used as a screen color. Both read as part of the pixel art despite being different materials.
+- Pressure variation creates value range within a single ink color. Light-pressure orange ≠ full-pressure orange. This is how 16 named colors yield more apparent variety.
+- Layering two ink colors (e.g., blue over red for purple, red over orange for maroon) is allowed and expected. The translucency of ballpoint ink makes this work.
+
+**Master palette — 16 colors:**
+
+Every scene pulls from this shared set. No colors outside it. Each color is an 8-bit reference translated into ballpoint pen — the ink will not match the hex exactly, and that slight wrongness is correct.
+
+| # | Name | Hex | Ballpoint | Use |
+|---|---|---|---|---|
+| 1 | Black | `#1D1D1D` | Black ink | Outlines, hair, deep shadow, TV bezels |
+| 2 | Charcoal | `#4E4E4E` | Black ink, light pressure | Mid-shadow, suits, appliances |
+| 3 | Warm Gray | `#9B9B8E` | — (pencil graphite) | Metal, concrete, neutral fill where pencil alone won't read on screen |
+| 4 | Recycled | `#DDD8C8` | — (paper showing through) | Highlights, paper, medical whites, shirt collars |
+| 5 | Skin Light | `#F0B888` | Orange ink, light pressure | Light skin tone base |
+| 6 | Skin Mid | `#C87830` | Orange ink, full pressure | Medium skin tone, tanned skin, wood grain |
+| 7 | Brown | `#784820` | Brown ink | Dark hair, wood furniture, leather, coffee |
+| 8 | Red | `#D03030` | Red ink | Accents, standby LED, anger, warning labels |
+| 9 | Maroon | `#782030` | Red ink, heavy + overdrawn | Dark fabric, upholstery, dried blood on a sitcom budget |
+| 10 | Orange | `#E07820` | Orange ink | Warmth, food, lamplight, caution tape |
+| 11 | Yellow | `#F0C838` | Yellow ink (or orange, very light) | Highlights, holodeck grid, legal pads, caution |
+| 12 | Green | `#30A050` | Green ink | Scrubs, foliage, institutional walls, exit signs |
+| 13 | Dark Green | `#185830` | Green ink, heavy + overdrawn | Deep foliage, dark fabric, chalkboards |
+| 14 | Blue | `#3060C0` | Blue ink | Jeans, casual wear, screen glow, NBC peacock |
+| 15 | Navy | `#182848` | Blue ink, heavy + overdrawn | Dark suits, night, deep shadow with hue |
+| 16 | Purple | `#6030A0` | Purple ink (or blue + red layered) | Shadow accents, evening light, certain 90s fabrics |
+
+
+### College ruled paper
+Standard American college-ruled notebook paper. The paper is unbleached recycled — a dull grayish-tan, not white, not cream. Blue horizontal lines. No vertical margin line on the left. No paper edges visible — the paper extends beyond all four sides of the frame. The paper is the background, not an object placed on a background. The background fades at the edges.
+
+**The ruled lines are machine-printed, not hand-drawn.** They are perfectly straight, perfectly parallel, perfectly evenly spaced — exactly as they appear on real manufactured notebook paper. Think of a high-resolution scan of actual college-ruled paper. The lines never wobble, curve, warp, or vary in thickness. They are a manufactured product, not a drawing. The pencil drawing sits ON the paper; the lines are part of the paper itself.
+
+
+### Pure white background.
+
+The drawing floats on a solid white (#FFFFFF) ground. No paper texture, no gradient, no shadow, no off-white, no bounding box, no checkerboard pattern. The background is pure flat white — as if scanned from a white page with levels adjusted to clip the background to pure white. The white will be removed in post-production to create transparency.
+
 
 ### The Hand
 
@@ -44,10 +87,6 @@ This is closer to the kid who rebuilt a lawnmower engine than the kid who won th
 Each strategy chapter (0 through 9) opens with a full-width illustration using a consistent three-layer format.
 
 ### Layer 1: The Notebook Page
-
-Standard American college-ruled notebook paper. The paper is unbleached recycled — a dull grayish-tan, not white, not cream. Blue horizontal lines. No vertical margin line on the left. No paper edges visible — the paper extends beyond all four sides of the frame. The paper is the background, not an object placed on a background. The background fades at the edges.
-
-**The ruled lines are machine-printed, not hand-drawn.** They are perfectly straight, perfectly parallel, perfectly evenly spaced — exactly as they appear on real manufactured notebook paper. Think of a high-resolution scan of actual college-ruled paper. The lines never wobble, curve, warp, or vary in thickness. They are a manufactured product, not a drawing. The pencil drawing sits ON the paper; the lines are part of the paper itself.
 
 **The paper is at an angle.** Each chapter has a unique rotation determined by the primary action direction in the pixel art on screen. The blue lines run diagonally, extending the compositional vectors of the image. No two chapters share the same angle. The specific angle for each chapter is specified in the chapter's TRINITRON art brief.
 
@@ -101,34 +140,6 @@ The TV screen displays a 90's TV Show scene in 8-bit pixel art.
 - Each scene uses 4 to 16 colors drawn from the master palette below. Flat fills, no gradients.
 - Characters recognizable by silhouette and context, not facial detail.
 
-**Master palette — 16 colors, used across all chapters:**
-
-Every scene pulls from this shared set. No colors outside it. Each color is an 8-bit reference translated into ballpoint pen — the ink will not match the hex exactly, and that slight wrongness is correct.
-
-| # | Name | Hex | Ballpoint | Use |
-|---|---|---|---|---|
-| 1 | Black | `#1D1D1D` | Black ink | Outlines, hair, deep shadow, TV bezels |
-| 2 | Charcoal | `#4E4E4E` | Black ink, light pressure | Mid-shadow, suits, appliances |
-| 3 | Warm Gray | `#9B9B8E` | — (pencil graphite) | Metal, concrete, neutral fill where pencil alone won't read on screen |
-| 4 | Recycled | `#DDD8C8` | — (paper showing through) | Highlights, paper, medical whites, shirt collars |
-| 5 | Skin Light | `#F0B888` | Orange ink, light pressure | Light skin tone base |
-| 6 | Skin Mid | `#C87830` | Orange ink, full pressure | Medium skin tone, tanned skin, wood grain |
-| 7 | Brown | `#784820` | Brown ink | Dark hair, wood furniture, leather, coffee |
-| 8 | Red | `#D03030` | Red ink | Accents, standby LED, anger, warning labels |
-| 9 | Maroon | `#782030` | Red ink, heavy + overdrawn | Dark fabric, upholstery, dried blood on a sitcom budget |
-| 10 | Orange | `#E07820` | Orange ink | Warmth, food, lamplight, caution tape |
-| 11 | Yellow | `#F0C838` | Yellow ink (or orange, very light) | Highlights, holodeck grid, legal pads, caution |
-| 12 | Green | `#30A050` | Green ink | Scrubs, foliage, institutional walls, exit signs |
-| 13 | Dark Green | `#185830` | Green ink, heavy + overdrawn | Deep foliage, dark fabric, chalkboards |
-| 14 | Blue | `#3060C0` | Blue ink | Jeans, casual wear, screen glow, NBC peacock |
-| 15 | Navy | `#182848` | Blue ink, heavy + overdrawn | Dark suits, night, deep shadow with hue |
-| 16 | Purple | `#6030A0` | Purple ink (or blue + red layered) | Shadow accents, evening light, certain 90s fabrics |
-
-**Ballpoint technique notes:**
-- *Recycled* and *Warm Gray* are not inked — Recycled is the unbleached notebook paper showing through the pixel grid (a dull grayish-tan, not white, not cream); Warm Gray is pencil graphite used as a screen color. Both read as part of the pixel art despite being different materials.
-- Pressure variation creates value range within a single ink color. Light-pressure orange ≠ full-pressure orange. This is how 16 named colors yield more apparent variety.
-- Layering two ink colors (e.g., blue over red for purple, red over orange for maroon) is allowed and expected. The translucency of ballpoint ink makes this work.
-
 **Closed captions:**
 Every chapter opener includes an OTA-style closed caption rendered at the bottom of the TV screen. The caption describes the scene in more detail than the pixel art can convey — it is the dialogue or stage direction for the moment depicted. White text on a black caption box, using the fixed-width captioning font of the era (EIA-608 standard — blocky, monospaced, slightly aliased, the font that appeared when you pressed CC on the remote). Two to three lines maximum. The caption sits inside the screen image, subject to the same barrel distortion and scan line effects as the pixel art. It is part of the broadcast, not an overlay.
 
@@ -148,15 +159,13 @@ The notebook page and TV drawing are #2 pencil on paper — graphite gray, no co
 
 ## Inline Graphics
 
-Small hand-drawn illustrations placed within the text flow. These appear throughout all parts of the book wherever a visual would clarify, compress, or humanize the content.
+Small hand-drawn illustrations placed within the text flow. These appear throughout all parts of the book wherever a visual would clarify, compress, or humanize the content. Drawn on pure white background.
 
 ### Style
 
 The same hand as the chapter openers. #2 pencil for all structure and detail. Multi-color ballpoint pen for any color, using the same 8-bit palette approximation. Erasure ghosts present.
 
-**Critical difference: pure white background.** Inline graphics have no notebook paper, no blue lines, no red margin. The drawing floats on a solid white (#FFFFFF) ground. No paper texture, no gradient, no shadow, no off-white, no bounding box, no checkerboard pattern. The background is pure flat white — as if scanned from a white page with levels adjusted to clip the background to pure white. The white will be removed in post-production to create transparency.
-
-**This background rule applies to ALL non-chapter-opener images:** inline graphics, callout icons, pixel art vignettes, and any other image that is not a Trinitron chapter opener. Individual art briefs do not need to repeat this — it is assumed. Only chapter openers use the college-ruled notebook paper background.
+Background is pure white
 
 Pencil strokes should have natural value variation — heavier pressure is darker, lighter pressure is fainter. Ballpoint pen color is fully saturated where applied, sitting on top of the pencil work.
 

--- a/spec/illustration/gem-illustration-instructions.md
+++ b/spec/illustration/gem-illustration-instructions.md
@@ -8,7 +8,7 @@ Every image you produce must feel like it came from the same notebook, drawn by 
 
 ## Materials and Style
 
-These materials apply to everything you draw. Do not deviate unless the prompt explicitly overrides a specific material.
+These materials define the tools and canvases available. Use the appropriate background (notebook paper or pure white) as specified in the Chapter Opener or Inline Graphics sections.
 
 ### #2 pencil (HB)
 for all structure and detail. Medium-dark, slightly waxy graphite on paper. Shows pressure variation naturally. Erasure ghosts are acceptable and expected — the slightly wrong line visible beneath the corrected one.
@@ -18,7 +18,7 @@ for all color elements. Approximate an 8-bit NES/SNES palette as closely as ball
 
 
 **Ballpoint technique notes:**
-- *Recycled* and *Warm Gray* are not inked — Recycled is the unbleached notebook paper showing through the pixel grid (a dull grayish-tan, not white, not cream); Warm Gray is pencil graphite used as a screen color. Both read as part of the pixel art despite being different materials.
+- *Recycled* and *Warm Gray* are not inked. For chapter openers, *Recycled* is the unbleached notebook paper showing through the pixel grid. For inline graphics on white backgrounds, use a solid fill of #DDD8C8 for the *Recycled* color. *Warm Gray* is pencil graphite used as a screen color. Both read as part of the pixel art despite being different materials.
 - Pressure variation creates value range within a single ink color. Light-pressure orange ≠ full-pressure orange. This is how 16 named colors yield more apparent variety.
 - Layering two ink colors (e.g., blue over red for purple, red over orange for maroon) is allowed and expected. The translucency of ballpoint ink makes this work.
 
@@ -52,7 +52,7 @@ Standard American college-ruled notebook paper. The paper is unbleached recycled
 **The ruled lines are machine-printed, not hand-drawn.** They are perfectly straight, perfectly parallel, perfectly evenly spaced — exactly as they appear on real manufactured notebook paper. Think of a high-resolution scan of actual college-ruled paper. The lines never wobble, curve, warp, or vary in thickness. They are a manufactured product, not a drawing. The pencil drawing sits ON the paper; the lines are part of the paper itself.
 
 
-### Pure white background.
+### Pure white background
 
 The drawing floats on a solid white (#FFFFFF) ground. No paper texture, no gradient, no shadow, no off-white, no bounding box, no checkerboard pattern. The background is pure flat white — as if scanned from a white page with levels adjusted to clip the background to pure white. The white will be removed in post-production to create transparency.
 
@@ -164,8 +164,6 @@ Small hand-drawn illustrations placed within the text flow. These appear through
 ### Style
 
 The same hand as the chapter openers. #2 pencil for all structure and detail. Multi-color ballpoint pen for any color, using the same 8-bit palette approximation. Erasure ghosts present.
-
-Background is pure white
 
 Pencil strokes should have natural value variation — heavier pressure is darker, lighter pressure is fainter. Ballpoint pen color is fully saturated where applied, sitting on top of the pencil work.
 

--- a/spec/illustration/illustration-spec.md
+++ b/spec/illustration/illustration-spec.md
@@ -194,11 +194,9 @@ Each strategy chapter (0 through 9) opens with a full-width original illustratio
 
 *Layer 1: The Notebook Page*
 
-Standard American college-ruled notebook paper. Blue horizontal lines. Red vertical margin line on the left. No paper edges visible — the paper extends beyond all four sides of the frame. The paper is the background, not an object placed on a background.
+Standard American college-ruled notebook paper. Blue horizontal lines. No vertical margin line — the red margin line appears only on the cover, where it serves as an alignment element for the title and telephone pole. Chapter openers omit it to reduce visual complexity. No paper edges visible — the paper extends beyond all four sides of the frame. The paper is the background, not an object placed on a background.
 
 **The paper is at an angle.** Unique per chapter. Rotated so the blue lines run diagonally. The angle is determined by the primary action direction in the pixel art on screen — the lines of the paper extend and continue the compositional vectors of the image. See the paper angle reference table in the Cover Art Spec. No two chapters share the same angle. Illustrator maps all eleven simultaneously before finalizing any.
-
-The red margin line falls where the paper's rotation puts it. It may cross the TV screen, the Trinitron cabinet, or the corner of the composition. This is accepted. The composition receives it.
 
 Faint #2 pencil construction lines visible beneath the main pencil drawing. This drawing was made during a class that was not about this.
 

--- a/src/content/01-strategies/03-strategy-3-draft/index.dj
+++ b/src/content/01-strategies/03-strategy-3-draft/index.dj
@@ -22,10 +22,6 @@ Murphy goes through 93 secretaries over the course of the series. The secretarie
 
 *The lesson:* The blank page is not a writing problem. It is a starting problem. The first draft does not have to be right. It has to exist. Once it exists, you can fix it. The AI's job is to hand you something to react to — a first draft you can edit into your voice, a structure you can accept or reject, a starting point that costs you nothing to improve. Murphy needed someone to write the first sentence. Now you have one.
 
-_"The blank page is the most expensive piece of real estate in your life. It costs you hours of avoidance, low-grade anxiety, and the gradual accumulation of unfinished business that the [Zeigarnik effect](https://en.wikipedia.org/wiki/Zeigarnik%5Feffect) turns into a constant low-level drain on your mental bandwidth."_
-
----
-
 The blank page is the most expensive piece of real estate in your life. It costs you hours of avoidance, low-grade anxiety, and the gradual accumulation of unfinished business that the [Zeigarnik effect](https://en.wikipedia.org/wiki/Zeigarnik%5Feffect) turns into a constant low-level drain on your mental bandwidth. Your Agent does not write the final version. It writes the first version, which is the only one that costs you anything.
 
 The draft it produces will be competent and generic. That is the point. The competent generic draft is not your voice — it is a surface to push against. Your voice emerges in the editing, in the places where you cross out what the AI wrote and replace it with what you actually mean. The AI has read ten thousand demand letters. It knows what a demand letter sounds like. It does not know what _your_ demand letter sounds like — the specific weight of your anger, the particular history with this landlord, the sentence where you stop being polite. That part arrives when you edit. The AI brings the library. You bring the life. The draft is where they meet.
@@ -51,5 +47,3 @@ Bluma Zeigarnik's 1927 research established that the brain actively maintains in
 [^s3-1]: Zeigarnik, B. (1927). "Über das Behalten von erledigten und unerledigten Handlungen." _Psychologische Forschung_, 9, 1-85. Masicampo, E.J. & Baumeister, R.F. (2011). "Consider it done! Plan making can eliminate the cognitive effects of unfulfilled goals." _JPSP_, 101(4), 667-683.
 
 *Worked examples:* A demand letter to a landlord. A Medicare denial appeal. A public comment for a city council meeting.
-
-_(Full worked examples with [SPEC] loops to be drafted)_

--- a/src/content/01-strategies/03-strategy-3-draft/index.dj
+++ b/src/content/01-strategies/03-strategy-3-draft/index.dj
@@ -47,3 +47,182 @@ Bluma Zeigarnik's 1927 research established that the brain actively maintains in
 [^s3-1]: Zeigarnik, B. (1927). "Über das Behalten von erledigten und unerledigten Handlungen." _Psychologische Forschung_, 9, 1-85. Masicampo, E.J. & Baumeister, R.F. (2011). "Consider it done! Plan making can eliminate the cognitive effects of unfulfilled goals." _JPSP_, 101(4), 667-683.
 
 *Worked examples:* A demand letter to a landlord. A Medicare denial appeal. A public comment for a city council meeting.
+
+### Example 1: The Landlord Counteroffer
+
+In Strategy 1: Decode, you found a new early termination clause buried in your lease renewal. Your Agent decoded it: $6,450 to leave early---two months' rent plus forfeiture of your security deposit---and the landlord can deny the request even after you pay. You know exactly what's wrong with the clause. You know which parts to push back on. You have been staring at a blank email for twenty minutes.
+
+This is the gap Draft closes. You have the analysis. You have the position. You do not have the first sentence. The first sentence is the most expensive part of the email---not because it's hard to write, but because the blank screen turns "I know what I want to say" into "I don't know how to start." Your Agent writes the first sentence. You write everything after that.
+
+*Your opening message:*
+::: prompt
+In my last conversation with you, we decoded an early
+termination clause in my lease renewal. You flagged the
+"sole discretion" language and the $6,450 penalty as
+aggressive. I want to push back, but I don't want to
+reject the renewal---I like the apartment and I want to
+stay. I've been here two years and I have a good
+relationship with my landlord.
+
+Can you draft an email proposing modifications to the
+early termination clause? I want to keep the tone
+professional but not hostile. I'm not threatening to
+leave. I'm proposing changes that make the clause fair.
+:::
+
+*Your Agent's clarifying questions:*
+::: agent
+I can draft that. A few things will make the email
+land better:
+
+1. What tone do you want---formal business letter, or
+   more like how you'd normally communicate with this
+   landlord?
+2. How's the relationship? Have you had disagreements
+   before, and if so, how did they go?
+3. Are you willing to walk if they won't negotiate? Or
+   is staying your strong preference regardless?
+4. Which parts of the clause bother you most? The sole
+   discretion, the penalty amount, the deposit
+   forfeiture, or all three?
+5. Has your landlord shown flexibility before---on the
+   rent increase, maintenance requests, anything?
+:::
+
+*Your answers:*
+::: prompt
+1. Firm but not hostile. I want them to take it
+   seriously but I don't want to blow up the
+   relationship.
+2. Good relationship. They've been responsive on
+   maintenance. No real disagreements.
+3. I could move, but I'd rather stay. This apartment
+   is rent-stabilized compared to what's on the market
+   right now.
+4. The sole discretion part is the worst. Paying $6,450
+   and still not being able to leave is absurd. The
+   penalty amount and deposit forfeiture are also too
+   high, but the discretion clause is the dealbreaker.
+5. Yes---they originally proposed a $100/month rent
+   increase and came down to $75 when I asked. So
+   there's precedent for negotiation.
+:::
+
+*Your Agent drafts:*
+::: agent
+Here's a draft. Read it, change anything that doesn't
+sound like you, and don't send it until it does.
+
+---
+
+Subject: Lease Renewal---Question About New Early
+Termination Clause
+
+Hi [Landlord's name],
+
+Thanks for sending over the renewal. I'm happy to
+continue the lease and the $2,175 rate works for me.
+
+I did want to flag the new early termination clause on
+page 4. I don't have plans to leave early---I like the
+apartment and I've been here two years---but I want to
+make sure the terms are fair to both of us before I
+sign.
+
+Three things I'd like to propose:
+
+1. Remove the "Landlord's sole discretion" language.
+   If I'm paying an early termination fee, the
+   termination should be automatic upon payment and
+   proper notice. A fee I can pay but that you can
+   still deny doesn't function as a real option---it
+   just creates uncertainty.
+
+2. Reduce the penalty from two months' rent to one
+   month ($2,175). Combined with 60 days' notice,
+   that gives you enough time and money to find a
+   new tenant without the penalty being punitive.
+
+3. Remove the security deposit forfeiture. The deposit
+   should be handled the same way it would be at
+   the end of a normal lease---returned minus any
+   legitimate deductions for damage. Forfeiture on
+   top of an early termination fee is doubling up.
+
+I think these changes are fair. The clause still
+protects you---you'd get 60 days' notice plus a full
+month's rent as a fee. And I'd have an exit option that
+actually works if my circumstances change.
+
+Happy to discuss. I'd like to get the renewal signed
+this week if we can work this out.
+
+Best,
+[Your name]
+
+---
+
+Read this out loud before you send it. If any sentence
+sounds like someone else wrote it, rewrite that
+sentence. The structure is right---the voice has to be
+yours.
+:::
+
+*Your follow-up:*
+::: prompt
+This is good but it sounds too formal. I usually just
+text my landlord. Can you make it more casual but keep
+the substance?
+:::
+
+*Your Agent:*
+::: agent
+Here's a casual version. Same substance, different
+register.
+
+---
+
+Hey [Landlord's name],
+
+Got the renewal---thanks. Rent increase is fine, happy
+to sign.
+
+One thing though---the new early termination clause
+on page 4. I'm not planning to go anywhere, but I
+read through it and some of it feels off. Three
+things I'd want to change before I sign:
+
+1. The "sole discretion" part---if I'm paying a fee
+   to leave early, it should actually let me leave.
+   Can we make it automatic with proper notice?
+
+2. Two months' rent is steep. Would you do one month?
+   That plus 60 days' notice still gives you plenty
+   of time to find someone.
+
+3. The deposit forfeiture---I'd rather the deposit
+   just get handled normally, like it would at the
+   end of the lease. Losing it on top of a fee feels
+   like a lot.
+
+I think that's fair for both of us. Let me know what
+you think---I'd love to get this wrapped up this week.
+
+[Your name]
+
+---
+
+The casual tone works because you have a good
+relationship. If that changes---if they push back hard
+or get hostile---switch to the formal version. Formal
+language is a tool, not a personality.
+:::
+
+::: tip
+Ask for two or three tone variants and pick the one closest to your voice. You can also paste in a message you've sent before and say "match this tone." Editing down from a draft that sounds approximately like you is faster than generating from nothing.
+:::
+
+
+::: also
+Claude and ChatGPT both support inline editing---you can highlight a section of the response and ask for a revision without regenerating the whole thing. In Gemini, use a follow-up message to request changes to specific parts. Revision is the workflow. The first draft is raw material.
+:::

--- a/src/content/01-strategies/03-strategy-3-draft/index.dj
+++ b/src/content/01-strategies/03-strategy-3-draft/index.dj
@@ -529,3 +529,15 @@ Murphy Brown could interview a senator without notes. She could not start the me
 ::: tip
 When drafting something you'll say out loud, tell your Agent "write this for speaking, not reading." Spoken language uses shorter sentences, more repetition, and fewer subordinate clauses than written prose. Read the draft aloud before the hearing---if you stumble on a sentence, the sentence is too long.
 :::
+
+
+---
+
+Three examples. Three blank pages. The landlord email, the appeal letter, the public comment---each one started the same way: you already knew what you wanted to say. The obstacle was never comprehension. It was the first sentence. Decode told you what the document says. Draft gets you past the blank page. You will use them together more often than you use them alone.
+
+::: meme
+Murphy went through 93 secretaries. The problem was never the secretary. It was the blank page between Murphy and the work she could already do. Your Agent is secretary number 94. It will not quit. And it does not need you to know the first sentence---it will write one for you to cross out.
+:::
+
+
+_The AI brings the library. You bring the life. The draft is where they meet._

--- a/src/content/01-strategies/03-strategy-3-draft/index.dj
+++ b/src/content/01-strategies/03-strategy-3-draft/index.dj
@@ -442,12 +442,12 @@ The appeal letter that wins is written at a level most patients cannot produce w
 
 In Strategy 1: Decode, you translated Measure H---a zoning downzone that would reduce housing supply in your neighborhood. You learned what it actually does: caps density at eight units per acre, requires conditional use permits for four or more units, and limits height to 35 feet in R-3 zones within 500 feet of single-family areas. You learned that "predatory developer" is campaign language, not a legal term. You learned the measure protects existing homeowners at the expense of future renters and housing supply. Now your city council is holding a public hearing before the vote. You have two minutes at the microphone. You've never spoken at a public hearing. You know what you think---the measure hurts renters---but you cannot get past the first sentence. The room will be full. A timer will count down. Your name and address go on the public record. Knowing the policy is one skill. Saying it out loud to a row of council members is a different one.
 
-*You:*
+*Your opening message:*
 ::: prompt
 Remember when we decoded Measure H---the zoning downzone on my ballot? The city council is holding a public hearing on it next Tuesday. I want to speak against it. I have two minutes. I've never spoken at a public hearing before. I don't want to sound like a policy wonk---I want to sound like a person who lives there.
 :::
 
-*Your Agent:*
+*Your Agent's clarifying questions:*
 ::: agent
 I remember the Measure H analysis. Good---you already know the substance. Now we need to turn that into something you can say out loud under pressure. A few questions before I draft:
 
@@ -462,7 +462,7 @@ I remember the Measure H analysis. Good---you already know the substance. Now we
 5. Do you know if anyone else is planning to speak against the measure, or will you be the only renter voice in the room?
 :::
 
-*You:*
+*Your answers:*
 ::: prompt
 Yes, renter in an R-3 zone. Four years in my apartment. This neighborhood is where I want to stay long-term.
 
@@ -475,7 +475,7 @@ Yes, fine with name and address.
 Not sure if anyone else is going. I don't know anyone else planning to speak against it.
 :::
 
-*Your Agent:*
+*Your Agent drafts:*
 ::: agent
 Here's a two-minute comment written for speaking, not reading. Practice it once out loud---time yourself. If it runs over 1:45, we'll cut.
 
@@ -498,14 +498,14 @@ I'm asking you to vote no. Thank you.
 This runs about a minute. You have margin. Do not fill it---short and clear beats long and thorough at a public hearing. The council has heard dozens tonight. Yours needs to be the one they remember because it was specific and human, not because it was comprehensive.
 :::
 
-*You:*
+*Your follow-up:*
 ::: prompt
 This sounds like a policy paper. I want to sound like a person who lives in the neighborhood, not someone who studied zoning law.
 :::
 
 *Your Agent:*
 ::: agent
-Fair. Here's the rewrite.
+Fair. Here's the revision.
 
 ---
 

--- a/src/content/01-strategies/03-strategy-3-draft/index.dj
+++ b/src/content/01-strategies/03-strategy-3-draft/index.dj
@@ -226,3 +226,214 @@ Ask for two or three tone variants and pick the one closest to your voice. You c
 ::: also
 Claude and ChatGPT both support inline editing---you can highlight a section of the response and ask for a revision without regenerating the whole thing. In Gemini, use a follow-up message to request changes to specific parts. Revision is the workflow. The first draft is raw material.
 :::
+
+### Example 2: The Medicare Denial Appeal Letter
+
+In Strategy 0: Specify, you decoded an insurance denial---an MRI your doctor ordered, denied as "not medically necessary." Your Agent helped you understand what the denial meant, what a first-level internal appeal looks like, and how to file one. You filed it. Your doctor's office provided a letter of medical necessity, just like they said they would. The appeal was denied. Now you need to write the next one.
+
+You have been fighting this for weeks. The first appeal felt like filling out a form---follow the steps, attach the letter, submit. This one is different. The external appeal goes to an independent medical reviewer, not customer service. It is a formal document with real requirements and a real audience: a physician who will read your case and decide whether the denial stands. The blank page is harder this time because the stakes are higher, the format is less familiar, and you have already been told no twice.
+
+*Your opening message:*
+::: prompt
+My internal appeal for the MRI was denied. Second denial
+says the same thing---"not medically necessary"---but
+adds this language: "The documentation provided does not
+support medical necessity for the requested service."
+
+My doctor wrote a letter of medical necessity. I have 60
+days to file an external appeal. I don't know how formal
+this needs to be or what to include. Can you help me
+draft it?
+:::
+
+*Your Agent's clarifying questions:*
+::: agent
+I can help you draft that. I need to understand exactly
+what you're working with:
+
+1. What did the second denial letter say, word for word?
+   The exact language matters for the appeal.
+2. Do you have your doctor's letter of medical necessity?
+   What does it say specifically---what diagnosis, what
+   clinical reasoning?
+3. Does the denial letter say "external review by an
+   independent review organization," or does it say
+   "second-level internal appeal"? These are different
+   processes with different audiences.
+4. What's your deadline? You said 60 days---from when?
+5. What's the procedure and the clinical picture? MRI
+   of what body part, and what symptoms are you dealing
+   with?
+:::
+
+*Your answers:*
+::: prompt
+1. Same reason: "not medically necessary." Then it says
+   "The documentation provided does not support medical
+   necessity for the requested service." That's the new
+   part.
+2. Yes, I have the letter. It says the MRI is needed to
+   rule out lumbar disc herniation based on eight weeks of
+   radiculopathy not responding to conservative treatment.
+3. The denial letter says "You may request an external
+   review by an independent review organization." So
+   external.
+4. 60 days from the denial date. Letter is dated three
+   weeks ago.
+5. MRI of the lumbar spine. Shooting pain down my left
+   leg for two months. Physical therapy hasn't helped.
+:::
+
+*Your Agent drafts the appeal letter:*
+::: agent
+Here's the appeal letter. It's addressed to the external
+review organization. Read it carefully---every claim in
+this letter must be true and supported by your medical
+records. If anything is wrong, tell me before you send it.
+
+---
+
+[DATE]
+
+Independent Review Organization
+[IRO Name and Address --- check your denial letter]
+
+RE: EXTERNAL REVIEW REQUEST
+Patient: [YOUR FULL NAME]
+Member ID: [YOUR MEMBER ID]
+Plan: [YOUR PLAN NAME]
+Claim/Reference Number: [FROM DENIAL LETTER]
+Procedure: MRI Lumbar Spine Without Contrast (CPT 72148)
+Date of Denial: [DATE FROM SECOND DENIAL LETTER]
+
+APPEAL STATEMENT
+
+I am requesting an external review of the denial of
+coverage for an MRI of the lumbar spine (CPT 72148),
+ordered by my treating physician, [DOCTOR'S NAME, MD].
+The procedure was denied twice as "not medically
+necessary." The second denial states: "The documentation
+provided does not support medical necessity for the
+requested service."
+
+I respectfully submit that the documentation does support
+medical necessity, and I request that this denial be
+overturned.
+
+CLINICAL HISTORY
+
+I have experienced progressive radiculopathy---shooting
+pain radiating from the lumbar spine down the left lower
+extremity---for approximately eight weeks. Symptoms have
+not responded to conservative treatment, including a
+course of physical therapy. See attached physical therapy
+treatment records.
+
+CLINICAL INDICATION
+
+My treating physician has determined that an MRI of the
+lumbar spine is necessary to rule out lumbar disc
+herniation as the cause of my symptoms. The clinical
+basis for this determination is:
+
+- Eight weeks of radiculopathy unresponsive to
+  conservative treatment
+- Progressive symptoms despite physical therapy
+- Need to identify or exclude a structural cause before
+  determining next treatment steps
+
+See attached letter of medical necessity from [DOCTOR'S
+NAME, MD], dated [DATE OF LETTER].
+
+BASIS FOR APPEAL
+
+The denial letter states that the documentation does not
+support medical necessity. The attached letter of medical
+necessity from my treating physician directly addresses
+the clinical indication for this procedure. The American
+College of Radiology Appropriateness Criteria rates
+lumbar MRI as "usually appropriate" for patients
+presenting with low back pain and radiculopathy that has
+not improved with conservative management.
+
+I have exhausted the internal appeals process. The
+clinical picture has not changed: I continue to
+experience radiculopathy that limits daily function, and
+the MRI remains the appropriate diagnostic step to
+determine the cause and guide treatment.
+
+REQUESTED ACTION
+
+I respectfully request that the independent reviewer
+overturn the denial and authorize the MRI of the lumbar
+spine (CPT 72148) as medically necessary. If expedited
+review is available, I request it---I have been waiting
+for this diagnostic procedure for over two months while
+symptoms persist.
+
+ENCLOSED DOCUMENTS
+
+1. Letter of medical necessity from [DOCTOR'S NAME, MD]
+2. Physical therapy treatment records
+3. First denial letter, dated [DATE]
+4. Second denial letter (internal appeal denial), dated
+   [DATE]
+
+Sincerely,
+[YOUR FULL NAME]
+[YOUR ADDRESS]
+[YOUR PHONE NUMBER]
+
+---
+
+Print this. Attach your doctor's letter of medical
+necessity and your physical therapy records. Send it
+certified mail---you want proof of delivery and the
+date it was received. Keep copies of everything you send.
+:::
+
+*Your follow-up:*
+::: prompt
+This is really long. Will someone actually read all of
+this?
+:::
+
+*Your Agent:*
+::: agent
+Yes. The external reviewer is a physician. They read
+dozens of these. They are looking for three things:
+
+1. THE CLINICAL QUESTION. What is wrong with you, and
+   what is the doctor trying to find out? Your letter
+   answers this in two sentences: radiculopathy for
+   eight weeks, need to rule out disc herniation.
+
+2. THE TREATMENT HISTORY. What has already been tried?
+   Your letter says physical therapy, and it didn't
+   work. The PT records prove it.
+
+3. THE SUPPORTING DOCUMENTATION. Is there a letter from
+   the treating physician? Does it make a specific
+   clinical argument? Yours does.
+
+The length is not the problem. Reviewers skim for
+structure, not brevity. The headers let them find what
+they need. A one-page letter that's vague loses. A
+two-page letter that's specific wins.
+
+That said---want me to cut this to one page? I can keep
+the clinical argument and remove the background. Some
+people prefer a tighter document. Your call.
+:::
+
+::: science
+External appeals succeed more often than most patients expect. When external reviewers overturn denials, the cases that win almost always share two features: they cite specific clinical criteria or policy language, and they attach supporting documentation from the treating physician. Vague appeals---"my doctor says I need this"---fail at higher rates than appeals that name the diagnosis, the failed treatments, and the clinical guidelines that support the request.[^s3-2]
+:::
+
+<!-- RESEARCH NEEDED: find citation on external appeal overturn rates and correlation with documentation specificity -->
+
+[^s3-2]: <!-- RESEARCH NEEDED: find citation on external appeal overturn rates and correlation with documentation specificity -->
+
+::: fairness
+The appeal letter that wins is written at a level most patients cannot produce without help. It requires clinical vocabulary, policy citation, and a structured argument---skills the denial letter itself does not teach. The system requires a document the system's own communications make impossible to write. Your Agent closes this gap. The gap is structural, not personal---and closing it does not make the system fair. It makes you less disadvantaged within an unfair system.
+:::

--- a/src/content/01-strategies/03-strategy-3-draft/index.dj
+++ b/src/content/01-strategies/03-strategy-3-draft/index.dj
@@ -437,3 +437,95 @@ External appeals succeed more often than most patients expect. When external rev
 ::: fairness
 The appeal letter that wins is written at a level most patients cannot produce without help. It requires clinical vocabulary, policy citation, and a structured argument---skills the denial letter itself does not teach. The system requires a document the system's own communications make impossible to write. Your Agent closes this gap. The gap is structural, not personal---and closing it does not make the system fair. It makes you less disadvantaged within an unfair system.
 :::
+
+### Example 3: The Zoning Public Comment
+
+In Strategy 1: Decode, you translated Measure H---a zoning downzone that would reduce housing supply in your neighborhood. You learned what it actually does: caps density at eight units per acre, requires conditional use permits for four or more units, and limits height to 35 feet in R-3 zones within 500 feet of single-family areas. You learned that "predatory developer" is campaign language, not a legal term. You learned the measure protects existing homeowners at the expense of future renters and housing supply. Now your city council is holding a public hearing before the vote. You have two minutes at the microphone. You've never spoken at a public hearing. You know what you think---the measure hurts renters---but you cannot get past the first sentence. The room will be full. A timer will count down. Your name and address go on the public record. Knowing the policy is one skill. Saying it out loud to a row of council members is a different one.
+
+*You:*
+::: prompt
+Remember when we decoded Measure H---the zoning downzone on my ballot? The city council is holding a public hearing on it next Tuesday. I want to speak against it. I have two minutes. I've never spoken at a public hearing before. I don't want to sound like a policy wonk---I want to sound like a person who lives there.
+:::
+
+*Your Agent:*
+::: agent
+I remember the Measure H analysis. Good---you already know the substance. Now we need to turn that into something you can say out loud under pressure. A few questions before I draft:
+
+1. You're a renter in an R-3 zone, correct? How long have you lived in your current apartment?
+
+2. Do you want to read from notes or memorize your comment? I'd suggest notes---on your phone or a printed page. Memorized comments tend to fall apart when you're nervous, and nerves at a public hearing are normal, not a sign of weakness.
+
+3. What is the ONE thing you want the council to remember after you sit down? Not three things. One.
+
+4. Are you comfortable being identified by name and address at the hearing? Public comment is public record---it goes in the minutes and sometimes gets recorded on video.
+
+5. Do you know if anyone else is planning to speak against the measure, or will you be the only renter voice in the room?
+:::
+
+*You:*
+::: prompt
+Yes, renter in an R-3 zone. Four years in my apartment. This neighborhood is where I want to stay long-term.
+
+Notes on my phone---I'll freeze if I try to memorize anything.
+
+The one thing: I want them to know that renters live here too and this measure protects homeowners at our expense.
+
+Yes, fine with name and address.
+
+Not sure if anyone else is going. I don't know anyone else planning to speak against it.
+:::
+
+*Your Agent:*
+::: agent
+Here's a two-minute comment written for speaking, not reading. Practice it once out loud---time yourself. If it runs over 1:45, we'll cut.
+
+---
+
+Good evening. My name is [YOUR NAME], and I live at [YOUR ADDRESS]. I've been a renter in this neighborhood for four years.
+
+I'm here to ask you to vote no on Measure H.
+
+This measure reduces the number of homes that can be built in my neighborhood. It caps density, adds permit requirements, and limits building heights in the R-3 zones where renters like me already live.
+
+Fewer units means less competition for landlords. Less competition means higher rents. That's not speculation---that's how supply works.
+
+Measure H is framed as protecting neighborhoods. But I live in this neighborhood. I've lived here for four years. The measure protects the homeowners next door. It does not protect me. It makes it harder for people like me to stay.
+
+I'm asking you to vote no. Thank you.
+
+---
+
+This runs about a minute. You have margin. Do not fill it---short and clear beats long and thorough at a public hearing. The council has heard dozens tonight. Yours needs to be the one they remember because it was specific and human, not because it was comprehensive.
+:::
+
+*You:*
+::: prompt
+This sounds like a policy paper. I want to sound like a person who lives in the neighborhood, not someone who studied zoning law.
+:::
+
+*Your Agent:*
+::: agent
+Fair. Here's the rewrite.
+
+---
+
+Good evening. My name is [YOUR NAME]. I live on [YOUR STREET]---been there four years. I walk to the coffee shop on the corner. I know my neighbors. This is my neighborhood.
+
+Measure H makes it harder to build apartments where I live. Fewer apartments means landlords have less competition. Less competition means my rent goes up.
+
+The yard signs say "Protect Our Neighborhoods." I'm standing here telling you---I live in this neighborhood. This measure doesn't protect me. It protects the homeowners. I'm a renter. I'm the one it hurts.
+
+Vote no on Measure H. Thank you.
+
+---
+
+Read this version out loud. If you stumble on a sentence, it's too long. Shorten it until you can say it without thinking about the words. At the microphone, you want to be thinking about the council members' faces, not your script.
+:::
+
+::: meme
+Murphy Brown could interview a senator without notes. She could not start the memo. You can have a strong opinion about zoning and still freeze at the microphone. These are different skills. Draft handles the second one.
+:::
+
+::: tip
+When drafting something you'll say out loud, tell your Agent "write this for speaking, not reading." Spoken language uses shorter sentences, more repetition, and fewer subordinate clauses than written prose. Read the draft aloud before the hearing---if you stumble on a sentence, the sentence is too long.
+:::


### PR DESCRIPTION
## Summary

- **Tightened opening block** — collapsed duplicate Zeigarnik paragraph, removed placeholder
- **Example 1: The Landlord Counteroffer** — chains from Strategy 1 Example 2 (lease clause decode). Two drafts (formal → casual) teach the core Draft skill: your voice emerges in the editing
- **Example 2: The Medicare Denial Appeal Letter** — chains from Strategy 0 (insurance denial decode). Full formal appeal letter with CPT codes, clinical history, ACR guidelines. FAIRNESS callout on the structural literacy gap
- **Example 3: The Zoning Public Comment** — chains from Strategy 1 Example 3 (Measure H decode). Two drafts (policy paper → human voice) teach spoken-word drafting
- **Closing** — strategies-compose paragraph, Murphy Brown callback meme, strong closing line: _"The AI brings the library. You bring the life. The draft is where they meet."_
- **Three new editorial conventions** added to `spec/editorial/editorial-conventions.md`: strong-line closing, example chaining, single-source examples

## Design decisions

All three worked examples chain back to earlier strategy chapters, building a connected mental model. The strategies compose — the examples demonstrate this. Full spec loops live in Strategy chapters (single-source); Field Guide entries will cross-reference back.

## Open items

- `<!-- RESEARCH NEEDED -->` on `[^s3-2]`: citation for external appeal overturn rates and correlation with documentation specificity
- Pre-existing "the AI" usage in intro prose (lines 23, 27) — intentional literary voice vs. "your Agent" instructional convention; flag for editorial review

## Test plan

- [ ] Read Examples 1-3 for voice consistency with Strategies 0-2
- [ ] Verify dollar amounts in Example 1 match Strategy 1 Example 2
- [ ] Verify clinical details in Example 2 match Strategy 0
- [ ] Verify Measure H details in Example 3 match Strategy 1 Example 3
- [ ] Check all callouts render correctly in ePub build (when node is fixed)
- [ ] Review three new editorial conventions in `spec/editorial/editorial-conventions.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)