### PR TITLE
content: use spec callout for the annotated Interview Loop

### DIFF
--- a/src/content/01-strategies/00-strategy-0-specify/index.dj
+++ b/src/content/01-strategies/00-strategy-0-specify/index.dj
@@ -36,7 +36,7 @@ _In the Field Guide: every Skill begins with a Strategy 0 specification intervie
 
 Here is the full loop, annotated. This is what every `[SPEC]` sidebar in this book is showing you.
 
-::: prompt
+::: spec
 STEP 1: Describe your situation loosely.
 Don't worry about being precise. Just say what's going on.
 


### PR DESCRIPTION
The chapter text introduces the block as "what every [SPEC] sidebar
in this book is showing you," but the block itself was wrapped in
::: prompt — the callout reserved for user input. Swap to ::: spec
so the callout type matches its semantics and the body text.