### PR TITLE
Fix Appendix A: add 43 missing field guide entries

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,34 +4,9 @@ Last reviewed: 2026-04-15 against spec/ directory and codebase.
 
 ---
 
-## Completed Since Last Review (2026-04-08)
-
-- [x] Strategy worked examples — all 10 strategies (0–9) now have 2–3 full spec-loop examples
-- [x] Jeeves voice rewrite — all Field Guide entries rewritten with "My Man Jeeves" openers, fact-checked with citations
-- [x] Field Guide reorganization — WB entries renumbered sequentially (WB-1 through WB-9), Creative domain added (Cr-1 through Cr-4)
-- [x] Field Guide entry labels standardized to Title Case
-- [x] Former stubs drafted: Ho-5, Ho-7, Ch-1, Ch-2, Ch-3, Ch-6 all have substantive content
-- [x] All footnote citations verified — 5 previously unverified `[^...]` footnotes now have real sources
-- [x] `[companion URL TBD]` markers resolved (none remaining)
-- [x] WB-* entry numbering rationalized (was non-sequential, now WB-1 through WB-9)
-- [x] New appendices added: Appendix I (Spec Literacy), Appendix J (Working with Text)
-- [x] Apple Books highlight sync — design spec, implementation plan, and script skeleton (#23)
-- [x] Build pipeline type-checks clean (`npm run build:check` passes)
-- [x] Ch 33 drafted (Advanced Free Tier Strategies)
-- [x] [ALSO] callouts added to all 10 strategy chapters
-- [x] Conservative-answer convention added to Strategy 7
-
----
-
 ## Unwritten Content
 
-### ~~Chapter 33: Advanced Free Tier Strategies (Part 3)~~
-
-- [x] ~~**Write Ch 33**~~ — drafted. Covers context as currency, conversation lifecycle, spec recycling, multi-service workflows (decode-and-draft, second-opinion), household majordomo context, and compound return of specification literacy. Extends Ch 3 for Part 3 readers.
-
 ### New Field Guide Entries
-
-- [ ] **Ho-?: Household Disaster Planning**
 
 - [ ] **Li-? or IRL-?: Roleplay in Practice — Everyday Scenarios**
   - Focus: real people, daily situations — customer service, restaurants, retail, phone calls, complaints
@@ -48,63 +23,13 @@ Last reviewed: 2026-04-15 against spec/ directory and codebase.
 
 ### Appendix B: Spec Interview Starters
 
-- [ ] **Complete Appendix B** — 8 of ~50 starters written. 42 more needed, organized by Field Guide domain. Must be print-ready at 8.5×11.
+- [ ] **Top off Appendix B** — 47 of ~50 starters written. 3 more needed.
 
 ---
 
 ## Needs Revisiting
 
 Content that exists but could be stronger, more complete, or better connected.
-
-### ~~Part 1: Missing Cross-References to Field Guide~~
-
-~~Only Strategies 4 and 9 cross-reference Field Guide entries by ID. The other 8 strategy chapters should too.~~ Done — all 10 strategy chapters now cross-reference 4–5 Field Guide entries by ID, placed between the strategy intro and the worked examples.
-
-### ~~Part 1: Conservative-Answer Convention~~
-
-~~Present in Strategy 7 and Strategy 8 but missing from Strategy 2 (Prepare, medical context) where the spec expects it.~~ Done — added conservative-answer language to Strategy 2's oncology example opening prompt.
-
-### ~~Part 1: [ALSO] Callout Coverage~~
-
-~~Only Strategy 0 has an [ALSO] callout. Other strategies reference Claude-specific features without cross-tool translation.~~ Done — all 10 strategy chapters now have [ALSO] callouts.
-
-### ~~Part 2: Domain Size Imbalance~~
-
-Entry target was ~80; current total is *91* across 12 domains. The target is exceeded overall, but distribution is uneven:
-
-| Domain | Count | Notes |
-|--------|-------|-------|
-| Health (H-) | 19 | Strong |
-| Life (Li-) | 12 | Strong |
-| Computer & Web (WB-) | 9 | Strong |
-| Civic (C-) | 7 | Solid |
-| Home (Ho-) | 7 | Solid |
-| Work (W-) | 7 | Solid |
-| Money (M-) | 6 | Light — financial complexity warrants 8–10 |
-| Chores (Ch-) | 6 | Solid |
-| Creative (Cr-) | 4 | New domain — assess if complete |
-| Legal (L-) | 4 | Light — expand to 6–8 |
-| Transportation (Tr-) | 4 | Light |
-| IRL (IRL-) | 3 | Light — expand to 5+ |
-| **Total** | **88** | **110% of original target** |
-
-Priority expansions: Money, Legal, IRL.
-
-### ~~Part 3: "Recognizing a Correct Spec"~~
-
-~~The architecture spec says Part 3 should teach "How to recognize a correct spec when Claude proposes one." No chapter covers this explicitly.~~ Done — added "Recognizing when the spec is right" section to Ch 32, between the echo-back failure modes and "When to start a new conversation." Covers four positive indicators (own words, names specifics, admits unknowns, explainable plan) as complement to the three failure modes.
-
-### ~~Part 3: Ch 31 → Ch 32 Connection~~
-
-~~Ch 31 (When to Use a Human) doesn't preview or reference the calibration question, which is the core of Ch 32. These should be linked.~~ Done — Ch 31 already had a forward reference (final paragraph); added a back-reference from Ch 32's calibration question section to Ch 31's human-edge framework.
-
-### Part 3: Ch 34 Art Brief
-
-Comment references Al Borland pixel art but no `.art.md` sidecar exists in the chapter directory.
-
-### ~~Part 2: Jargon Links in Introduction~~
-
-~~"A Note Before You Start" introduces CPT code, EOB, and IRA without linking them on first mention. Spec requires Wikipedia links for all jargon.~~ Already done — all three are linked on first mention (lines 14 and 16).
 
 ### Cross-Reference Self-Help Books Into Relevant Entries
 
@@ -120,11 +45,9 @@ Place as `See also:` or footnote citations where they fit:
 
 ---
 
-## ~~Research & Editorial Notes~~
+## Editorial Notes
 
-*Footnote citations* — all resolved. Every `[^...]` footnote in the book now has a real, verified source.
-
-*Editorial research notes* — 60 `<!-- RESEARCH NEEDED: ... -->` and 74 `<!-- HUMAN CONDITION ... -->` comments remain across Part 2. These are author memos: background research directions, sociological context, and expansion ideas. They do not appear in the built ePub and do not correspond to unverified claims in the text. They should be reviewed before publication to decide what gets surfaced, expanded, or removed.
+60 `<!-- RESEARCH NEEDED: ... -->` and 74 `<!-- HUMAN CONDITION ... -->` comments remain across Part 2. These are author memos: background research directions, sociological context, and expansion ideas. They do not appear in the built ePub and do not correspond to unverified claims in the text. They should be reviewed before publication to decide what gets surfaced, expanded, or removed.
 
 | Domain | RESEARCH NEEDED | HUMAN CONDITION | Total |
 |--------|-----------------|-----------------|-------|
@@ -141,20 +64,13 @@ Place as `See also:` or footnote citations where they fit:
 | Chores | 0 | 2 | 2 |
 | **Total** | **60** | **74** | **134** |
 
-Parts 0, 1, 3, and 4 have zero research comments — clean. Strategy 3 had two (insurance appeal citation) — now resolved.
-
 ---
 
 ## Pre-Publication Checklist
 
-- [x] All `[companion URL TBD]` resolved
-- [x] All footnote citations verified (previously 5 unverified `[^...]` footnotes)
-- [x] All stubs drafted
-- [x] Ch 33 written
-- [x] Appendix B complete (50 starters across 12 domains)
-- [ ] Appendix A reflects final entry list (88 entries across 12 domains)
+- [ ] Appendix B topped off (47/50 starters)
 - [ ] Editorial notes reviewed — 134 `RESEARCH NEEDED` + `HUMAN CONDITION` comments to surface or remove
-- [ ] All art briefs have corresponding images in `src/images/`
+- [ ] All art briefs have corresponding images in `src/images/` (17 of 44 missing)
 - [ ] XMP metadata embedded in all images
 - [ ] Version bumped and tagged
 - [ ] `npm run build` produces clean ePub
@@ -164,6 +80,5 @@ Parts 0, 1, 3, and 4 have zero research comments — clean. Strategy 3 had two (
 
 ## Pending
 
-- [ ] Assign entry IDs for new entries (Ho-?, Li/IRL-?) once domain slots confirmed
-- [ ] Cross-reference new entries against existing Field Guide index in Appendix A
 - [ ] Author to upload full roleplay entry draft
+- [ ] Assign entry ID for roleplay entry once domain slot confirmed

--- a/src/content/04-appendices/00-appendix-a-quick-reference/index.dj
+++ b/src/content/04-appendices/00-appendix-a-quick-reference/index.dj
@@ -52,6 +52,10 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | M-4: Collections and Bankruptcy | Assert + Decode | "I am dealing with [debt in collections / considering bankruptcy]..." |
 | M-5: Retirement and Investing | Research + Decide | "I want to understand and improve my retirement situation..." |
 | M-6: Financial Coach | Decide + Research (Expert Role) | "Act as a fee-only financial coach with no products to sell..." |
+| M-7: Understanding Your Taxes | Decode + Prepare | "I want to understand my tax situation better and make sure I'm not overpaying or missing anything." |
+| M-8: Insurance You Actually Need | Research + Decide | "I want to make sure I have the right insurance and am not overpaying or underinsured." |
+| M-9: Navigating Financial Aid and Student Loans | Navigate + Assert | "I need help understanding and managing my student loans." |
+| M-10: Evaluating a Big Purchase | Research + Decide | "I'm considering a major purchase and I want to make sure I'm thinking about it clearly." |
 
 ---
 
@@ -60,9 +64,15 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | Entry | Strategy | Spec opener |
 |---|---|---|
 | L-1: Negotiating a Contract | Decode + Assert | "I am about to sign this contract. [Paste the contract...]" |
-| L-2: Small Claims Court | Navigate + Prepare + Draft | _(being drafted)_ |
-| L-3: Writing a Demand Letter | Draft | _(stub -- see full entry)_ |
-| L-4: Navigating a Traffic Ticket | Navigate + Research | _(stub -- see full entry)_ |
+| L-2: Small Claims Court | Navigate + Prepare + Draft | "I want to file a small claims court case..." |
+| L-3: Writing a Demand Letter | Draft | "I need to write a demand letter..." |
+| L-4: Navigating a Traffic Ticket | Navigate + Research | "I got a traffic ticket..." |
+| L-5: Understanding Your Rights as a Tenant | Decode + Assert | "I am a tenant and I need to understand my rights..." |
+| L-6: Navigating Family Court | Navigate + Prepare | "I need to navigate family court..." |
+| L-7: Dealing with Debt Collectors | Assert + Decode | "A debt collector has contacted me..." |
+| L-8: Power of Attorney and Advance Directives | Draft + Prepare | "I need to create advance planning documents..." |
+| L-10: Navigating a Background Check | Decode + Assert | "I need to understand and prepare for a background check..." |
+| L-11: Filing a Consumer Complaint | Assert + Navigate | "I need to file a consumer complaint against a company..." |
 
 ---
 
@@ -77,6 +87,9 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | Ho-5: Understanding Your Utility Bill and Energy Options | Decode + Research | "I want to understand my utility bill and find out if there are programs..." |
 | Ho-6: Getting a Home | Navigate + Research | "I need to find a place to live..." |
 | Ho-7: Gardening & Landscaping | Diagnose + Research (Expert Role) | "Act as an experienced Master Gardener..." |
+| Ho-8: Household Disaster Preparedness | Prepare + Research | "I want to create a household emergency preparedness plan." |
+| Ho-9: Decluttering and Organizing | Diagnose + Navigate | "I need help organizing and decluttering my [room / apartment / house / specific area]..." |
+| Ho-10: Home Security and Safety | Research + Decide | "I want to make my home safer and more secure." |
 
 ---
 
@@ -110,6 +123,10 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | W-5: Unions | Navigate + Assert | "I want to understand [my rights regarding unionizing]..." |
 | W-6: OSHA and Worker's Comp | Assert + Navigate | "I have a workplace safety concern [or: I was injured at work]..." |
 | W-7: Using Your Agent to Get More Done | Navigate + Draft (Expert Role) | "I want to use my AI Agent to work more efficiently..." |
+| W-8: Freelancing and Self-Employment | Navigate + Prepare | "I am [freelancing / self-employed / considering going independent] in [field or industry]." |
+| W-9: Navigating a Performance Review | Prepare + Assert | "I have a performance review coming up [or: I just received a performance review I want to respond to]." |
+| W-10: Dealing with Workplace Conflict | Prepare + Navigate | "I am dealing with a workplace conflict that I need to handle myself — it is not an HR-level issue (yet)." |
+| W-11: Understanding Your Benefits | Decode + Decide | "I need to understand my workplace benefits and make decisions about them." |
 
 ---
 
@@ -124,6 +141,7 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | C-5: Understanding Jury Duty | Decode + Navigate | "I [received a jury duty summons / am currently serving on a jury]..." |
 | C-6: Knowing Your Voter Rights | Assert + Research | "I want to make sure I can vote and that my vote counts..." |
 | C-7: Understanding Your Rights Where You Live | Research + Assert | "I want to understand what rights and protections I actually have where I live..." |
+| C-8: Participating in AI Policy | Research + Draft + Navigate | "I want to participate in AI policy decisions that affect me." |
 
 ---
 
@@ -137,6 +155,11 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | Ch-4: Dog Training | Diagnose + Navigate (Expert Role) | "Act as a certified positive-reinforcement dog trainer..." |
 | Ch-5: Cooking and Culinary Skills | Research + Diagnose (Expert Role) | "Act as a culinary instructor..." |
 | Ch-6: Optimizing Manual Chores | Diagnose + Navigate (Expert Role) | "Act as a household operations consultant..." |
+| Ch-7: Meal Planning and Grocery Shopping | Research + Prepare | "I need to plan meals for the week and build a grocery list." |
+| Ch-8: Cleaning and Laundry | Research + Navigate (Expert Role) | "Act as a textile care and cleaning specialist." |
+| Ch-9: Pet Care and Training | Research + Navigate (Expert Role) | "Act as a veterinary-informed pet care advisor." |
+| Ch-10: Seasonal Maintenance | Prepare + Navigate | "I need a seasonal home maintenance checklist." |
+| Ch-11: Managing Subscriptions and Recurring Costs | Decode + Assert | "I need to audit my subscriptions and recurring charges." |
 
 ---
 
@@ -147,6 +170,13 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | IRL-1: Navigating Government Offices | Prepare + Navigate | "I need to go to [DMV / Social Security office / county clerk]..." |
 | IRL-2: Getting Help from Customer Service | Prepare + Assert | "I need to resolve a problem with [company] about [issue]..." |
 | IRL-3: First-Time Situations | Prepare + Research | "I am about to [go to / do / attend] [specific situation] for the first time..." |
+| IRL-4: Negotiating a Price | Prepare + Assert | "I need to negotiate a price for [car / furniture / medical bill / rent renewal / contractor work / other]." |
+| IRL-6: Navigating a Hospital Visit | Prepare + Navigate | "I [am going to the hospital / am accompanying someone] for [scheduled surgery / ER visit / labor and delivery / procedure]..." |
+| IRL-7: Talking to a Mechanic | Prepare + Decode | "I need to take my car to a mechanic and I want to be prepared." |
+| IRL-8: Navigating a Parent-Teacher Conference | Prepare + Assert | "I have a parent-teacher conference coming up for my [age/grade] child." |
+| IRL-9: Handling a Car Accident | Prepare + Navigate | "I was just in a car accident. [Or: I want to be prepared in case I'm in one.]" |
+| IRL-10: Attending a Funeral or Memorial | Prepare + Navigate | "I am attending a funeral or memorial service and I want to be prepared." |
+| IRL-11: Job Interviews In Person | Prepare + Assert | "I have an in-person job interview coming up and I want to be fully prepared." |
 
 ---
 
@@ -174,6 +204,13 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | Cr-2: Learning Visual Design | Create + Research (Expert Role) | "Act as an expert visual designer. I need help with [a website / a poster / a flyer]..." |
 | Cr-3: Editing a Movie | Create + Navigate | "I want to edit a video..." |
 | Cr-4: Writing a Book (Like This One) | Create + Draft | "I want to write a book about [topic / story / argument]..." |
+| Cr-5: Making Music | Create + Navigate | "I want to make music." |
+| Cr-6: Podcasting and Audio Production | Create + Navigate | "I want to start a podcast." |
+| Cr-7: Drawing and Illustration | Create + Diagnose | "I want to learn to draw." |
+| Cr-8: Crafts and Maker Projects | Create + Research | "I want to make something." |
+| Cr-9: Creative Writing | Create + Draft | "I want to write [a short story / a poem / a personal essay / flash fiction / a screenplay scene]..." |
+| Cr-10: Graphic Design for Real Life | Create + Draft | "I need to design [a flyer / a poster / an invitation / a social media graphic / a resume / a business card]..." |
+| Cr-11: Learning an Instrument | Create + Research (Expert Role) | "I want to learn [guitar / piano / ukulele / bass / drums / violin / harmonica / banjo / another instrument]." |
 
 ---
 
@@ -185,3 +222,9 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | Tr-2: Car Maintenance | Diagnose + Research (Expert Role) | "Act as an experienced mechanic and car maintenance advisor..." |
 | Tr-3: Public Transit, Cycling, and Walkability | Research + Navigate | "I want to [reduce my car dependence / go car-free]..." |
 | Tr-4: Air Travel | Prepare + Assert | "I need help with air travel..." |
+| Tr-5: Road Trips and Long-Distance Driving | Prepare + Navigate | "I'm planning a road trip and want to be prepared." |
+| Tr-7: Understanding Rideshare and Delivery Gig Work | Research + Decode | "I want to understand rideshare and delivery gig work." |
+| Tr-8: Navigating International Travel | Prepare + Navigate | "I'm planning international travel and need help preparing." |
+| Tr-9: Accessible Transportation | Assert + Navigate | "I need help with accessible transportation." |
+| Tr-10: Electric Vehicles and the Transition | Research + Decide | "I'm considering an electric vehicle and want the real picture." |
+| Tr-11: Boating, RVs, and Niche Vehicles | Research + Navigate | "I'm looking into [buying / renting / maintaining] a [boat / RV / motorcycle / ATV / other specialty vehicle]." |

--- a/src/content/04-appendices/00-appendix-a-quick-reference/index.dj
+++ b/src/content/04-appendices/00-appendix-a-quick-reference/index.dj
@@ -52,10 +52,10 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | M-4: Collections and Bankruptcy | Assert + Decode | "I am dealing with [debt in collections / considering bankruptcy]..." |
 | M-5: Retirement and Investing | Research + Decide | "I want to understand and improve my retirement situation..." |
 | M-6: Financial Coach | Decide + Research (Expert Role) | "Act as a fee-only financial coach with no products to sell..." |
-| M-7: Understanding Your Taxes | Decode + Prepare | "I want to understand my tax situation better and make sure I'm not overpaying or missing anything." |
-| M-8: Insurance You Actually Need | Research + Decide | "I want to make sure I have the right insurance and am not overpaying or underinsured." |
-| M-9: Navigating Financial Aid and Student Loans | Navigate + Assert | "I need help understanding and managing my student loans." |
-| M-10: Evaluating a Big Purchase | Research + Decide | "I'm considering a major purchase and I want to make sure I'm thinking about it clearly." |
+| M-7: Understanding Your Taxes | Decode + Prepare | "I want to understand my tax situation better and make sure I'm not overpaying or missing anything..." |
+| M-8: Insurance You Actually Need | Research + Decide | "I want to make sure I have the right insurance and am not overpaying or underinsured..." |
+| M-9: Navigating Financial Aid and Student Loans | Navigate + Assert | "I need help understanding and managing my student loans..." |
+| M-10: Evaluating a Big Purchase | Research + Decide | "I'm considering a major purchase and I want to make sure I'm thinking about it clearly..." |
 
 ---
 
@@ -87,9 +87,9 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | Ho-5: Understanding Your Utility Bill and Energy Options | Decode + Research | "I want to understand my utility bill and find out if there are programs..." |
 | Ho-6: Getting a Home | Navigate + Research | "I need to find a place to live..." |
 | Ho-7: Gardening & Landscaping | Diagnose + Research (Expert Role) | "Act as an experienced Master Gardener..." |
-| Ho-8: Household Disaster Preparedness | Prepare + Research | "I want to create a household emergency preparedness plan." |
+| Ho-8: Household Disaster Preparedness | Prepare + Research | "I want to create a household emergency preparedness plan..." |
 | Ho-9: Decluttering and Organizing | Diagnose + Navigate | "I need help organizing and decluttering my [room / apartment / house / specific area]..." |
-| Ho-10: Home Security and Safety | Research + Decide | "I want to make my home safer and more secure." |
+| Ho-10: Home Security and Safety | Research + Decide | "I want to make my home safer and more secure..." |
 
 ---
 
@@ -123,10 +123,10 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | W-5: Unions | Navigate + Assert | "I want to understand [my rights regarding unionizing]..." |
 | W-6: OSHA and Worker's Comp | Assert + Navigate | "I have a workplace safety concern [or: I was injured at work]..." |
 | W-7: Using Your Agent to Get More Done | Navigate + Draft (Expert Role) | "I want to use my AI Agent to work more efficiently..." |
-| W-8: Freelancing and Self-Employment | Navigate + Prepare | "I am [freelancing / self-employed / considering going independent] in [field or industry]." |
-| W-9: Navigating a Performance Review | Prepare + Assert | "I have a performance review coming up [or: I just received a performance review I want to respond to]." |
-| W-10: Dealing with Workplace Conflict | Prepare + Navigate | "I am dealing with a workplace conflict that I need to handle myself — it is not an HR-level issue (yet)." |
-| W-11: Understanding Your Benefits | Decode + Decide | "I need to understand my workplace benefits and make decisions about them." |
+| W-8: Freelancing and Self-Employment | Navigate + Prepare | "I am [freelancing / self-employed / considering going independent] in [field or industry]..." |
+| W-9: Navigating a Performance Review | Prepare + Assert | "I have a performance review coming up [or: I just received a performance review I want to respond to]..." |
+| W-10: Dealing with Workplace Conflict | Prepare + Navigate | "I am dealing with a workplace conflict that I need to handle myself — it is not an HR-level issue (yet)..." |
+| W-11: Understanding Your Benefits | Decode + Decide | "I need to understand my workplace benefits and make decisions about them..." |
 
 ---
 
@@ -141,7 +141,7 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | C-5: Understanding Jury Duty | Decode + Navigate | "I [received a jury duty summons / am currently serving on a jury]..." |
 | C-6: Knowing Your Voter Rights | Assert + Research | "I want to make sure I can vote and that my vote counts..." |
 | C-7: Understanding Your Rights Where You Live | Research + Assert | "I want to understand what rights and protections I actually have where I live..." |
-| C-8: Participating in AI Policy | Research + Draft + Navigate | "I want to participate in AI policy decisions that affect me." |
+| C-8: Participating in AI Policy | Research + Draft + Navigate | "I want to participate in AI policy decisions that affect me..." |
 
 ---
 
@@ -155,11 +155,11 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | Ch-4: Dog Training | Diagnose + Navigate (Expert Role) | "Act as a certified positive-reinforcement dog trainer..." |
 | Ch-5: Cooking and Culinary Skills | Research + Diagnose (Expert Role) | "Act as a culinary instructor..." |
 | Ch-6: Optimizing Manual Chores | Diagnose + Navigate (Expert Role) | "Act as a household operations consultant..." |
-| Ch-7: Meal Planning and Grocery Shopping | Research + Prepare | "I need to plan meals for the week and build a grocery list." |
-| Ch-8: Cleaning and Laundry | Research + Navigate (Expert Role) | "Act as a textile care and cleaning specialist." |
-| Ch-9: Pet Care and Training | Research + Navigate (Expert Role) | "Act as a veterinary-informed pet care advisor." |
-| Ch-10: Seasonal Maintenance | Prepare + Navigate | "I need a seasonal home maintenance checklist." |
-| Ch-11: Managing Subscriptions and Recurring Costs | Decode + Assert | "I need to audit my subscriptions and recurring charges." |
+| Ch-7: Meal Planning and Grocery Shopping | Research + Prepare | "I need to plan meals for the week and build a grocery list..." |
+| Ch-8: Cleaning and Laundry | Research + Navigate (Expert Role) | "Act as a textile care and cleaning specialist..." |
+| Ch-9: Pet Care and Training | Research + Navigate (Expert Role) | "Act as a veterinary-informed pet care advisor..." |
+| Ch-10: Seasonal Maintenance | Prepare + Navigate | "I need a seasonal home maintenance checklist..." |
+| Ch-11: Managing Subscriptions and Recurring Costs | Decode + Assert | "I need to audit my subscriptions and recurring charges..." |
 
 ---
 
@@ -170,13 +170,13 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | IRL-1: Navigating Government Offices | Prepare + Navigate | "I need to go to [DMV / Social Security office / county clerk]..." |
 | IRL-2: Getting Help from Customer Service | Prepare + Assert | "I need to resolve a problem with [company] about [issue]..." |
 | IRL-3: First-Time Situations | Prepare + Research | "I am about to [go to / do / attend] [specific situation] for the first time..." |
-| IRL-4: Negotiating a Price | Prepare + Assert | "I need to negotiate a price for [car / furniture / medical bill / rent renewal / contractor work / other]." |
+| IRL-4: Negotiating a Price | Prepare + Assert | "I need to negotiate a price for [car / furniture / medical bill / rent renewal / appliance / contractor work / other]..." |
 | IRL-6: Navigating a Hospital Visit | Prepare + Navigate | "I [am going to the hospital / am accompanying someone] for [scheduled surgery / ER visit / labor and delivery / procedure]..." |
-| IRL-7: Talking to a Mechanic | Prepare + Decode | "I need to take my car to a mechanic and I want to be prepared." |
-| IRL-8: Navigating a Parent-Teacher Conference | Prepare + Assert | "I have a parent-teacher conference coming up for my [age/grade] child." |
-| IRL-9: Handling a Car Accident | Prepare + Navigate | "I was just in a car accident. [Or: I want to be prepared in case I'm in one.]" |
-| IRL-10: Attending a Funeral or Memorial | Prepare + Navigate | "I am attending a funeral or memorial service and I want to be prepared." |
-| IRL-11: Job Interviews In Person | Prepare + Assert | "I have an in-person job interview coming up and I want to be fully prepared." |
+| IRL-7: Talking to a Mechanic | Prepare + Decode | "I need to take my car to a mechanic and I want to be prepared..." |
+| IRL-8: Navigating a Parent-Teacher Conference | Prepare + Assert | "I have a parent-teacher conference coming up for my [age/grade] child..." |
+| IRL-9: Handling a Car Accident | Prepare + Navigate | "I was just in a car accident. [Or: I want to be prepared in case I'm in one.]..." |
+| IRL-10: Attending a Funeral or Memorial | Prepare + Navigate | "I am attending a funeral or memorial service and I want to be prepared..." |
+| IRL-11: Job Interviews In Person | Prepare + Assert | "I have an in-person job interview coming up and I want to be fully prepared..." |
 
 ---
 
@@ -204,13 +204,13 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | Cr-2: Learning Visual Design | Create + Research (Expert Role) | "Act as an expert visual designer. I need help with [a website / a poster / a flyer]..." |
 | Cr-3: Editing a Movie | Create + Navigate | "I want to edit a video..." |
 | Cr-4: Writing a Book (Like This One) | Create + Draft | "I want to write a book about [topic / story / argument]..." |
-| Cr-5: Making Music | Create + Navigate | "I want to make music." |
-| Cr-6: Podcasting and Audio Production | Create + Navigate | "I want to start a podcast." |
-| Cr-7: Drawing and Illustration | Create + Diagnose | "I want to learn to draw." |
-| Cr-8: Crafts and Maker Projects | Create + Research | "I want to make something." |
+| Cr-5: Making Music | Create + Navigate | "I want to make music..." |
+| Cr-6: Podcasting and Audio Production | Create + Navigate | "I want to start a podcast..." |
+| Cr-7: Drawing and Illustration | Create + Diagnose | "I want to learn to draw..." |
+| Cr-8: Crafts and Maker Projects | Create + Research | "I want to make something..." |
 | Cr-9: Creative Writing | Create + Draft | "I want to write [a short story / a poem / a personal essay / flash fiction / a screenplay scene]..." |
 | Cr-10: Graphic Design for Real Life | Create + Draft | "I need to design [a flyer / a poster / an invitation / a social media graphic / a resume / a business card]..." |
-| Cr-11: Learning an Instrument | Create + Research (Expert Role) | "I want to learn [guitar / piano / ukulele / bass / drums / violin / harmonica / banjo / another instrument]." |
+| Cr-11: Learning an Instrument | Create + Research (Expert Role) | "I want to learn [guitar / piano / ukulele / bass / drums / violin / harmonica / banjo / another instrument]..." |
 
 ---
 
@@ -222,9 +222,9 @@ _A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-
 | Tr-2: Car Maintenance | Diagnose + Research (Expert Role) | "Act as an experienced mechanic and car maintenance advisor..." |
 | Tr-3: Public Transit, Cycling, and Walkability | Research + Navigate | "I want to [reduce my car dependence / go car-free]..." |
 | Tr-4: Air Travel | Prepare + Assert | "I need help with air travel..." |
-| Tr-5: Road Trips and Long-Distance Driving | Prepare + Navigate | "I'm planning a road trip and want to be prepared." |
-| Tr-7: Understanding Rideshare and Delivery Gig Work | Research + Decode | "I want to understand rideshare and delivery gig work." |
-| Tr-8: Navigating International Travel | Prepare + Navigate | "I'm planning international travel and need help preparing." |
-| Tr-9: Accessible Transportation | Assert + Navigate | "I need help with accessible transportation." |
-| Tr-10: Electric Vehicles and the Transition | Research + Decide | "I'm considering an electric vehicle and want the real picture." |
-| Tr-11: Boating, RVs, and Niche Vehicles | Research + Navigate | "I'm looking into [buying / renting / maintaining] a [boat / RV / motorcycle / ATV / other specialty vehicle]." |
+| Tr-5: Road Trips and Long-Distance Driving | Prepare + Navigate | "I'm planning a road trip and want to be prepared..." |
+| Tr-7: Understanding Rideshare and Delivery Gig Work | Research + Decode | "I want to understand rideshare and delivery gig work..." |
+| Tr-8: Navigating International Travel | Prepare + Navigate | "I'm planning international travel and need help preparing..." |
+| Tr-9: Accessible Transportation | Assert + Navigate | "I need help with accessible transportation..." |
+| Tr-10: Electric Vehicles and the Transition | Research + Decide | "I'm considering an electric vehicle and want the real picture..." |
+| Tr-11: Boating, RVs, and Niche Vehicles | Research + Navigate | "I'm looking into [buying / renting / maintaining] a [boat / RV / motorcycle / ATV / other specialty vehicle]..." |


### PR DESCRIPTION
## Summary
- Appendix A listed 88 entries but the field guide has grown to 131 — 43 entries were missing from the quick reference index
- Added missing entries across 9 domains: Money (+4), Legal (+6), Home (+3), Work (+4), Civic (+1), Chores (+5), IRL (+7), Creative (+7), Transportation (+6)
- Replaced stub markers on L-2, L-3, L-4 with their actual spec openers now that all stubs have been drafted
- Intentional ID gaps (L-9, IRL-5, Tr-6) are accurately reflected — those entries don't exist in the field guide

## Test plan
- [x] `npm run build:check` passes
- [x] `npm test` passes (20/20)
- [ ] Verify entry count matches actual `.dj` files in `src/content/02-field-guide/`
- [ ] Spot-check spec openers against source entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)