### PR TITLE
link Field Guide references in Strategy 0 to their chapters

### DIFF
--- a/src/content/01-strategies/00-strategy-0-specify/index.dj
+++ b/src/content/01-strategies/00-strategy-0-specify/index.dj
@@ -30,7 +30,7 @@ Every strategy in this book begins here. Before your Agent can Decode, Draft, Na
 
 The insight that makes this book work: *you do not have to write the spec.* Your Agent will interview you into one. Your job is to answer its questions honestly and tell it when the spec it proposes doesn't accurately reflect your situation. That is a human skill you already have. You know your own situation. You just needed someone to ask the right questions.
 
-_In the Field Guide: every Skill begins with a Strategy 0 specification interview. Skills using the Expert Role variant include Ho-7 (Gardening), Ch-4 (Dog Training), Tr-2 (Car Maintenance), and H-8 (Wellness Coach)._
+_In the Field Guide: every Skill begins with a Strategy 0 specification interview. Skills using the Expert Role variant include [Ho-7: Gardening & Landscaping](04-home.xhtml), [Ch-4: Dog Training](08-chores.xhtml), [Tr-2: Car Maintenance](99-transportation.xhtml), and [H-8: Wellness and Nutrition Coach](01-health.xhtml)._
 
 ### The Specification Interview Loop
 

--- a/src/content/01-strategies/00-strategy-0-specify/index.dj
+++ b/src/content/01-strategies/00-strategy-0-specify/index.dj
@@ -30,7 +30,7 @@ Every strategy in this book begins here. Before your Agent can Decode, Draft, Na
 
 The insight that makes this book work: *you do not have to write the spec.* Your Agent will interview you into one. Your job is to answer its questions honestly and tell it when the spec it proposes doesn't accurately reflect your situation. That is a human skill you already have. You know your own situation. You just needed someone to ask the right questions.
 
-_In the Field Guide: every Skill begins with a Strategy 0 specification interview. Skills using the Expert Role variant include [Ho-7: Gardening & Landscaping](04-home.xhtml), [Ch-4: Dog Training](08-chores.xhtml), [Tr-2: Car Maintenance](99-transportation.xhtml), and [H-8: Wellness and Nutrition Coach](01-health.xhtml)._
+_In the Field Guide: every Skill begins with a Strategy 0 specification interview. Skills using the Expert Role variant include [Ho-7: Gardening & Landscaping](04-home.xhtml), [Ch-9: Pet Care and Training](08-chores.xhtml), [Tr-2: Car Maintenance](99-transportation.xhtml), and [H-8: Wellness and Nutrition Coach](01-health.xhtml)._
 
 ### The Specification Interview Loop
 


### PR DESCRIPTION
Match Appendix A entry names (e.g. "Ho-7: Gardening & Landscaping")
instead of informal parentheticals.