### PR TITLE
Add Field Guide cross-references and Ch 31↔32 link

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -53,9 +53,9 @@ Last reviewed: 2026-04-15 against spec/ directory and codebase.
 
 Content that exists but could be stronger, more complete, or better connected.
 
-### Part 1: Missing Cross-References to Field Guide
+### ~~Part 1: Missing Cross-References to Field Guide~~
 
-Only Strategies 4 and 9 cross-reference Field Guide entries by ID. The other 8 strategy chapters should too — e.g., Strategy 8 (Assert) → H-4, L-1, W-2; Strategy 1 (Decode) → H-3, M-2, L-1.
+~~Only Strategies 4 and 9 cross-reference Field Guide entries by ID. The other 8 strategy chapters should too.~~ Done — all 10 strategy chapters now cross-reference 4–5 Field Guide entries by ID, placed between the strategy intro and the worked examples.
 
 ### Part 1: Conservative-Answer Convention
 
@@ -91,17 +91,17 @@ Priority expansions: Money, Legal, IRL.
 
 The architecture spec says Part 3 should teach "How to recognize a correct spec when Claude proposes one." No chapter covers this explicitly. Ch 30 teaches the Five-Part Frame but not the "when is it good enough?" judgment call.
 
-### Part 3: Ch 31 → Ch 32 Connection
+### ~~Part 3: Ch 31 → Ch 32 Connection~~
 
-Ch 31 (When to Use a Human) doesn't preview or reference the calibration question, which is the core of Ch 32. These should be linked.
+~~Ch 31 (When to Use a Human) doesn't preview or reference the calibration question, which is the core of Ch 32. These should be linked.~~ Done — Ch 31 already had a forward reference (final paragraph); added a back-reference from Ch 32's calibration question section to Ch 31's human-edge framework.
 
 ### Part 3: Ch 34 Art Brief
 
 Comment references Al Borland pixel art but no `.art.md` sidecar exists in the chapter directory.
 
-### Part 2: Jargon Links in Introduction
+### ~~Part 2: Jargon Links in Introduction~~
 
-"A Note Before You Start" introduces CPT code, EOB, and IRA without linking them on first mention. Spec requires Wikipedia links for all jargon.
+~~"A Note Before You Start" introduces CPT code, EOB, and IRA without linking them on first mention. Spec requires Wikipedia links for all jargon.~~ Already done — all three are linked on first mention (lines 14 and 16).
 
 ### Cross-Reference Self-Help Books Into Relevant Entries
 

--- a/src/content/01-strategies/00-strategy-0-specify/index.dj
+++ b/src/content/01-strategies/00-strategy-0-specify/index.dj
@@ -30,6 +30,8 @@ Every strategy in this book begins here. Before your Agent can Decode, Draft, Na
 
 The insight that makes this book work: *you do not have to write the spec.* Your Agent will interview you into one. Your job is to answer its questions honestly and tell it when the spec it proposes doesn't accurately reflect your situation. That is a human skill you already have. You know your own situation. You just needed someone to ask the right questions.
 
+_Every entry in the Field Guide begins with a Strategy 0 specification interview. Entries that use the Expert Role variant are marked in Appendix A --- including Ho-7 (Gardening), Ch-4 (Dog Training), Tr-2 (Car Maintenance), and H-8 (Wellness Coach)._
+
 ### The Specification Interview Loop
 
 Here is the full loop, annotated. This is what every `[SPEC]` sidebar in this book is showing you.

--- a/src/content/01-strategies/00-strategy-0-specify/index.dj
+++ b/src/content/01-strategies/00-strategy-0-specify/index.dj
@@ -30,7 +30,7 @@ Every strategy in this book begins here. Before your Agent can Decode, Draft, Na
 
 The insight that makes this book work: *you do not have to write the spec.* Your Agent will interview you into one. Your job is to answer its questions honestly and tell it when the spec it proposes doesn't accurately reflect your situation. That is a human skill you already have. You know your own situation. You just needed someone to ask the right questions.
 
