### PR TITLE
fix(epub): render lists inside prompt/agent conversation blocks

### DIFF
--- a/build/filters/callouts.test.ts
+++ b/build/filters/callouts.test.ts
@@ -98,6 +98,36 @@ describe('conversationFilter', () => {
     expect(html).toContain('<samp>');
     expect(html).toContain('I can help with that.');
   });
+
+  it('renders an ordered list inside a prompt div', () => {
+    const dj = '::: prompt\n1. First answer.\n2. Second answer.\n:::';
+    const html = process(dj);
+    expect(html).toContain('conversation-prompt');
+    expect(html).toContain('1. First answer.');
+    expect(html).toContain('2. Second answer.');
+  });
+
+  it('renders a paragraph followed by a list inside an agent div', () => {
+    const dj = '::: agent\nA few questions:\n\n1. What type?\n2. What reason?\n:::';
+    const html = process(dj);
+    expect(html).toContain('A few questions:');
+    expect(html).toContain('1. What type?');
+    expect(html).toContain('2. What reason?');
+  });
+
+  it('renders a bullet list inside a prompt div', () => {
+    const dj = '::: prompt\n- alpha\n- beta\n:::';
+    const html = process(dj);
+    expect(html).toContain('alpha');
+    expect(html).toContain('beta');
+  });
+
+  it('respects ordered list start number', () => {
+    const dj = '::: prompt\n3. third\n4. fourth\n:::';
+    const html = process(dj);
+    expect(html).toContain('3. third');
+    expect(html).toContain('4. fourth');
+  });
 });
 
 describe('endnotes', () => {

--- a/build/filters/endnotes.ts
+++ b/build/filters/endnotes.ts
@@ -7,6 +7,9 @@ import type {
   ThematicBreak,
   FootnoteReference,
   Footnote,
+  OrderedList,
+  BulletList,
+  ListItem,
   Visitor,
   HTMLRenderer,
 } from '@djot/djot';
@@ -203,18 +206,54 @@ export function epubOverrides(
 
 /**
  * Extract text from a conversation div's children, applying prose wrapping:
- * single newlines become spaces, blank lines become <br/> breaks.
+ * paragraphs are separated by blank-line breaks, and ordered/bullet lists are
+ * flattened to one item per line so the content renders inside <kbd>/<samp>
+ * without introducing block-level list markup.
  */
 function extractConversationText(node: Div, renderer: HTMLRenderer): string {
-  // Render each child paragraph, then join with <br/><br/> breaks
   const parts: string[] = [];
   for (const child of node.children) {
-    if (child.tag === 'para') {
-      const html = renderer.renderChildren(child);
-      parts.push(html);
-    }
+    const rendered = renderConversationBlock(child, renderer);
+    if (rendered) parts.push(rendered);
   }
   return parts.join('<br/><br/>');
+}
+
+function renderConversationBlock(
+  block: Div['children'][number],
+  renderer: HTMLRenderer
+): string {
+  if (block.tag === 'para') {
+    return renderer.renderChildren(block);
+  }
+  if (block.tag === 'ordered_list' || block.tag === 'bullet_list') {
+    return renderConversationList(block, renderer);
+  }
+  return '';
+}
+
+function renderConversationList(
+  list: OrderedList | BulletList,
+  renderer: HTMLRenderer
+): string {
+  const isOrdered = list.tag === 'ordered_list';
+  let num = isOrdered ? (list as OrderedList).start ?? 1 : 0;
+  const lines: string[] = [];
+  for (const item of list.children) {
+    if (item.tag !== 'list_item') continue;
+    const marker = isOrdered ? `${num++}. ` : '— ';
+    lines.push(marker + renderListItemContent(item, renderer));
+  }
+  return lines.join('<br/>');
+}
+
+function renderListItemContent(item: ListItem, renderer: HTMLRenderer): string {
+  const parts: string[] = [];
+  for (const child of item.children) {
+    const rendered = renderConversationBlock(child, renderer);
+    if (rendered) parts.push(rendered);
+  }
+  return parts.join('<br/>');
 }
 
 /**


### PR DESCRIPTION
`extractConversationText` only processed `para` children, so any
`::: prompt` or `::: agent` block whose body was a standalone ordered
or bullet list (e.g. the "Your answers" turn in Strategy 0) rendered
as an empty `<kbd>`/`<samp>` — only the speaker icon was visible.

Flatten `ordered_list` and `bullet_list` children to one marker-prefixed
line per item, separated by `<br/>`, so list turns render as typed text
inside the `<pre>` without introducing block-level list markup.