### PR TITLE
Rebrand book from "A Majordomo for Everyone" to "Majordomo"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: epub
-          path: dist/a-majordomo-for-everyone.epub
+          path: dist/majordomo.epub
 
       - uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# A Majordomo for Everyone
+# Majordomo
 
-*Managing Your Personal Staff of AI Agents*
+*Billionaires have staff, now you do too.*
 
 The billionaire class has always had a staff attorney, a bookkeeper, a chief of staff. The word for that person, in the old houses, was *majordomo* — the one who runs the household, reads the contracts, knows which bill to dispute and which to pay.
 
@@ -17,7 +17,7 @@ npm run build:check  # type-check only
 npm test             # vitest
 ```
 
-The output is `dist/a-majordomo-for-everyone.epub`.
+The output is `dist/majordomo.epub`.
 
 ## Illustrations
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO — A Majordomo for Everyone
+# TODO — Majordomo
 
 Last reviewed: 2026-04-21 against spec/ directory and codebase.
 

--- a/build/index.ts
+++ b/build/index.ts
@@ -19,7 +19,7 @@ import { assembleEpub } from './epub/assemble.js';
 import { generateMissingArt } from './generate-art.js';
 import { BOOK_META } from './types.js';
 
-const OUTPUT_PATH = join(ROOT, 'dist', 'a-majordomo-for-everyone.epub');
+const OUTPUT_PATH = join(ROOT, 'dist', 'majordomo.epub');
 
 function imageExistsSync(imagesDir: string, brief: ArtBrief): boolean {
   try {

--- a/build/pdf/index.ts
+++ b/build/pdf/index.ts
@@ -18,7 +18,7 @@ import {
 } from '../pipeline.js';
 import { BOOK_META } from '../types.js';
 
-const OUTPUT_PATH = join(ROOT, 'dist', 'a-majordomo-for-everyone.pdf');
+const OUTPUT_PATH = join(ROOT, 'dist', 'majordomo.pdf');
 
 function escapeHtml(str: string): string {
   return str

--- a/build/site/index.ts
+++ b/build/site/index.ts
@@ -89,8 +89,8 @@ async function buildSite(): Promise<void> {
 
   // Copy epub and pdf if they exist (built by earlier steps in build:all)
   for (const file of [
-    'a-majordomo-for-everyone.epub',
-    'a-majordomo-for-everyone.pdf',
+    'majordomo.epub',
+    'majordomo.pdf',
   ]) {
     const src = join(ROOT, 'dist', file);
     try {

--- a/build/site/templates.ts
+++ b/build/site/templates.ts
@@ -205,7 +205,7 @@ export function landingPage(meta: BookMeta): string {
       <p class="hero-pitch">The billionaire class has always had access to lawyers, doctors, and financial advisors who explain things in plain language &mdash; now you have something close to that, for free, on your phone.</p>
       <div class="hero-ctas">
         <a href="/read/" class="hero-cta">Read Online</a>
-        <a href="/a-majordomo-for-everyone.epub" class="hero-cta hero-cta-secondary" download>Download ePub</a>
+        <a href="/majordomo.epub" class="hero-cta hero-cta-secondary" download>Download ePub</a>
 
         <a href="https://github.com/davidwkeith/A-Majordomo-for-Everyone" class="hero-cta hero-cta-secondary">View Source</a>
       </div>
@@ -230,11 +230,11 @@ export function landingPage(meta: BookMeta): string {
   <div class="share-section">
     <p class="share-label">Share this book</p>
     <div class="share-links">
-      <a href="https://bsky.app/intent/compose?text=${encodeURIComponent(meta.title + ' — free practical guide to using AI tools for health, legal, financial, and everyday decisions\n\nhttps://a-majordomo-for-everyone.dwk.io')}" target="_blank" rel="noopener" class="share-btn share-bluesky">Bluesky</a>
-      <a href="https://s2f.kytta.dev/?text=${encodeURIComponent(meta.title + ' — free practical guide to using AI tools for health, legal, financial, and everyday decisions')}&url=${encodeURIComponent('https://a-majordomo-for-everyone.dwk.io')}" target="_blank" rel="noopener" class="share-btn share-mastodon">Mastodon</a>
-      <a href="https://twitter.com/intent/tweet?text=${encodeURIComponent(meta.title + ' — free practical guide to using AI tools for health, legal, financial, and everyday decisions')}&url=${encodeURIComponent('https://a-majordomo-for-everyone.dwk.io')}" target="_blank" rel="noopener" class="share-btn share-twitter">Twitter</a>
-      <a href="https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent('https://a-majordomo-for-everyone.dwk.io')}" target="_blank" rel="noopener" class="share-btn share-facebook">Facebook</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent('https://a-majordomo-for-everyone.dwk.io')}" target="_blank" rel="noopener" class="share-btn share-linkedin">LinkedIn</a>
+      <a href="https://bsky.app/intent/compose?text=${encodeURIComponent(meta.title + ' — free practical guide to using AI tools for health, legal, financial, and everyday decisions\n\nhttps://majordomo.dwk.io')}" target="_blank" rel="noopener" class="share-btn share-bluesky">Bluesky</a>
+      <a href="https://s2f.kytta.dev/?text=${encodeURIComponent(meta.title + ' — free practical guide to using AI tools for health, legal, financial, and everyday decisions')}&url=${encodeURIComponent('https://majordomo.dwk.io')}" target="_blank" rel="noopener" class="share-btn share-mastodon">Mastodon</a>
+      <a href="https://twitter.com/intent/tweet?text=${encodeURIComponent(meta.title + ' — free practical guide to using AI tools for health, legal, financial, and everyday decisions')}&url=${encodeURIComponent('https://majordomo.dwk.io')}" target="_blank" rel="noopener" class="share-btn share-twitter">Twitter</a>
+      <a href="https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent('https://majordomo.dwk.io')}" target="_blank" rel="noopener" class="share-btn share-facebook">Facebook</a>
+      <a href="https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent('https://majordomo.dwk.io')}" target="_blank" rel="noopener" class="share-btn share-linkedin">LinkedIn</a>
     </div>
   </div>
   <footer class="landing-footer">

--- a/build/types.ts
+++ b/build/types.ts
@@ -40,8 +40,8 @@ export interface BookMeta {
 }
 
 export const BOOK_META: BookMeta = {
-  title: 'A Majordomo for Everyone',
-  subtitle: 'Managing Your Personal Staff of AI Agents',
+  title: 'Majordomo',
+  subtitle: 'Billionaires have staff, now you do too.',
   language: 'en-US',
   creator: 'David W. Keith',
   publisher: 'David W. Keith',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "a-majordomo-for-everyone",
-  "version": "0.2.0",
+  "name": "majordomo",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "a-majordomo-for-everyone",
-      "version": "0.2.0",
+      "name": "majordomo",
+      "version": "0.3.0",
       "license": "CC-BY-SA-4.0",
       "dependencies": {
         "@djot/djot": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "a-majordomo-for-everyone",
-  "version": "0.2.0",
-  "description": "ePub and website build pipeline for A Majordomo for Everyone",
+  "name": "majordomo",
+  "version": "0.3.0",
+  "description": "ePub and website build pipeline for Majordomo",
   "type": "module",
   "private": true,
   "engines": {

--- a/scripts/sync-highlights.py
+++ b/scripts/sync-highlights.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.12"
 # ///
-"""Sync Apple Books highlights for A Majordomo for Everyone to notes/highlights.md."""
+"""Sync Apple Books highlights for Majordomo to notes/highlights.md."""
 
 import glob
 import logging
@@ -20,7 +20,7 @@ logging.basicConfig(
 log = logging.getLogger(__name__)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-BOOK_TITLE = "A Majordomo for Everyone"
+BOOK_TITLE = "Majordomo"
 
 ANNOTATION_DB_GLOB = os.path.expanduser(
     "~/Library/Containers/com.apple.iBooksX/Data/Documents/AEAnnotation/*.sqlite"

--- a/spec/architecture.md
+++ b/spec/architecture.md
@@ -91,4 +91,4 @@ PART THREE: THE GENERAL METHOD
 
 **The central meme:**
 
-> *A Majordomo for Everyone has this to say about dealing with large institutions: always know where your specification is.*
+> *Majordomo has this to say about dealing with large institutions: always know where your specification is.*

--- a/spec/illustration/cover-spec.md
+++ b/spec/illustration/cover-spec.md
@@ -106,8 +106,8 @@ Over the front lawn: **DONT** / **PROMPT**. Two lines. Large. Over the most acti
 
 ### Zone 1 — Top: Helvetica Black
 
-- *"A Majordomo for Everyone"* — Helvetica Black. Large. At the very top, above the roofline. **Left edge of the text aligns to the red margin line.** The title respects the paper's own grid.
-- *"Managing Your Personal Staff of AI Agents"* — Helvetica Black, smaller. Directly beneath, same left alignment.
+- *"Majordomo"* — Helvetica Black. Large. At the very top, above the roofline. **Left edge of the text aligns to the red margin line.** The title respects the paper's own grid.
+- *"Billionaires have staff, now you do too."* — Helvetica Black, smaller. Directly beneath, same left alignment.
 - The red margin line runs from the title block down through the telephone pole zone. Title left edge, margin line, telephone pole shaft: a vertical conversation running the full height of the cover.
 
 Helvetica Black is typeset, not drawn. It is the system's font — cold, institutional, precise. It contrasts with everything else on the page.

--- a/spec/illustration/gem-illustration-instructions.md
+++ b/spec/illustration/gem-illustration-instructions.md
@@ -1,6 +1,6 @@
 # Illustration Instructions
 
-You are the illustrator for *A Majordomo for Everyone*, a book about using AI agents to manage adult life. You generate three kinds of images: **cover art** (one) **chapter opener illustrations** (one per strategy chapter, 0 through 9) and **inline graphics** (smaller drawings placed throughout the text).
+You are the illustrator for *Majordomo*, a book about using AI agents to manage adult life. You generate three kinds of images: **cover art** (one) **chapter opener illustrations** (one per strategy chapter, 0 through 9) and **inline graphics** (smaller drawings placed throughout the text).
 
 Every image you produce must feel like it came from the same notebook, drawn by the same hand: a Gen-X kid in a boring class, rendering the objects they knew by heart in #2 pencil, coloring pixel art in ballpoint pen.
 

--- a/spec/metadata.md
+++ b/spec/metadata.md
@@ -1,14 +1,14 @@
 # ePub Build Specification
 
 ```