-_Every entry in the Field Guide begins with a Strategy 0 specification interview. Entries that use the Expert Role variant are marked in Appendix A --- including Ho-7 (Gardening), Ch-4 (Dog Training), Tr-2 (Car Maintenance), and H-8 (Wellness Coach)._
+_In the Field Guide: every entry begins with a Strategy 0 specification interview. Entries using the Expert Role variant include Ho-7 (Gardening), Ch-4 (Dog Training), Tr-2 (Car Maintenance), and H-8 (Wellness Coach)._
 
 ### The Specification Interview Loop
 

--- a/src/content/01-strategies/01-strategy-1-decode/index.dj
+++ b/src/content/01-strategies/01-strategy-1-decode/index.dj
@@ -72,6 +72,8 @@ Legal boilerplate is written at a 16th-grade reading level on average — four g
 
 The hardest part of Decode is not the skill. It is the habit. The next time you receive a document from an institution — any document, any institution — paste it into your Agent before you do anything else. Before you sign. Before you pay. Before you panic. Before you throw it on the pile. Paste it. Ask what it says. That is the entire strategy.
 
+_In the Field Guide: H-3 (Medical Bills), L-1 (Contracts), C-1 (Ballot Measures), Ho-5 (Utility Bills), M-3 (Mortgages)._
+
 ### Example 1: An Insurance EOB After a Doctor's Visit
 
 The situation: you had blood work done at your annual physical. Three weeks later, an Explanation of Benefits arrives. It has procedure codes, columns labeled "amount billed," "plan discount," "plan paid," and "your responsibility." One number says $347. You don't know if you owe $347 or not. The document is designed to explain your benefits. It does not explain your benefits.

--- a/src/content/01-strategies/02-strategy-2-prepare/index.dj
+++ b/src/content/01-strategies/02-strategy-2-prepare/index.dj
@@ -48,6 +48,8 @@ Patients who arrive at medical appointments with written questions report higher
 
 Preparation does not require expertise. It requires ten minutes and a list. The doctor, the HR director, and the contractor all expect you to show up without one. The list is what changes the power dynamic in the room. Every example in this chapter follows the same pattern: tell your Agent what's coming, answer its clarifying questions, and walk in with a list on your phone. That is the entire strategy.
 
