### PR TITLE
test(a11y): tighten <img> alt detection per review

### DIFF
--- a/build/validators/a11y.test.ts
+++ b/build/validators/a11y.test.ts
@@ -79,6 +79,40 @@ describe('validateAccessibility', () => {
     expect(alt[0].message).toContain('empty alt');
   });
 
+  it('fails on single-quoted empty alt', () => {
+    const html = "<img src='x.png' alt=''/>";
+    const issues = validateAccessibility(BOOK_META, [chapter({}, html)], ctx());
+    const alt = issues.filter((i) => i.feature === 'alternativeText');
+    expect(alt.length).toBe(1);
+    expect(alt[0].message).toContain('empty alt');
+  });
+
+  it('tolerates whitespace around alt=', () => {
+    const present = '<img src="x.png" alt = "A figure."/>';
+    const absent = validateAccessibility(BOOK_META, [chapter({}, present)], ctx());
+    expect(absent.filter((i) => i.feature === 'alternativeText')).toEqual([]);
+
+    const empty = '<img src="x.png" alt = " "/>';
+    const issues = validateAccessibility(BOOK_META, [chapter({}, empty)], ctx());
+    expect(issues.filter((i) => i.feature === 'alternativeText').length).toBe(1);
+  });
+
+  it('does not confuse data-alt with alt', () => {
+    const html = '<img src="x.png" data-alt="not real"/>';
+    const issues = validateAccessibility(BOOK_META, [chapter({}, html)], ctx());
+    const alt = issues.filter((i) => i.feature === 'alternativeText');
+    expect(alt.length).toBe(1);
+    expect(alt[0].message).toContain('without alt');
+  });
+
+  it('reports every violation in a chapter, not just the first', () => {
+    const html =
+      '<img src="a.png"/><img src="b.png" alt=""/><img src="c.png" alt="ok"/><img src="d.png"/>';
+    const issues = validateAccessibility(BOOK_META, [chapter({}, html)], ctx());
+    const alt = issues.filter((i) => i.feature === 'alternativeText');
+    expect(alt.length).toBe(3);
+  });
+
   it('passes on <img> with non-empty alt attribute', () => {
     const html = '<img src="x.png" alt="A figure."/>';
     const issues = validateAccessibility(BOOK_META, [chapter({}, html)], ctx());

--- a/build/validators/a11y.ts
+++ b/build/validators/a11y.ts
@@ -20,8 +20,16 @@ export const DECLARED_A11Y_FEATURES = [
   'longDescription',
 ] as const;
 
-const IMG_NO_ALT = /<img\b(?![^>]*\balt=)[^>]*>/i;
-const IMG_EMPTY_ALT = /<img\b[^>]*\balt="\s*"/i;
+// Whitespace before `alt` distinguishes the real attribute from `data-alt`,
+// `srcset-alt`, etc. Both quote styles are accepted, with optional whitespace
+// around `=` and inside the quotes.
+const IMG_NO_ALT = /<img\b(?![^>]*\s+alt\s*=)[^>]*>/gi;
+const IMG_EMPTY_ALT = /<img\b[^>]*\s+alt\s*=\s*(['"])\s*\1/gi;
+
+function snippet(tag: string): string {
+  const flat = tag.replace(/\s+/g, ' ').trim();
+  return flat.length > 80 ? flat.slice(0, 77) + '...' : flat;
+}
 
 export function validateAccessibility(
   meta: BookMeta,
@@ -98,17 +106,17 @@ export function validateAccessibility(
     }
   }
   for (const ch of chapters) {
-    if (IMG_NO_ALT.test(ch.html)) {
+    for (const m of ch.html.matchAll(IMG_NO_ALT)) {
       issues.push({
         feature: 'alternativeText',
-        message: '<img> without alt attribute',
+        message: `<img> without alt attribute: ${snippet(m[0])}`,
         source: ch.meta.sourceFile,
       });
     }
-    if (IMG_EMPTY_ALT.test(ch.html)) {
+    for (const m of ch.html.matchAll(IMG_EMPTY_ALT)) {
       issues.push({
         feature: 'alternativeText',
-        message: '<img> with empty alt attribute',
+        message: `<img> with empty alt attribute: ${snippet(m[0])}`,
         source: ch.meta.sourceFile,
       });
     }


### PR DESCRIPTION
gemini-code-assist flagged that the alt-attribute regex missed single-quoted alts, broke on whitespace around =, and would treat data-alt= as a real alt. It also only reported one violation per chapter, making fixes a whack-a-mole.

Require whitespace before alt= (so data-alt no longer collides), accept either quote style with optional inner/outer whitespace, and iterate every match per chapter so each problem image is reported once, including a snippet of the offending tag for context.

Tests cover single quotes, whitespace around =, the data-alt collision, and a chapter with multiple violations.

https://claude.ai/code/session_015uYfo4Gug86TZe5ZFwzjRK