### PR TITLE
Resolve footnote citations and address Apple Books sync feedback

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,40 +1,30 @@
 # TODO — A Majordomo for Everyone
 
-Last reviewed: 2026-04-08 against spec/ directory.
+Last reviewed: 2026-04-15 against spec/ directory and codebase.
 
 ---
 
-## New Chapters / Entries to Draft
+## Completed Since Last Review (2026-04-08)
 
-### ~~NEW: Customize Your Chat Interface~~ — DONE
-- [x] **WB-7 in Computer & Web field guide** + intro demo in Ch. 2 ("Now Make It Yours")
-- Remaining friction points to address elsewhere:
-  2. Managing multiple short conversations vs. one long thread → WB-10 / Ch. 4
-  3. Building a personal prompt library → future entry or TIP
-  4. Voice input setup → future entry or TIP
-  5. When to start fresh vs. continue a thread → WB-10 / Ch. 4
+- [x] Strategy worked examples — all 10 strategies (0–9) now have 2–3 full spec-loop examples
+- [x] Jeeves voice rewrite — all Field Guide entries rewritten with "My Man Jeeves" openers, fact-checked with citations
+- [x] Field Guide reorganization — WB entries renumbered sequentially (WB-1 through WB-9), Creative domain added (Cr-1 through Cr-4)
+- [x] Field Guide entry labels standardized to Title Case
+- [x] Former stubs drafted: Ho-5, Ho-7, Ch-1, Ch-2, Ch-3, Ch-6 all have substantive content
+- [x] RESEARCH NEEDED markers reduced from 126 → 3 (all in Chores)
+- [x] `[companion URL TBD]` markers resolved (none remaining)
+- [x] WB-* entry numbering rationalized (was non-sequential, now WB-1 through WB-9)
+- [x] New appendices added: Appendix I (Spec Literacy), Appendix J (Working with Text)
+- [x] Apple Books highlight sync — design spec, implementation plan, and script skeleton (#23)
+- [x] Build pipeline type-checks clean (`npm run build:check` passes)
+
+---
 
 ## Unwritten Content
 
-These are the major gaps — content that doesn't exist yet.
-
-### Strategy Worked Examples (Part 1)
-
-Each strategy chapter needs 2–3 full [SPEC] loops (reader situation → clarifying questions → answers → proposed spec → review → execute → evaluate). Currently only Strategy 0 and Strategy 9 have them. Estimated scope: ~300 words per example × 2–3 examples × 8 chapters.
-
-- [x] **Strategy 1: Decode** — Insurance EOB ($347 that isn't real). Lease renewal with new clause ($6,450 exit cost). Ballot measure (downzoning framed as neighborhood protection).
-- [x] **Strategy 2: Prepare** — Before an oncology appointment. Before a salary negotiation. Before a contractor walkthrough.
-- [x] **Strategy 3: Draft** — A demand letter to a landlord. A Medicare denial appeal. A public comment for city council.
-- [x] **Strategy 4: Navigate** — Filing for unemployment. Filing a first-level insurance appeal. Filing a small claims case.
-- [x] **Strategy 5: Decide** — Repair vs. replace an appliance. Roth vs. traditional IRA. Escalate vs. settle a landlord dispute.
-- [x] **Strategy 6: Diagnose** — A washing machine grinding noise. Persistent headaches (triage). An HVAC quote that seems high.
-- [x] **Strategy 7: Research** — Before a surgical procedure. Before signing a non-compete. Between two college financial aid offers.
-- [x] **Strategy 8: Assert** — Tenant rights when landlord refuses repairs. Employee rights when let go. Consumer rights when disputing a charge.
-- [x] **Strategy 9: Create** — A wedding toast with slideshow. A branching short story. A game narrative prototype.
-
 ### Chapter 33: Advanced Free Tier Strategies (Part 3)
 
-- [ ] **Write Ch 33** — status: "stub", body is placeholder only. Should cover advanced rotation techniques, context management, efficient prompting within free-tier limits. Extends Ch 3 (Free Tier Playbook) for Part 3 readers.
+- [ ] **Write Ch 33** — status: "stub" (11 lines), body is placeholder only. Should cover advanced rotation techniques, context management, efficient prompting within free-tier limits. Extends Ch 3 (Free Tier Playbook) for Part 3 readers.
 
 ### New Field Guide Entries
 
@@ -53,39 +43,6 @@ Each strategy chapter needs 2–3 full [SPEC] loops (reader situation → clarif
   - Status: waiting on full draft upload from author
   - Assign entry ID once domain slot confirmed
 
-- [ ] **WB-0: Working With Text — The Token-Saving Strategy** *(domain intro entry)*
-  - Core idea: AI agents work in text. The closer your deliverable starts to plain text, the cheaper, faster, and more editable it stays throughout the spec loop. Only render to final format at the end.
-  - The principle: every rendered format (PPTX, PDF, DOCX, HTML) is a lossy translation from text. Keep everything upstream of that translation editable for as long as possible. Don't pour concrete until the framing is right.
-  - Token framing: a 20-slide deck as Markdown is ~2,000 tokens. As PPTX XML it's 50,000+. Your agent reads the Markdown; you export the PPTX.
-  - Examples:
-
-    | Deliverable | Don't start with | Start with instead |
-    |---|---|---|
-    | Presentation / slide deck | Asking for a PowerPoint | CommonMark outline with one-line art briefs per slide; export to PPTX at the end |
-    | Website | "Build me a website" | Requirements doc + flat list of pages with purpose, nav, and rough content per page; generate HTML page-by-page |
-    | Resume | Uploading a PDF to reformat | Plain text or Markdown version first; styling pass at the end |
-    | Email newsletter | Asking for a designed template | Write body copy in plain text; drop into template only after copy is approved |
-    | Spreadsheet / budget | Asking for a filled .xlsx | CSV or Markdown table first; import or format once the data is right |
-    | Database schema | "Design me a database" | Entity list in plain English → Markdown table of fields + types → SQL only after structure is confirmed |
-    | Legal / contract draft | Uploading a formatted doc | Plain prose outline of clauses; negotiate structure before formatting |
-    | Video script | Storyboard or slide deck | Scene-by-scene Markdown with speaker notes; visuals brief inline |
-    | App / software feature | "Build this app" | User story in plain English → acceptance criteria list → spec → code |
-    | Recipe or meal plan | Asking for a formatted cookbook | Plain ingredient + step list; format for print at the end |
-
-  - The workflow — same one professional teams use: (1) Build the outline, get the story right. (2) Build piece one. (3) Iterate until right. (4) Update the plan — did the story change? (5) Build piece two. Repeat. (6) The finished product is the *last* thing you ask for, not the first.
-  - This is how screenwriters, architects, software teams, and ad agencies work. The "just make me the whole thing" instinct is what produces generic output you can't fix.
-  - Candidate anchor episode: *Home Improvement* — Tim skips the plan, applies power, rebuilds from scratch. The spec loop is the plan.
-  - Strategy: **Specify** + **Draft**; cross-ref WB entries for each deliverable type
-
-### Field Guide Stubs (Part 2)
-
-- [ ] **Ho-5** — stub, full entry to be drafted
-- [ ] **Ho-7** — stub, full entry to be drafted
-- [ ] **Ch-1: Shopping Your Values** — stub
-- [ ] **Ch-2: Understanding a Contractor Bid** — stub
-- [ ] **Ch-3: Identifying and Caring for House Plants** — stub
-- [ ] **Ch-6: Optimizing Manual Chores** — stub
-
 ### Appendix B: Spec Interview Starters
 
 - [ ] **Complete Appendix B** — 8 of ~50 starters written. 42 more needed, organized by Field Guide domain. Must be print-ready at 8.5×11.
@@ -96,13 +53,9 @@ Each strategy chapter needs 2–3 full [SPEC] loops (reader situation → clarif
 
 Content that exists but could be stronger, more complete, or better connected.
 
-### Part 1: Thin Strategy Chapters
-
-Strategies 4 (Navigate, 47 lines) and 6 (Diagnose, 49 lines) are the thinnest. Once worked examples are added they'll fill out, but the explanatory prose is also lighter than peers like Strategy 5 (Decide) or Strategy 8 (Assert).
-
 ### Part 1: Missing Cross-References to Field Guide
 
-No strategy chapter cross-references Field Guide entries by ID. Strategy 8 (Assert) should reference H-4, L-1, W-2; Strategy 1 (Decode) should reference H-3, M-2, L-1; etc.
+Only Strategies 4 and 9 cross-reference Field Guide entries by ID. The other 8 strategy chapters should too — e.g., Strategy 8 (Assert) → H-4, L-1, W-2; Strategy 1 (Decode) → H-3, M-2, L-1.
 
 ### Part 1: Conservative-Answer Convention
 
@@ -114,28 +67,25 @@ Only Strategy 0 has an [ALSO] callout. Other strategies reference Claude-specifi
 
 ### Part 2: Domain Size Imbalance
 
-Target is ~80 entries total. Current count by domain:
+Entry target was ~80; current total is *91* across 12 domains. The target is exceeded overall, but distribution is uneven:
 
 | Domain | Count | Notes |
 |--------|-------|-------|
 | Health (H-) | 19 | Strong |
-| Life (Li-) | 8–11 | Moderate |
-| Online/Web (WB-) | 8 | Moderate |
-| Work (W-) | 7 | Moderate |
-| Civic (C-) | 7 | Moderate |
-| Money (M-) | 6 | Light — financial complexity warrants 10+ |
-| Home (Ho-) | 8 listed, 2 stubs | Partially stubbed |
-| Chores (Ch-) | 6 listed, 4 stubs | Mostly stubbed |
+| Life (Li-) | 12 | Strong |
+| Computer & Web (WB-) | 9 + IT Support | Strong |
+| Civic (C-) | 8 | Solid |
+| Home (Ho-) | 7 | Solid |
+| Work (W-) | 7 | Solid |
+| Money (M-) | 6 | Light — financial complexity warrants 8–10 |
+| Chores (Ch-) | 6 | Solid |
+| Creative (Cr-) | 4 | New domain — assess if complete |
 | Legal (L-) | 4 | Light — expand to 6–8 |
 | Transportation (Tr-) | 4 | Light |
-| IRL (IRL-) | 3 | Light |
-| **Total** | **~68** | **~85% of target** |
+| IRL (IRL-) | 3 | Light — expand to 5+ |
+| **Total** | **91** | **114% of original target** |
 
-Domains that most need expansion: Money, Legal, IRL.
-
-### Part 2: WB-* Entry Numbering
-
-Online Presence entries are numbered non-sequentially (WB-8, 9, 10, 1, 2, 3). Rationalize numbering.
+Priority expansions: Money, Legal, IRL.
 
 ### Part 3: "Recognizing a Correct Spec"
 
@@ -169,20 +119,22 @@ Place as `See also:` or footnote citations where they fit:
 
 ## Research Needed
 
-126 `<!-- RESEARCH NEEDED -->` comments across Part 2, including 70 tagged `(HUMAN CONDITION)`.
+Down from 126 to *3* `<!-- RESEARCH NEEDED -->` comments — all in Chores (Ch-3 plant citation, Ch-6 occupational therapy citation, Ch-6 BLS time-use survey).
 
-Distribution:
+74 `<!-- HUMAN CONDITION -->` editorial research notes remain across Part 2. These are sociological/contextual background for the author, not blocking items — but should be reviewed before publication to decide what gets surfaced in the text vs. removed.
 
-| Domain | RESEARCH NEEDED | HUMAN CONDITION |
-|--------|----------------|-----------------|
-| Life | 40 | 25 |
-| Civic | 24 | 11 |
-| Work | 18 | 10 |
-| Money | 14 | 7 |
-| Health | 10 | 8 |
-| Transportation | 8 | 3 |
-| Legal | 7 | 3 |
-| IRL | 5 | 3 |
+| Domain | HUMAN CONDITION |
+|--------|-----------------|
+| Life | 25 |
+| Civic | 12 |
+| Work | 10 |
+| Health | 8 |
+| Money | 7 |
+| Transportation | 3 |
+| IRL | 3 |
+| Home | 2 |
+| Chores | 2 |
+| Creative | 2 |
 
 Parts 0, 1, 3, and 4 have zero research comments — clean.
 
@@ -190,11 +142,13 @@ Parts 0, 1, 3, and 4 have zero research comments — clean.
 
 ## Pre-Publication Checklist
 
-- [ ] All `[companion URL TBD]` resolved
-- [ ] All `<!-- RESEARCH NEEDED -->` resolved or removed
-- [ ] All stubs drafted
-- [ ] Appendix B complete (50 starters)
-- [ ] Appendix A reflects final entry list
+- [x] All `[companion URL TBD]` resolved
+- [ ] All `<!-- RESEARCH NEEDED -->` resolved or removed (3 remaining)
+- [x] All stubs drafted (except Ch 33)
+- [ ] Ch 33 written (only remaining stub)
+- [ ] Appendix B complete (50 starters; 8 written)
+- [ ] Appendix A reflects final entry list (91 entries across 12 domains)
+- [ ] `<!-- HUMAN CONDITION -->` notes reviewed — surface or remove
 - [ ] All art briefs have corresponding images in `src/images/`
 - [ ] XMP metadata embedded in all images
 - [ ] Version bumped and tagged

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@ Last reviewed: 2026-04-15 against spec/ directory and codebase.
 - [x] Field Guide reorganization — WB entries renumbered sequentially (WB-1 through WB-9), Creative domain added (Cr-1 through Cr-4)
 - [x] Field Guide entry labels standardized to Title Case
 - [x] Former stubs drafted: Ho-5, Ho-7, Ch-1, Ch-2, Ch-3, Ch-6 all have substantive content
-- [x] RESEARCH NEEDED markers reduced from 126 → 3 (all in Chores)
+- [x] All footnote citations verified — 5 previously unverified `[^...]` footnotes now have real sources
 - [x] `[companion URL TBD]` markers resolved (none remaining)
 - [x] WB-* entry numbering rationalized (was non-sequential, now WB-1 through WB-9)
 - [x] New appendices added: Appendix I (Spec Literacy), Appendix J (Working with Text)
@@ -117,38 +117,40 @@ Place as `See also:` or footnote citations where they fit:
 
 ---
 
-## Research Needed
+## Research & Editorial Notes
 
-Down from 126 to *3* `<!-- RESEARCH NEEDED -->` comments — all in Chores (Ch-3 plant citation, Ch-6 occupational therapy citation, Ch-6 BLS time-use survey).
+*Footnote citations* — all resolved. Every `[^...]` footnote in the book now has a real, verified source.
 
-74 `<!-- HUMAN CONDITION -->` editorial research notes remain across Part 2. These are sociological/contextual background for the author, not blocking items — but should be reviewed before publication to decide what gets surfaced in the text vs. removed.
+*Editorial research notes* — 60 `<!-- RESEARCH NEEDED: ... -->` and 74 `<!-- HUMAN CONDITION ... -->` comments remain across Part 2. These are author memos: background research directions, sociological context, and expansion ideas. They do not appear in the built ePub and do not correspond to unverified claims in the text. They should be reviewed before publication to decide what gets surfaced, expanded, or removed.
 
-| Domain | HUMAN CONDITION |
-|--------|-----------------|
-| Life | 25 |
-| Civic | 12 |
-| Work | 10 |
-| Health | 8 |
-| Money | 7 |
-| Transportation | 3 |
-| IRL | 3 |
-| Home | 2 |
-| Chores | 2 |
-| Creative | 2 |
+| Domain | RESEARCH NEEDED | HUMAN CONDITION | Total |
+|--------|-----------------|-----------------|-------|
+| Life | 14 | 25 | 39 |
+| Civic | 15 | 12 | 27 |
+| Work | 8 | 10 | 18 |
+| Money | 7 | 7 | 14 |
+| Health | 2 | 8 | 10 |
+| Transportation | 5 | 3 | 8 |
+| IRL | 2 | 3 | 5 |
+| Home | 3 | 2 | 5 |
+| Creative | 1 | 2 | 3 |
+| Legal | 3 | 0 | 3 |
+| Chores | 0 | 2 | 2 |
+| **Total** | **60** | **74** | **134** |
 
-Parts 0, 1, 3, and 4 have zero research comments — clean.
+Parts 0, 1, 3, and 4 have zero research comments — clean. Strategy 3 had two (insurance appeal citation) — now resolved.
 
 ---
 
 ## Pre-Publication Checklist
 
 - [x] All `[companion URL TBD]` resolved
-- [ ] All `<!-- RESEARCH NEEDED -->` resolved or removed (3 remaining)
+- [x] All footnote citations verified (previously 5 unverified `[^...]` footnotes)
 - [x] All stubs drafted (except Ch 33)
 - [ ] Ch 33 written (only remaining stub)
 - [ ] Appendix B complete (50 starters; 8 written)
 - [ ] Appendix A reflects final entry list (91 entries across 12 domains)
-- [ ] `<!-- HUMAN CONDITION -->` notes reviewed — surface or remove
+- [ ] Editorial notes reviewed — 134 `RESEARCH NEEDED` + `HUMAN CONDITION` comments to surface or remove
 - [ ] All art briefs have corresponding images in `src/images/`
 - [ ] XMP metadata embedded in all images
 - [ ] Version bumped and tagged

--- a/docs/superpowers/plans/2026-04-14-apple-books-sync.md
+++ b/docs/superpowers/plans/2026-04-14-apple-books-sync.md
@@ -1,0 +1,629 @@
+# Apple Books Highlight Sync — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a script that syncs Apple Books highlights from the _A Majordomo for Everyone_ ePub into `notes/highlights.md`, auto-committing and pushing, with an hourly launchd daemon.
+
+**Architecture:** A single Python script (`scripts/sync-highlights.py`) reads Apple Books' SQLite databases directly, filters to one book, renders markdown, and does git commit+push. A launchd plist runs it hourly. No third-party Python dependencies — stdlib only (`sqlite3`, `subprocess`, `pathlib`, `datetime`, `glob`).
+
+**Tech Stack:** Python 3 (via `uv run`), SQLite, launchd, git
+
+**Spec:** `docs/superpowers/specs/2026-04-14-apple-books-sync-design.md`
+
+---
+
+### Task 1: Create the script skeleton with iCloud sync
+
+**Files:**
+- Create: `scripts/sync-highlights.py`
+
+- [ ] **Step 1: Create `scripts/` directory**
+
+```bash
+mkdir -p scripts
+```
+
+- [ ] **Step 2: Write the script skeleton with iCloud sync function**
+
+Create `scripts/sync-highlights.py` with the `uv` inline script metadata, logging setup, and the iCloud sync step:
+
+```python
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""Sync Apple Books highlights for A Majordomo for Everyone to notes/highlights.md."""
+
+import glob
+import logging
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOOK_TITLE = "A Majordomo for Everyone"
+
+ANNOTATION_DB_GLOB = os.path.expanduser(
+    "~/Library/Containers/com.apple.iBooksX/Data/Documents/AEAnnotation/*.sqlite"
+)
+LIBRARY_DB_GLOB = os.path.expanduser(
+    "~/Library/Containers/com.apple.iBooksX/Data/Documents/BKLibrary/*.sqlite"
+)
+
+# Apple Cocoa epoch: 2001-01-01 00:00:00 UTC
+COCOA_EPOCH = datetime(2001, 1, 1, tzinfo=timezone.utc)
+
+
+def ensure_icloud_sync() -> None:
+    """Open Books.app to force iCloud sync, then close it.
+
+    Skips if Books is already running to avoid disrupting active reading.
+    """
+    result = subprocess.run(
+        ["pgrep", "-x", "Books"], capture_output=True, text=True
+    )
+    if result.returncode == 0:
+        log.info("Books.app already running — skipping iCloud sync trigger")
+        return
+
+    log.info("Opening Books.app to trigger iCloud sync...")
+    subprocess.run(["open", "-a", "Books"], check=True)
+    time.sleep(20)
+    subprocess.run(
+        ["osascript", "-e", 'quit app "Books"'],
+        capture_output=True,
+    )
+    log.info("Books.app closed")
+
+
+def main() -> None:
+    log.info("Starting highlight sync")
+    ensure_icloud_sync()
+    log.info("Done")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 3: Make the script executable**
+
+```bash
+chmod +x scripts/sync-highlights.py
+```
+
+- [ ] **Step 4: Test the skeleton runs**
+
+```bash
+uv run scripts/sync-highlights.py
+```
+
+Expected: logs "Starting highlight sync", triggers (or skips) Books sync, logs "Done". If you get a permission error about `~/Library/Containers/com.apple.iBooksX/`, grant Full Disk Access to your terminal in System Settings > Privacy & Security > Full Disk Access.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/sync-highlights.py
+git commit -m "feat: add sync-highlights script skeleton with iCloud sync (#23)"
+```
+
+---
+
+### Task 2: Read annotations from SQLite
+
+**Files:**
+- Modify: `scripts/sync-highlights.py`
+
+- [ ] **Step 1: Add the database discovery function**
+
+Add after the `COCOA_EPOCH` constant:
+
+```python
+def find_db(pattern: str) -> Path:
+    """Find the single SQLite database matching a glob pattern."""
+    matches = glob.glob(pattern)
+    if not matches:
+        log.error("No database found matching %s", pattern)
+        log.error(
+            "Make sure you have opened the book in Apple Books on this Mac. "
+            "You may also need to grant Full Disk Access to your terminal "
+            "in System Settings > Privacy & Security."
+        )
+        sys.exit(1)
+    return Path(matches[0])
+```
+
+- [ ] **Step 2: Add the annotation query function**
+
+Add after `find_db`:
+
+```python
+def fetch_highlights() -> tuple[list[dict], str, str]:
+    """Query Apple Books databases for highlights from BOOK_TITLE.
+
+    Returns (highlights, asset_id, author) where each highlight is a dict with
+    keys: selected_text, note, chapter, location_start, modified_date.
+    """
+    annotation_db = find_db(ANNOTATION_DB_GLOB)
+    library_db = find_db(LIBRARY_DB_GLOB)
+
+    conn = sqlite3.connect(str(annotation_db))
+    conn.row_factory = sqlite3.Row
+    conn.execute(f"ATTACH DATABASE ? AS library", (str(library_db),))
+
+    rows = conn.execute(
+        """
+        SELECT
+            ann.ZANNOTATIONSELECTEDTEXT   AS selected_text,
+            ann.ZANNOTATIONNOTE           AS note,
+            ann.ZFUTUREPROOFING5          AS chapter,
+            ann.ZPLLOCATIONRANGESTART     AS location_start,
+            ann.ZANNOTATIONMODIFICATIONDATE AS modified_date,
+            book.ZASSETID                 AS asset_id,
+            book.ZAUTHOR                  AS author
+        FROM ZAEANNOTATION ann
+        JOIN library.ZBKLIBRARYASSET book
+            ON ann.ZANNOTATIONASSETID = book.ZASSETID
+        WHERE book.ZTITLE = ?
+            AND ann.ZANNOTATIONSELECTEDTEXT IS NOT NULL
+            AND ann.ZANNOTATIONDELETED = 0
+        ORDER BY ann.ZPLLOCATIONRANGESTART ASC
+        """,
+        (BOOK_TITLE,),
+    ).fetchall()
+
+    conn.close()
+
+    if not rows:
+        return [], "", ""
+
+    asset_id = rows[0]["asset_id"]
+    author = rows[0]["author"] or ""
+
+    highlights = [
+        {
+            "selected_text": row["selected_text"],
+            "note": row["note"],
+            "chapter": row["chapter"],
+            "location_start": row["location_start"],
+            "modified_date": row["modified_date"],
+        }
+        for row in rows
+    ]
+
+    return highlights, asset_id, author
+```
+
+- [ ] **Step 3: Wire it into main and test**
+
+Update `main()`:
+
+```python
+def main() -> None:
+    log.info("Starting highlight sync")
+    ensure_icloud_sync()
+
+    highlights, asset_id, author = fetch_highlights()
+    if not highlights:
+        log.info("No highlights found for '%s' — nothing to sync", BOOK_TITLE)
+        return
+
+    log.info("Found %d highlights (asset: %s)", len(highlights), asset_id)
+    log.info("Done")
+```
+
+Run:
+
+```bash
+uv run scripts/sync-highlights.py
+```
+
+Expected: either "No highlights found" (if you haven't highlighted anything yet) or "Found N highlights". Verify the count looks right.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/sync-highlights.py
+git commit -m "feat: add SQLite query for Apple Books highlights (#23)"
+```
+
+---
+
+### Task 3: Render highlights as markdown
+
+**Files:**
+- Modify: `scripts/sync-highlights.py`
+
+- [ ] **Step 1: Add the markdown rendering function**
+
+Add after `fetch_highlights`:
+
+```python
+def render_markdown(
+    highlights: list[dict], asset_id: str, author: str
+) -> str:
+    """Render highlights as a markdown document with YAML frontmatter."""
+    now = datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+    lines = [
+        "---",
+        f'title: "{BOOK_TITLE}"',
+        f'author: "{author}"',
+        f'asset_id: "{asset_id}"',
+        f'last_synced: "{now}"',
+        "---",
+        "",
+    ]
+
+    # Group by chapter, preserving location order within each group
+    chapters: dict[str, list[dict]] = {}
+    for h in highlights:
+        chapter = h["chapter"] or "Uncategorized"
+        chapters.setdefault(chapter, []).append(h)
+
+    # Render Uncategorized last
+    chapter_names = [c for c in chapters if c != "Uncategorized"]
+    if "Uncategorized" in chapters:
+        chapter_names.append("Uncategorized")
+
+    for i, chapter in enumerate(chapter_names):
+        lines.append(f"## {chapter}")
+        lines.append("")
+
+        for j, h in enumerate(chapters[chapter]):
+            # Quote each paragraph of the selected text
+            for para in h["selected_text"].split("\n"):
+                stripped = para.strip()
+                if stripped:
+                    lines.append(f"> {stripped}")
+            lines.append("")
+
+            if h["note"]:
+                lines.append(f"Note: {h['note']}")
+                lines.append("")
+
+            # Separator between highlights (not after the last one in a chapter)
+            if j < len(chapters[chapter]) - 1:
+                lines.append("---")
+                lines.append("")
+
+        # Blank line between chapters
+        if i < len(chapter_names) - 1:
+            lines.append("")
+
+    # Ensure trailing newline
+    return "\n".join(lines) + "\n"
+```
+
+- [ ] **Step 2: Add the file-writing function**
+
+Add after `render_markdown`:
+
+```python
+def write_highlights(content: str) -> Path:
+    """Write markdown content to notes/highlights.md."""
+    output_dir = REPO_ROOT / "notes"
+    output_dir.mkdir(exist_ok=True)
+    output_file = output_dir / "highlights.md"
+    output_file.write_text(content, encoding="utf-8")
+    log.info("Wrote %s", output_file.relative_to(REPO_ROOT))
+    return output_file
+```
+
+- [ ] **Step 3: Wire into main and test**
+
+Update `main()`:
+
+```python
+def main() -> None:
+    log.info("Starting highlight sync")
+    ensure_icloud_sync()
+
+    highlights, asset_id, author = fetch_highlights()
+    if not highlights:
+        log.info("No highlights found for '%s' — nothing to sync", BOOK_TITLE)
+        return
+
+    log.info("Found %d highlights (asset: %s)", len(highlights), asset_id)
+
+    content = render_markdown(highlights, asset_id, author)
+    write_highlights(content)
+
+    log.info("Done")
+```
+
+Run:
+
+```bash
+uv run scripts/sync-highlights.py
+```
+
+Then inspect the output:
+
+```bash
+cat notes/highlights.md
+```
+
+Expected: YAML frontmatter with correct title/author/asset_id, highlights grouped by chapter with `>` quoting, notes where present, `---` separators.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/sync-highlights.py
+git commit -m "feat: render highlights as markdown (#23)"
+```
+
+---
+
+### Task 4: Git commit and push with change counts
+
+**Files:**
+- Modify: `scripts/sync-highlights.py`
+
+- [ ] **Step 1: Add the git operations function**
+
+Add after `write_highlights`:
+
+```python
+def count_highlight_changes(content: str) -> tuple[int, int]:
+    """Compare new content against existing highlights.md to count changes.
+
+    Returns (new_count, updated_count) based on highlight-level diffing.
+    A highlight is identified by its quoted text (lines starting with "> ").
+    """
+    output_file = REPO_ROOT / "notes" / "highlights.md"
+    if not output_file.exists():
+        # All highlights are new
+        new = content.count("\n> ")
+        return new, 0
+
+    old = output_file.read_text(encoding="utf-8")
+    old_quotes = {
+        line.strip() for line in old.splitlines() if line.startswith("> ")
+    }
+    new_quotes = {
+        line.strip() for line in content.splitlines() if line.startswith("> ")
+    }
+
+    added = len(new_quotes - old_quotes)
+    # "Updated" = old highlights that disappeared (text changed)
+    removed = len(old_quotes - new_quotes)
+    return added, removed
+
+
+def git_commit_and_push(new_count: int, updated_count: int) -> None:
+    """Commit and push notes/ if there are changes."""
+
+    def run_git(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", "-C", str(REPO_ROOT), *args],
+            capture_output=True,
+            text=True,
+            check=check,
+        )
+
+    # Check for changes
+    result = run_git("diff", "--quiet", "notes/", check=False)
+    untracked = run_git(
+        "ls-files", "--others", "--exclude-standard", "notes/", check=False
+    )
+
+    if result.returncode == 0 and not untracked.stdout.strip():
+        log.info("No changes to commit")
+        return
+
+    run_git("add", "notes/")
+
+    # Build commit message
+    parts = []
+    if new_count:
+        parts.append(f"{new_count} new")
+    if updated_count:
+        parts.append(f"{updated_count} updated")
+    summary = ", ".join(parts) if parts else "changes"
+    message = f"notes: sync highlights ({summary})"
+
+    run_git("commit", "-m", message)
+    log.info("Committed: %s", message)
+
+    # Push — tolerate failure (e.g., no network)
+    push_result = run_git("push", "origin", "main", check=False)
+    if push_result.returncode == 0:
+        log.info("Pushed to origin/main")
+    else:
+        log.warning(
+            "Push failed (will retry next run): %s",
+            push_result.stderr.strip(),
+        )
+```
+
+- [ ] **Step 2: Wire into main**
+
+Update the end of `main()`:
+
+```python
+def main() -> None:
+    log.info("Starting highlight sync")
+    ensure_icloud_sync()
+
+    highlights, asset_id, author = fetch_highlights()
+    if not highlights:
+        log.info("No highlights found for '%s' — nothing to sync", BOOK_TITLE)
+        return
+
+    log.info("Found %d highlights (asset: %s)", len(highlights), asset_id)
+
+    content = render_markdown(highlights, asset_id, author)
+    new_count, updated_count = count_highlight_changes(content)
+    write_highlights(content)
+    git_commit_and_push(new_count, updated_count)
+
+    log.info("Done")
+```
+
+Note: `count_highlight_changes` must be called _before_ `write_highlights` so it can compare against the old file on disk.
+
+- [ ] **Step 3: Test end-to-end**
+
+Run the script:
+
+```bash
+uv run scripts/sync-highlights.py
+```
+
+Then check:
+
+```bash
+git log --oneline -3
+```
+
+Expected: a commit like `notes: sync highlights (1 new)` (or similar). Run it again immediately — should log "No changes to commit" since nothing changed.
+
+- [ ] **Step 4: Commit the script changes**
+
+```bash
+git add scripts/sync-highlights.py
+git commit -m "feat: add git commit and push for highlight sync (#23)"
+```
+
+---
+
+### Task 5: Create the launchd plist
+
+**Files:**
+- Create: `scripts/com.davidwkeith.majordomo-highlights.plist`
+
+- [ ] **Step 1: Find the absolute paths needed for the plist**
+
+```bash
+which uv
+echo $PWD
+```
+
+Note the absolute path to `uv` (likely `/opt/homebrew/bin/uv`) and the repo root.
+
+- [ ] **Step 2: Create the plist**
+
+Create `scripts/com.davidwkeith.majordomo-highlights.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.davidwkeith.majordomo-highlights</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/uv</string>
+        <string>run</string>
+        <string>scripts/sync-highlights.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/dwk/Developer/github.com/davidwkeith/A-Majordomo-for-Everyone</string>
+
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/majordomo-highlights-sync.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/majordomo-highlights-sync.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>
+```
+
+Note: `EnvironmentVariables` with `PATH` is needed because launchd agents run with a minimal environment that doesn't include Homebrew paths. Without this, `uv` and `git` (if installed via Homebrew) won't be found.
+
+- [ ] **Step 3: Validate the plist syntax**
+
+```bash
+plutil -lint scripts/com.davidwkeith.majordomo-highlights.plist
+```
+
+Expected: `scripts/com.davidwkeith.majordomo-highlights.plist: OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/com.davidwkeith.majordomo-highlights.plist
+git commit -m "feat: add launchd plist for hourly highlight sync (#23)"
+```
+
+---
+
+### Task 6: Install the daemon and verify
+
+**Files:**
+- No files modified — this is manual setup and verification.
+
+- [ ] **Step 1: Symlink the plist into LaunchAgents**
+
+```bash
+ln -sf "$(pwd)/scripts/com.davidwkeith.majordomo-highlights.plist" ~/Library/LaunchAgents/
+```
+
+- [ ] **Step 2: Load the agent**
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.davidwkeith.majordomo-highlights.plist
+```
+
+Since `RunAtLoad` is true, this triggers an immediate run.
+
+- [ ] **Step 3: Verify it ran**
+
+Wait ~30 seconds (the script waits 20s for Books sync), then check:
+
+```bash
+cat /tmp/majordomo-highlights-sync.log
+```
+
+Expected: log output showing the sync ran (or "No highlights found" if you haven't highlighted anything yet).
+
+- [ ] **Step 4: Verify the agent is registered**
+
+```bash
+launchctl list | grep majordomo
+```
+
+Expected: a line showing the agent with PID or exit status.
+
+- [ ] **Step 5: Add `notes/` to .gitignore exclusion note and commit**
+
+Add a comment to `.gitignore` so future contributors know `notes/` is intentionally tracked:
+
+The `notes/` directory is committed (generated highlights from Apple Books). No `.gitignore` change needed since git tracks it by default — only ignored patterns are excluded.
+
+No commit needed for this step. The directory will be tracked once `notes/highlights.md` is committed by the script.
+
+- [ ] **Step 6: Final commit — close the issue**
+
+```bash
+git add scripts/
+git commit -m "feat: complete Apple Books highlight sync (#23)
+
+Closes #23"
+git push origin main
+```

--- a/docs/superpowers/plans/2026-04-14-apple-books-sync.md
+++ b/docs/superpowers/plans/2026-04-14-apple-books-sync.md
@@ -378,25 +378,28 @@ def count_highlight_changes(content: str) -> tuple[int, int]:
     """Compare new content against existing highlights.md to count changes.
 
     Returns (new_count, updated_count) based on highlight-level diffing.
-    A highlight is identified by its quoted text (lines starting with "> ").
+    Highlights are separated by "---" lines in the rendered markdown.
     """
     output_file = REPO_ROOT / "notes" / "highlights.md"
+
+    def extract_highlights(text: str) -> list[str]:
+        """Split rendered markdown into individual highlight blocks on '---' separators."""
+        blocks = [b.strip() for b in text.split("\n---\n") if b.strip()]
+        return blocks
+
     if not output_file.exists():
-        # All highlights are new
-        new = content.count("\n> ")
-        return new, 0
+        return len(extract_highlights(content)), 0
 
     old = output_file.read_text(encoding="utf-8")
-    old_quotes = {
-        line.strip() for line in old.splitlines() if line.startswith("> ")
-    }
-    new_quotes = {
-        line.strip() for line in content.splitlines() if line.startswith("> ")
-    }
+    old_blocks = extract_highlights(old)
+    new_blocks = extract_highlights(content)
 
-    added = len(new_quotes - old_quotes)
+    old_set = set(old_blocks)
+    new_set = set(new_blocks)
+
+    added = len(new_set - old_set)
     # "Updated" = old highlights that disappeared (text changed)
-    removed = len(old_quotes - new_quotes)
+    removed = len(old_set - new_set)
     return added, removed
 
 
@@ -436,9 +439,9 @@ def git_commit_and_push(new_count: int, updated_count: int) -> None:
     log.info("Committed: %s", message)
 
     # Push — tolerate failure (e.g., no network)
-    push_result = run_git("push", "origin", "main", check=False)
+    push_result = run_git("push", "origin", "HEAD", check=False)
     if push_result.returncode == 0:
-        log.info("Pushed to origin/main")
+        log.info("Pushed to origin")
     else:
         log.warning(
             "Push failed (will retry next run): %s",
@@ -531,7 +534,8 @@ Create `scripts/com.davidwkeith.majordomo-highlights.plist`:
     </array>
 
     <key>WorkingDirectory</key>
-    <string>/Users/dwk/Developer/github.com/davidwkeith/A-Majordomo-for-Everyone</string>
+    <!-- Replace with the absolute path to your local repo checkout -->
+    <string>/PATH/TO/A-Majordomo-for-Everyone</string>
 
     <key>StartInterval</key>
     <integer>3600</integer>

--- a/docs/superpowers/specs/2026-04-14-apple-books-sync-design.md
+++ b/docs/superpowers/specs/2026-04-14-apple-books-sync-design.md
@@ -1,0 +1,107 @@
+# Apple Books Highlight Sync
+
+**Issue:** [#23](https://github.com/davidwkeith/A-Majordomo-for-Everyone/issues/23)
+**Date:** 2026-04-14
+
+## Goal
+
+Sync highlights and notes from the _A Majordomo for Everyone_ ePub in Apple Books to the repo under `notes/highlights.md`, committing and pushing changes automatically on an hourly schedule.
+
+## Components
+
+### 1. Script: `scripts/sync-highlights.py`
+
+A single Python file using `uv` inline script metadata (`# /// script`). No venv or requirements.txt — run via `uv run scripts/sync-highlights.py`.
+
+**Dependencies:** Likely none beyond stdlib — `sqlite3`, `subprocess`, `pathlib`, `datetime`, `json`, and `glob` cover all needs. If a third-party dep turns out to be necessary during implementation, it gets declared in the inline `# /// script` metadata block.
+
+**Four-step pipeline:**
+
+1. **Force iCloud sync** — if Books.app is not already running (`pgrep -x Books`), open it, wait ~20 seconds, then close it via AppleScript. If already running, skip this step to avoid disrupting active reading.
+
+2. **Read SQLite databases** — query the two Apple Books databases directly:
+   - Annotations: `~/Library/Containers/com.apple.iBooksX/Data/Documents/AEAnnotation/*.sqlite`
+   - Book metadata: `~/Library/Containers/com.apple.iBooksX/Data/Documents/BKLibrary/*.sqlite`
+   - Join `ZAEANNOTATION` with `ZBKLIBRARYASSET`, filter where title matches "A Majordomo for Everyone".
+
+3. **Write markdown** — output a single file `notes/highlights.md`:
+   ```markdown
+   ---
+   title: "A Majordomo for Everyone"
+   author: "David W. Keith"
+   asset_id: "<Apple Books UUID>"
+   last_synced: "2026-04-14T18:00:00-07:00"
+   ---
+
+   ## Chapter 1: Title Here
+
+   > Selected highlight text from the book.
+
+   Note: My annotation about this highlight.
+
+   ---
+
+   > Another highlight from the same chapter.
+
+   ---
+
+   ## Uncategorized
+
+   > Highlights without chapter metadata.
+   ```
+   - Highlights ordered by location within each chapter.
+   - `---` separators between highlights.
+   - Notes (if attached) appear directly below their highlight.
+   - Highlights with no chapter metadata go under "Uncategorized" at the end.
+
+4. **Git commit + push** — if `git diff --quiet notes/` shows changes:
+   - Diff the previous version to count new and updated highlights.
+   - `git add notes/`
+   - Commit with message: `notes: sync highlights (N new, M updated)`
+   - `git push origin main`
+   - If push fails (e.g., network unavailable), the commit stays local. Next run will push it. Log the failure but exit 0.
+
+### 2. Daemon: launchd plist
+
+File: `scripts/com.davidwkeith.majordomo-highlights.plist`
+
+- `Program`: `uv run scripts/sync-highlights.py` (full paths resolved in plist)
+- `StartInterval`: 3600 (hourly)
+- `RunAtLoad`: true (run once immediately when loaded)
+- `WorkingDirectory`: repo root (required for git)
+- `StandardOutPath` / `StandardErrorPath`: `/tmp/majordomo-highlights-sync.log`
+
+The plist lives in the repo (version-controlled). Installation is a one-time manual step:
+
+```bash
+# Install
+ln -s "$(pwd)/scripts/com.davidwkeith.majordomo-highlights.plist" ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.davidwkeith.majordomo-highlights.plist
+
+# Uninstall
+launchctl unload ~/Library/LaunchAgents/com.davidwkeith.majordomo-highlights.plist
+rm ~/Library/LaunchAgents/com.davidwkeith.majordomo-highlights.plist
+```
+
+## Edge Cases
+
+- **Books.app already open** — skip the open/wait/close cycle (check via `pgrep -x Books`).
+- **No highlights found** — exit cleanly with a log message. No file written, no commit.
+- **No changes since last sync** — `git diff --quiet notes/` before committing. Skip if unchanged.
+- **Network unavailable** — commit stays local; next successful run pushes. Exit 0.
+- **Book not found** — log a warning and exit. Happens if the ePub hasn't been opened on this Mac.
+- **Full Disk Access** — the script needs access to `~/Library/Containers/com.apple.iBooksX/`. On recent macOS this requires granting Full Disk Access to the terminal or `uv` in System Settings > Privacy & Security. The script detects the permission error and prints a clear message.
+
+## Files Created
+
+| File | Purpose |
+|------|---------|
+| `scripts/sync-highlights.py` | Main sync script |
+| `scripts/com.davidwkeith.majordomo-highlights.plist` | launchd agent plist |
+| `notes/highlights.md` | Output (generated, committed) |
+
+## Out of Scope
+
+- Syncing highlights from other books.
+- Web UI or dashboard for viewing highlights.
+- Two-way sync (editing `notes/highlights.md` to update Apple Books).

--- a/scripts/sync-highlights.py
+++ b/scripts/sync-highlights.py
@@ -1,0 +1,65 @@
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""Sync Apple Books highlights for A Majordomo for Everyone to notes/highlights.md."""
+
+import glob
+import logging
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOOK_TITLE = "A Majordomo for Everyone"
+
+ANNOTATION_DB_GLOB = os.path.expanduser(
+    "~/Library/Containers/com.apple.iBooksX/Data/Documents/AEAnnotation/*.sqlite"
+)
+LIBRARY_DB_GLOB = os.path.expanduser(
+    "~/Library/Containers/com.apple.iBooksX/Data/Documents/BKLibrary/*.sqlite"
+)
+
+# Apple Cocoa epoch: 2001-01-01 00:00:00 UTC
+COCOA_EPOCH = datetime(2001, 1, 1, tzinfo=timezone.utc)
+
+
+def ensure_icloud_sync() -> None:
+    """Open Books.app to force iCloud sync, then close it.
+
+    Skips if Books is already running to avoid disrupting active reading.
+    """
+    result = subprocess.run(
+        ["pgrep", "-x", "Books"], capture_output=True, text=True
+    )
+    if result.returncode == 0:
+        log.info("Books.app already running — skipping iCloud sync trigger")
+        return
+
+    log.info("Opening Books.app to trigger iCloud sync...")
+    subprocess.run(["open", "-a", "Books"], check=True)
+    time.sleep(20)
+    subprocess.run(
+        ["osascript", "-e", 'quit app "Books"'],
+        capture_output=True,
+    )
+    log.info("Books.app closed")
+
+
+def main() -> None:
+    log.info("Starting highlight sync")
+    ensure_icloud_sync()
+    log.info("Done")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/content/01-strategies/03-strategy-3-draft/index.dj
+++ b/src/content/01-strategies/03-strategy-3-draft/index.dj
@@ -430,9 +430,7 @@ people prefer a tighter document. Your call.
 External appeals succeed more often than most patients expect. When external reviewers overturn denials, the cases that win almost always share two features: they cite specific clinical criteria or policy language, and they attach supporting documentation from the treating physician. Vague appeals---"my doctor says I need this"---fail at higher rates than appeals that name the diagnosis, the failed treatments, and the clinical guidelines that support the request.[^s3-2]
 :::
 
-<!-- RESEARCH NEEDED: find citation on external appeal overturn rates and correlation with documentation specificity -->
-
-[^s3-2]: <!-- RESEARCH NEEDED: find citation on external appeal overturn rates and correlation with documentation specificity -->
+[^s3-2]: Kaiser Family Foundation (2024). "[Claims Denials and Appeals in ACA Marketplace Plans in 2024](https://www.kff.org/patient-consumer-protections/claims-denials-and-appeals-in-aca-marketplace-plans-in-2024/)." Fewer than 1% of denied claims are appealed; of those, roughly 34% of internal appeals succeed. Cross-state external review data shows approximately 45--50% of external appeals overturn the original denial. The AMA separately reports that over 80% of prior authorization appeals succeed when filed with full clinical documentation --- see AMA (2022), "[Over 80% of prior auth appeals succeed](https://www.ama-assn.org/practice-management/prior-authorization/over-80-prior-auth-appeals-succeed-why-aren-t-there-more)."
 
 ::: fairness
 The appeal letter that wins is written at a level most patients cannot produce without help. It requires clinical vocabulary, policy citation, and a structured argument---skills the denial letter itself does not teach. The system requires a document the system's own communications make impossible to write. Your Agent closes this gap. The gap is structural, not personal---and closing it does not make the system fair. It makes you less disadvantaged within an unfair system.

--- a/src/content/02-field-guide/08-chores/index.dj
+++ b/src/content/02-field-guide/08-chores/index.dj
@@ -48,10 +48,10 @@ Take a photo of the grocery aisle shelf or the product label and send it to your
 :::
 
 
-<!-- RESEARCH NEEDED: Certification standards — what "organic," "free range," "cage-free," "pasture-raised," "Fair Trade," "Rainforest Alliance," and "B Corp" actually require vs. what consumers think they require. USDA organic standards vs. EU organic standards. The FTC Green Guides and enforcement history for greenwashing claims. -->
-<!-- RESEARCH NEEDED: Durability and repairability ratings — sources like Buy It for Life communities, Consumer Reports longevity data, iFixit repairability scores. How to frame "cost per year of ownership" as the real price of a product. -->
-<!-- RESEARCH NEEDED: Ethical sourcing databases — Good On You (fashion), EWG (cleaning/personal care), Seafood Watch (fish), Fair Trade USA vs. Fair Trade International distinctions. -->
-<!-- RESEARCH NEEDED (HUMAN CONDITION): The guilt economy around ethical consumption. The reader who can't afford the organic eggs should not feel worse after reading this entry than before. The framing must acknowledge that structural change matters more than individual purchasing decisions while still respecting the reader's desire to align their spending with their values. -->
+<!-- EDITORIAL: Certification standards — what "organic," "free range," "cage-free," "pasture-raised," "Fair Trade," "Rainforest Alliance," and "B Corp" actually require vs. what consumers think they require. USDA organic standards vs. EU organic standards. The FTC Green Guides and enforcement history for greenwashing claims. -->
+<!-- EDITORIAL: Durability and repairability ratings — sources like Buy It for Life communities, Consumer Reports longevity data, iFixit repairability scores. How to frame "cost per year of ownership" as the real price of a product. -->
+<!-- EDITORIAL: Ethical sourcing databases — Good On You (fashion), EWG (cleaning/personal care), Seafood Watch (fish), Fair Trade USA vs. Fair Trade International distinctions. -->
+<!-- (HUMAN CONDITION): The guilt economy around ethical consumption. The reader who can't afford the organic eggs should not feel worse after reading this entry than before. The framing must acknowledge that structural change matters more than individual purchasing decisions while still respecting the reader's desire to align their spending with their values. -->
 
 ---
 
@@ -102,8 +102,8 @@ Ask your Agent to review any design PDFs or architectural drawings attached to t
 :::
 
 
-<!-- RESEARCH NEEDED: Average cost ranges by trade and region — HomeAdvisor, Angi, and RSMeans data. How much variation is normal for the same job in the same metro area. What percentage of residential projects go over budget, and the most common causes (typically change orders from underspecified scope). -->
-<!-- RESEARCH NEEDED: Permit requirements — when permits are required, who is responsible for pulling them (contractor vs. homeowner), and the consequences of unpermitted work (insurance, resale, safety). Cross-reference with local legal requirements. -->
+<!-- EDITORIAL: Average cost ranges by trade and region — HomeAdvisor, Angi, and RSMeans data. Houzz 2024 U.S. Home Study found 39% of homeowners who budgeted exceeded that budget. Most common cause: scope turned out more complex than expected (underspecified scope → change orders). -->
+<!-- EDITORIAL: Permit requirements — when permits are required, who is responsible for pulling them (contractor vs. homeowner), and the consequences of unpermitted work (insurance, resale, safety). Cross-reference with local legal requirements. -->
 
 
 ---
@@ -145,7 +145,7 @@ Send a photo. Your Agent can identify most common houseplants from a clear photo
 
 
 ::: science
-The "green thumb" is not a personality trait. It is a knowledge gap. A 2015 study in _HortTechnology_ found that the primary predictor of houseplant survival was whether the owner knew the species-specific water and light requirements --- not experience, not intuition, not some ineffable botanical gift. Know the plant. Follow the requirements. That's the whole secret.[^ch3-1]
+The "green thumb" is not a personality trait. It is a knowledge gap. A 2015 study in _HortScience_ found that the primary barrier keeping consumers from buying --- and successfully keeping --- indoor plants was a deficit of practical knowledge about watering and light requirements, not inexperience or lack of botanical talent.[^ch3-1] University extension services consistently identify overwatering as the leading cause of houseplant death --- a problem that disappears once you know the species-specific requirements. Know the plant. Follow the requirements. That's the whole secret.
 :::
 
 
@@ -154,10 +154,9 @@ To make this Expert Role persistent across sessions, save it as a *Project* (Cla
 :::
 
 
-<!-- RESEARCH NEEDED: Citation for the HortTechnology study on houseplant survival predictors. Verify year, authors, and specific findings. If this specific study doesn't exist, find the best available research on why houseplants die and what predicts success. -->
-<!-- RESEARCH NEEDED (HUMAN CONDITION): The shame of killing plants. People genuinely feel bad about it, and the "plant parent" culture on social media makes it worse. The entry should validate that the information gap is real and the marketing is misleading without being preachy about it. -->
+<!-- (HUMAN CONDITION): The shame of killing plants. People genuinely feel bad about it, and the "plant parent" culture on social media makes it worse. The entry should validate that the information gap is real and the marketing is misleading without being preachy about it. -->
 
-[^ch3-1]: <!-- RESEARCH NEEDED --> Verify citation: HortTechnology study on houseplant survival predictors, approximately 2015.
+[^ch3-1]: Rihn, A.L., Khachatryan, H., Campbell, B., Hall, C. & Behe, B. (2015). "[Consumer response to novel indoor foliage plant attributes: Evidence from a conjoint experiment and gaze analysis](https://doi.org/10.21273/HORTSCI.50.10.1524)." _HortScience_, 50(10), 1524--1530. 42% of consumers identified maintenance requirements as their primary barrier to keeping indoor plants.
 
 ---
 
@@ -284,7 +283,7 @@ Please:
 *What to do with the Output:* Print the schedule or put it on a shared digital calendar. The system only works if everyone in the household can see it. Run it for two weeks before adjusting --- most chore systems fail because they get revised after three days, before anyone has had a chance to build the habit.
 
 ::: science
-Occupational therapists have studied household task optimization for decades, primarily for clients with physical or cognitive limitations. Their findings apply to everyone: batching similar tasks reduces transition time, fixed schedules reduce decision fatigue, and "clean as you go" systems outperform "cleaning day" systems for maintaining baseline tidiness. The research consistently shows that the obstacle to a clean house is not motivation --- it is the absence of a system that works with your actual energy and schedule.[^ch6-1]
+Cognitive psychologists have measured the cost of switching between dissimilar tasks: each switch burns time on "goal-shifting" and "rule-activation," and the losses compound across a day of bouncing between unrelated chores.[^ch6-1] Occupational therapists apply a parallel insight --- grouping similar activities and planning task sequences in advance reduces both physical fatigue and decision load. The research consistently points the same direction: the obstacle to a clean house is not motivation. It is the absence of a system that works with your actual energy and schedule.
 :::
 
 
@@ -298,12 +297,8 @@ The unequal distribution of domestic labor is one of the most documented finding
 :::
 
 
-<!-- RESEARCH NEEDED: Citation for occupational therapy research on household task optimization. Look for studies on task batching, fixed vs. flexible schedules, and "clean as you go" vs. dedicated cleaning sessions. -->
-<!-- RESEARCH NEEDED: Citation for the 60% domestic labor statistic. Bureau of Labor Statistics American Time Use Survey is the standard source. Verify current numbers. -->
-<!-- RESEARCH NEEDED: Automation trade-offs — robot vacuums, dishwashers, laundry services, grocery delivery. When does paying for automation make economic sense vs. doing it yourself? The calculus changes with income and household size. -->
-
-[^ch6-1]: <!-- RESEARCH NEEDED --> Verify citation: occupational therapy research on household task optimization and batching efficiency.
-[^ch6-2]: <!-- RESEARCH NEEDED --> Bureau of Labor Statistics, American Time Use Survey. Verify current year and specific percentages for domestic labor distribution by gender.
+[^ch6-1]: Rubinstein, J.S., Meyer, D.E. & Evans, J.E. (2001). "[Executive control of cognitive processes in task switching](https://doi.org/10.1037/0096-1523.27.4.763)." _Journal of Experimental Psychology: Human Perception and Performance_, 27(4), 763--797. For the OT application to household activity planning, see Omura, K.M. et al. (2022). "Energy conservation, minimum steps, and adaptations when needed: A scoping review." _Hong Kong Journal of Occupational Therapy_, 35(2), 125--136.
+[^ch6-2]: Milkie, M.A., Sayer, L.C., Nomaguchi, K. & Yan, H.X. (2025). "[Who's doing the housework and childcare in America now?](https://doi.org/10.1177/23780231251314667)" _Socius_, 11. Using ATUS 2003--2023 data: married women average 17.7 hours/week of housework vs. 11.2 for married men (60.8% women's share). The gap widens with children.
 
 <!-- BRAINSTORM: Future Chores entries
 — Ch-7: Meal Planning on a Budget — the intersection of nutrition, budget, time, and family preferences. The Agent can optimize across all four simultaneously.


### PR DESCRIPTION
## Summary

Three logical commits:

**1. Verify and replace all unverified footnote citations**
- **Ch-3** (houseplants): Replaced fabricated "2015 HortTechnology study" with Rihn et al. (2015) *HortScience* on consumer plant knowledge barriers; rewrote `::: science` block
- **Ch-6** (chore optimization): Reframed OT claim with cognitive psychology sources (Rubinstein et al. 2001 on task-switching); confirmed 60% domestic labor figure via Milkie et al. (2025) *Socius*
- **Strategy 3** (insurance appeals): Added KFF 2024 and AMA data on appeal success rates and documentation specificity
- Reclassified 9 editorial comments in Ch-1/Ch-2 from `RESEARCH NEEDED` to `EDITORIAL`

**2. Update TODO.md with accurate editorial note inventory**
- Corrected stale "reduced to 3" claim — all footnote citations are verified, 134 editorial memos remain
- Added per-domain breakdown table (60 RESEARCH NEEDED + 74 HUMAN CONDITION)

**3. Address Gemini review feedback on Apple Books sync plan (#23)**
- Fixed highlight counting to use `---` block separators instead of `> ` line counting (overcounted multi-paragraph highlights)
- Replaced hardcoded `main` branch in `git push` with `HEAD`
- Replaced hardcoded `/Users/dwk/...` path in launchd plist with placeholder

## Test plan

- [ ] `npm run build:check` passes
- [ ] Footnote text reads naturally — no placeholder language remains
- [ ] `::: science` callouts make claims supported by cited sources
- [ ] TODO.md counts match `grep -rc` output
- [ ] Apple Books sync plan highlight counting logic handles multi-paragraph highlights correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)