+_In the Field Guide: H-2 (Doctor's Appointments), Li-1 (Difficult Conversations), IRL-1 (Government Offices), IRL-2 (Customer Service), Tr-4 (Air Travel)._
+
 ::: tip
 For high-stakes appointments — medical, legal, financial — end your preparation spec with: "Give me the most conservative framing. I will verify everything with the professional." This ensures the question list helps you ask, not conclude.
 :::

--- a/src/content/01-strategies/03-strategy-3-draft/index.dj
+++ b/src/content/01-strategies/03-strategy-3-draft/index.dj
@@ -46,6 +46,8 @@ Bluma Zeigarnik's 1927 research established that the brain actively maintains in
 
 [^s3-1]: Zeigarnik, B. (1927). "Über das Behalten von erledigten und unerledigten Handlungen." _Psychologische Forschung_, 9, 1-85. Masicampo, E.J. & Baumeister, R.F. (2011). "Consider it done! Plan making can eliminate the cognitive effects of unfulfilled goals." _JPSP_, 101(4), 667-683.
 
+_In the Field Guide: H-4 (Insurance Appeals), Li-2 (Eulogies), C-2 (Public Comments), L-3 (Demand Letters), W-1 (Job Search)._
+
 *Worked examples:* A demand letter to a landlord. A Medicare denial appeal. A public comment for a city council meeting.
 
 ### Example 1: The Landlord Counteroffer

--- a/src/content/01-strategies/04-strategy-4-navigate/index.dj
+++ b/src/content/01-strategies/04-strategy-4-navigate/index.dj
@@ -43,7 +43,7 @@ including any deadlines or time-sensitive elements I should know about.
 :::
 
 
-_In the Field Guide: H-4 (Insurance Appeals), L-2 (Small Claims Court), Ho-6 (Getting a Home), IRL-1 (Government Offices), C-5 (Jury Duty)._
+_In the Field Guide: W-2 (If You're Let Go), H-4 (Insurance Appeals), L-2 (Small Claims Court), Ho-6 (Getting a Home), IRL-1 (Government Offices)._
 
 ### Example 1: Filing for Unemployment Benefits
 

--- a/src/content/01-strategies/04-strategy-4-navigate/index.dj
+++ b/src/content/01-strategies/04-strategy-4-navigate/index.dj
@@ -43,6 +43,8 @@ including any deadlines or time-sensitive elements I should know about.
 :::
 
 
+_In the Field Guide: H-4 (Insurance Appeals), L-2 (Small Claims Court), Ho-6 (Getting a Home), IRL-1 (Government Offices), C-5 (Jury Duty)._
+
 ### Example 1: Filing for Unemployment Benefits
 
 The situation: you were let go last Friday. An email from the CEO said "position eliminated, replaced by AI." You have never filed for unemployment. You don't know if you qualify, where to start, or what the deadlines are.

--- a/src/content/01-strategies/05-strategy-5-decide/index.dj
+++ b/src/content/01-strategies/05-strategy-5-decide/index.dj
@@ -49,6 +49,8 @@ Decision fatigue — the degradation of decision quality after a sustained perio
 
 [^s5-1]: Baumeister, R.F. et al. (1998). "Ego depletion: Is the active self a limited resource?" _JPSP_, 74(5), 1252-1265. Danziger, S. et al. (2011). "Extraneous factors in judicial decisions." _PNAS_, 108(17), 6889-6892.
 
+_In the Field Guide: M-5 (Retirement), M-1 (Banking), Li-9 (Household Budget), Ch-1 (Shopping Your Values), Tr-1 (Car Ownership)._
+
 ### Example 1: Repair or Replace a Washing Machine
 
 The situation: your washing machine stopped draining mid-cycle. It's 8 years old — a basic top-loader you bought at a big-box store. A repair tech came out, diagnosed a failed drain pump, and quoted $380 for parts and labor. A new comparable machine is $650. You're not sure which option is smarter.

--- a/src/content/01-strategies/06-strategy-6-diagnose/index.dj
+++ b/src/content/01-strategies/06-strategy-6-diagnose/index.dj
@@ -45,6 +45,8 @@ I actually need a professional or can handle this myself.
 :::
 
 
+_In the Field Guide: Ho-1 (Home Maintenance), Ho-2 (Home Repair), Tr-2 (Car Maintenance), Ch-3 (House Plants), Ch-6 (Optimizing Chores)._
+
 ### Example 1: A Washing Machine Making a Grinding Noise
 
 The situation: your washing machine started making a loud grinding noise during the spin cycle two days ago. It still runs. You don't know if it's about to die, if you can fix it, or if you need to call someone. A repair visit starts at $150.

--- a/src/content/01-strategies/07-strategy-7-research/index.dj
+++ b/src/content/01-strategies/07-strategy-7-research/index.dj
@@ -55,7 +55,7 @@ Research on [health literacy](https://en.wikipedia.org/wiki/Health%5Fliteracy) c
 :::
 
 
-_In the Field Guide: H-5 (Chronic Conditions), M-5 (Retirement), Li-3 (Scams), C-7 (Your Rights Where You Live), Tr-3 (Public Transit)._
+_In the Field Guide: H-5 (Chronic Conditions), L-1 (Contracts), M-5 (Retirement), Li-3 (Scams), C-7 (Your Rights Where You Live)._
 
 *Worked examples:* Before a knee arthroscopy. Before signing a non-compete clause. Between two college financial aid offers.
 

--- a/src/content/01-strategies/07-strategy-7-research/index.dj
+++ b/src/content/01-strategies/07-strategy-7-research/index.dj
@@ -55,6 +55,8 @@ Research on [health literacy](https://en.wikipedia.org/wiki/Health%5Fliteracy) c
 :::
 
 
+_In the Field Guide: H-5 (Chronic Conditions), M-5 (Retirement), Li-3 (Scams), C-7 (Your Rights Where You Live), Tr-3 (Public Transit)._
+
 *Worked examples:* Before a knee arthroscopy. Before signing a non-compete clause. Between two college financial aid offers.
 
 ### Example 1: Before a Knee Arthroscopy

--- a/src/content/01-strategies/08-strategy-8-assert/index.dj
+++ b/src/content/01-strategies/08-strategy-8-assert/index.dj
@@ -55,6 +55,8 @@ When asking about legal rights, always follow up with: _"Is this answer the same
 
 [^s8-1]: Herd, P. & Moynihan, D.P. (2018). _Administrative Burden: Policymaking by Other Means._ Russell Sage Foundation.
 
+_In the Field Guide: Ho-4 (Renter Rights), W-2 (If You're Let Go), M-4 (Collections), C-3 (Police Encounters), H-15 (Drug Laws)._
+
 *Worked examples:* Tenant rights when a landlord refuses repairs. Employee rights when let go without a clear reason. Consumer rights when disputing a charge.
 
 _(Full worked examples with [SPEC] loops to be drafted)_

--- a/src/content/01-strategies/09-strategy-9-create/index.dj
+++ b/src/content/01-strategies/09-strategy-9-create/index.dj
@@ -38,6 +38,8 @@ The failure mode — "I asked it to write me a story and it was generic" — hap
 
 This strategy is about keeping both jobs clearly assigned.
 
+_In the Field Guide: Cr-4 (Writing a Book), Cr-2 (Visual Design), Cr-3 (Editing a Movie), WB-5 (Building a Website), WB-8 (Blogging)._
+
 ---
 
 ### The Architecture: Deterministic and Dynamic

--- a/src/content/03-general-method/02-chapter-32-consistent-answers/index.dj
+++ b/src/content/03-general-method/02-chapter-32-consistent-answers/index.dj
@@ -119,7 +119,7 @@ How confident are you in this answer, and what are the two
 or three things I should independently verify before acting on it?
 :::
 
-This single question will consistently improve the quality of the guidance you receive. Claude will tell you where its answer is reliable and where it is extrapolating. That boundary is exactly where you should apply your own judgment -- or pick up the phone and call a professional.
+This single question will consistently improve the quality of the guidance you receive. Claude will tell you where its answer is reliable and where it is extrapolating. That boundary is exactly where you should apply your own judgment -- or pick up the phone and call a professional. It is the same line Chapter 31 draws from the other direction: where AI's edge ends and the human's begins.
 
 ::: science
 Research on _algorithm aversion_ -- the human tendency to distrust algorithmic recommendations even when they are demonstrably more accurate -- shows that people accept algorithmic guidance more readily when they can see the reasoning behind it (Dietvorst et al., 2018). Asking Claude to show its work is not just practically useful. It also addresses the well-documented psychological resistance to following advice from a source you cannot fully understand.[^32-1]


### PR DESCRIPTION
## Summary

- **Field Guide cross-references in all 10 strategy chapters**: Each strategy now lists 4–5 relevant Field Guide entries by ID, placed between the strategy intro and the worked examples. Entries were selected to complement the chapter's examples and cover the strategy's key domains.
- **Ch 31 ↔ Ch 32 bidirectional link**: Ch 31 already had a forward reference to Ch 32's calibration question. Added a back-reference from Ch 32 to Ch 31's human-edge framework ("where AI's edge ends and the human's begins").
- **TODO cleanup**: Marked three items as done — cross-references, Ch 31→32 connection, and jargon links (which were already present in "A Note Before You Start").

## Test plan

- [x] `npm run build:check` passes
- [x] `npm test` passes (20/20)
- [ ] Verify cross-reference entry IDs match Appendix A
- [ ] Read through each strategy chapter to confirm placement feels natural

🤖 Generated with [Claude Code](https://claude.com/claude-code)