### PR TITLE
Replace inline-graphic invert filter with a light paper backdrop

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -481,10 +481,13 @@ th {
   height: 5em;
 }
 
-/* Dark mode: boost pencil-on-transparent visibility */
+/* Dark mode: transparent inline graphics need a light "paper" behind them.
+   Inverting the pixels would distort skin tones in drawings of people. */
 @media (prefers-color-scheme: dark) {
   .inline-graphic img {
-    filter: invert(1) hue-rotate(180deg);
+    background: #f5f3f0;
+    padding: 0.6em;
+    border-radius: 2px;
   }
 }
 

--- a/src/styles/pdf.css
+++ b/src/styles/pdf.css
@@ -98,11 +98,7 @@ a {
   color: var(--link);
 }
 
-/* Don't invert images in print */
-.inline-graphic img {
-  filter: none !important;
-}
-
+/* Don't invert callout icons in print */
 .callout-label::before {
   filter: none !important;
 }


### PR DESCRIPTION
Dark mode previously applied `filter: invert(1) hue-rotate(180deg)` to
every transparent inline graphic so the pencil work would show against
the dark page. The side effect was that any drawing of a person had its
skin tones inverted, which is not an acceptable trade-off for a book
whose inline graphics frequently feature characters.

Render a light warm-paper panel (#f5f3f0, matching the site's hero bg
in light mode) behind each inline graphic in dark mode instead. Pencil
stays visible, colors stay true. The now-redundant `filter: none` print
override on `.inline-graphic img` is removed; the callout-icon override
remains because those icons still rely on inversion.

https://claude.ai/code/session_01WazGfUrLHcw7sbR1Lf6XXa