-title:        A Majordomo for Everyone
-subtitle:     Managing Your Personal Staff of AI Agents
+title:        Majordomo
+subtitle:     Billionaires have staff, now you do too.
 cover-tag:    DON'T PROMPT (large, warm, friendly letters — see cover notes)
 language:     en-US
 trim:         Mass market paperback / 5.5" x 8.5"
 epub-version: 3.0
 toc-depth:    3
-website:      https://a-majordomo-for-everyone.dwk.io/
+website:      https://majordomo.dwk.io/
 footnotes:    endnotes per chapter (epub), footnotes per page (print)
 distribution: Free. No paywall. No signup required.
 license:      Creative Commons Attribution-ShareAlike 4.0 (CC BY-SA 4.0)

--- a/spec/outline.md
+++ b/spec/outline.md
@@ -1,4 +1,4 @@
-# A Majordomo for Everyone — Agent Outline
+# Majordomo — Agent Outline
 
 ## What This Book Is
 
@@ -146,7 +146,7 @@ The book aligns with five Roddenberry values: Urgency (lead with friction moment
 
 ## The Central Meme
 
-> *A Majordomo for Everyone has this to say about dealing with large institutions: always know where your specification is.*
+> *Majordomo has this to say about dealing with large institutions: always know where your specification is.*
 
 (Riff on the Hitchhiker's Guide: "always know where your towel is.")
 

--- a/spec/version-history.md
+++ b/spec/version-history.md
@@ -80,6 +80,14 @@ v1.7  — Obsession zone system added to Illustration Spec.
 		   compliance plate, Sony logo, screen corners.
 		 Each zone chosen for structural resonance with its chapter's episode
 		   and strategy. Never labeled. Always present.
+v1.8  — Retitled. New title: Majordomo.
+		 New subtitle: Billionaires have staff, now you do too.
+		 Prior title (A Majordomo for Everyone) and subtitle
+		   (Managing Your Personal Staff of AI Agents) retired.
+		 Package slug, ePub/PDF filenames, and companion domain
+		   updated from a-majordomo-for-everyone to majordomo.
+		 In-world self-reference quote shortened to match new title.
+		 Cover typography spec updated; cover art queued for regeneration.
 ```
 
 *If you are reading a version later than the one listed here, someone improved it. That is correct.*

--- a/src/content/04-appendices/00-appendix-a-quick-reference/index.dj
+++ b/src/content/04-appendices/00-appendix-a-quick-reference/index.dj
@@ -8,9 +8,9 @@ status: "draft"
 
 ## Appendix A: Field Guide Quick Reference
 
-_This reference is designed to be pulled out and kept somewhere accessible -- taped inside a cabinet, saved on your phone, or printed from the companion website at [a-majordomo-for-everyone.dwk.io](https://a-majordomo-for-everyone.dwk.io/). Each entry shows the strategy, the first line of the spec, and where to find the full entry._
+_This reference is designed to be pulled out and kept somewhere accessible -- taped inside a cabinet, saved on your phone, or printed from the companion website at [majordomo.dwk.io](https://majordomo.dwk.io/). Each entry shows the strategy, the first line of the spec, and where to find the full entry._
 
-_A printable PDF version is available at [a-majordomo-for-everyone.dwk.io/quick-reference](https://a-majordomo-for-everyone.dwk.io/quick-reference)._
+_A printable PDF version is available at [majordomo.dwk.io/quick-reference](https://majordomo.dwk.io/quick-reference)._
 
 > This is an ePub -- printing is poor. The Quick Reference is also available as a separate piece of media (HTML/PDF on the book's website) for easy printing and posting.
 

--- a/src/content/04-appendices/02-appendix-c-free-tools/index.dj
+++ b/src/content/04-appendices/02-appendix-c-free-tools/index.dj
@@ -10,7 +10,7 @@ status: "draft"
 
 This appendix is a link, not a table. Free tier limits, tool capabilities, and best-use comparisons change faster than any publication cycle can track. The companion site maintains a current version:
 
-*→ [a-majordomo-for-everyone.dwk.io/tools](https://a-majordomo-for-everyone.dwk.io/tools)*
+*→ [majordomo.dwk.io/tools](https://majordomo.dwk.io/tools)*
 
 The page covers:
 - Current free tier limits for Claude, ChatGPT, Gemini, and Copilot

--- a/src/content/04-appendices/05-appendix-f-version-history/index.dj
+++ b/src/content/04-appendices/05-appendix-f-version-history/index.dj
@@ -8,7 +8,7 @@ status: "draft"
 
 ## Appendix F: Version History
 
-This book is a living document. Each version is numbered and dated. The full changelog is maintained at *[a-majordomo-for-everyone.dwk.io/versions](https://a-majordomo-for-everyone.dwk.io/versions)*.
+This book is a living document. Each version is numbered and dated. The full changelog is maintained at *[majordomo.dwk.io/versions](https://majordomo.dwk.io/versions)*.
 
 ::: prompt
 v0.1  -- Initial outline and chapter scaffolding
@@ -88,6 +88,14 @@ v1.7  -- Obsession zone system added to Illustration Spec.
            compliance plate, Sony logo, screen corners.
          Each zone chosen for structural resonance with its chapter's episode
            and strategy. Never labeled. Always present.
+v1.8  -- Retitled. New title: Majordomo.
+         New subtitle: Billionaires have staff, now you do too.
+         Prior title (A Majordomo for Everyone) and subtitle
+           (Managing Your Personal Staff of AI Agents) retired.
+         Package slug, ePub/PDF filenames, and companion domain
+           updated from a-majordomo-for-everyone to majordomo.
+         In-world self-reference quote shortened to match new title.
+         Cover typography spec updated; cover art queued for regeneration.
 :::
 
 _If you are reading a version later than the one listed here, someone improved it. That is correct._

--- a/src/content/04-appendices/06-appendix-g-feature-table/index.dj
+++ b/src/content/04-appendices/06-appendix-g-feature-table/index.dj
@@ -8,7 +8,7 @@ status: "draft"
 
 ## Appendix G: Feature Translation Table
 
-_The [ALSO] blocks throughout this book point here for the full reference. This table is a living document -- tool features change, names change, new tools emerge. Current version maintained at [a-majordomo-for-everyone.dwk.io/features](https://a-majordomo-for-everyone.dwk.io/features)._
+_The [ALSO] blocks throughout this book point here for the full reference. This table is a living document -- tool features change, names change, new tools emerge. Current version maintained at [majordomo.dwk.io/features](https://majordomo.dwk.io/features)._
 
 The book uses Claude as its default example. Every feature named below exists in some form across all major tools, but the names differ. This table is your vocabulary key.
 
@@ -88,7 +88,7 @@ The book uses Claude as its default example. Every feature named below exists in
 | Paid price (approx.) | $20/mo | $20/mo | $20/mo | $20/mo |
 | Key paid benefit | Higher limits, extended thinking, Projects | Gemini Advanced model, more Gems | GPT-4o full access, more GPTs | Priority access, more features |
 
-_All pricing and feature availability subject to change. See [a-majordomo-for-everyone.dwk.io/features](https://a-majordomo-for-everyone.dwk.io/features) for current information._
+_All pricing and feature availability subject to change. See [majordomo.dwk.io/features](https://majordomo.dwk.io/features) for current information._
 
 ---
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,4 +1,4 @@
-/* A Majordomo for Everyone — Shared Stylesheet (ePub + Web) */
+/* Majordomo — Shared Stylesheet (ePub + Web) */
 
 /* ---- Theme Variables ---- */
 

--- a/src/styles/pdf.css
+++ b/src/styles/pdf.css
@@ -1,4 +1,4 @@
-/* A Majordomo for Everyone — PDF Print Stylesheet */
+/* Majordomo — PDF Print Stylesheet */
 
 @page {
   size: letter;

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -1,4 +1,4 @@
-/* A Majordomo for Everyone — Website Layout */
+/* Majordomo — Website Layout */
 
 /* ---- Site Variables ---- */
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "a-majordomo-for-everyone-dwk-io"
+name = "majordomo-dwk-io"
 main = "worker/index.js"
 compatibility_date = "2025-04-01"
 


### PR DESCRIPTION
## Summary
This PR completes a comprehensive rebranding of the book project, updating the title from "A Majordomo for Everyone" to "Majordomo" and the subtitle from "Managing Your Personal Staff of AI Agents" to "Billionaires have staff, now you do too."

## Key Changes

- **Title & Subtitle Updates**: Updated all references to the book's title and subtitle across metadata, configuration, and content files
- **Domain & URL Updates**: Changed companion domain from `a-majordomo-for-everyone.dwk.io` to `majordomo.dwk.io` in all social sharing links, documentation references, and website configuration
- **File & Package Naming**: Updated ePub and PDF output filenames from `a-majordomo-for-everyone.{epub,pdf}` to `majordomo.{epub,pdf}` in build scripts and artifact handling
- **Package Metadata**: Updated `package.json` name from `a-majordomo-for-everyone` to `majordomo` and bumped version to 0.3.0
- **Cover Specification**: Updated cover typography spec to reflect new title and subtitle in Helvetica Black layout
- **Documentation**: Updated all internal documentation, specs, and comments to reference the new title
- **Version History**: Added v1.8 entry documenting the rebranding, including the package slug, filename, and domain changes
- **Cloudflare Configuration**: Updated `wrangler.toml` deployment name to match new branding

## Implementation Details

The rebranding is comprehensive and touches:
- Build pipeline configuration and output paths
- Website landing page and social sharing functionality
- ePub metadata and specification files
- All content references and cross-links
- Development scripts and documentation
- Deployment configuration

All references maintain consistency across the codebase, ensuring the new branding is applied uniformly throughout the project.

https://claude.ai/code/session_018TrKosaJpdLwDAKk7uMo4J