### PR TITLE
Add semantic cross-refs and fix silent djot rendering

### DIFF
--- a/build/filters/callouts.test.ts
+++ b/build/filters/callouts.test.ts
@@ -157,6 +157,22 @@ describe('endnotes', () => {
     expect(html).toContain('aria-label="Back to reference 1"');
   });
 
+  it('renders the backlink inline inside the note paragraph', () => {
+    const dj = 'A claim.[^n1]\n\n[^n1]: Source.';
+    const html = process(dj);
+    // Backlink must be inside the last <p>, not a sibling block after it.
+    expect(html).toMatch(/<a[^>]*epub:type="backlink"[^>]*>\u21a9<\/a><\/p>/);
+    expect(html).not.toMatch(/<\/p>\s*<a[^>]*epub:type="backlink"/);
+  });
+
+  it('prefixes each endnote with its visible number label', () => {
+    const dj = 'A.[^n1] B.[^n2]\n\n[^n1]: First.\n\n[^n2]: Second.';
+    const html = process(dj);
+    // Each note opens with <p><span class="endnote-num">[N]</span> ...
+    expect(html).toMatch(/<p><span class="endnote-num">\[1\]<\/span> First\./);
+    expect(html).toMatch(/<p><span class="endnote-num">\[2\]<\/span> Second\./);
+  });
+
   it('only attaches fnref id to the first reference when a note is cited twice', () => {
     const dj = 'First.[^n1] Second.[^n1]\n\n[^n1]: Source.';
     const html = process(dj);

--- a/build/filters/endnotes.ts
+++ b/build/filters/endnotes.ts
@@ -63,14 +63,6 @@ function sizeToClass(size: string): string {
   }
 }
 
-/** Flatten a heading's inline children to plain text for id generation. */
-function extractHeadingText(node: any): string {
-  if (!node) return '';
-  if (typeof node.text === 'string') return node.text;
-  if (Array.isArray(node.children)) return node.children.map(extractHeadingText).join('');
-  return '';
-}
-
 /** Check if a para contains only a single art span. */
 function isArtPara(node: Para): boolean {
   return (
@@ -202,22 +194,11 @@ export function epubOverrides(
       return `<a epub:type="noteref" role="doc-noteref" href="#en-${escaped}"${idAttr} class="endnote-ref">[${num}]</a>`;
     },
 
+    // Suppress the implicit <section> wrapper djot generates around each
+    // heading. Headings render flat inside the chapter body; the heading
+    // id (set by headingIdsFilter) is the anchor target.
     section: (node: Section, renderer: HTMLRenderer): string => {
-      // Hoist an id onto the first heading so cross-references can link
-      // directly to a skill section. Prefer a code-based slug (e.g. "H-2"
-      // or "Ho-7") extracted from the heading text — that gives stable,
-      // predictable anchors that match the code used in cross-refs.
-      const children = renderer.renderChildren(node);
-      const first = node.children?.[0] as any;
-      if (first?.tag !== 'heading') return children;
-      const headingText = extractHeadingText(first);
-      const codeMatch = headingText.match(/^([A-Za-z]{1,3}-\d+[a-z]?):/);
-      const id = codeMatch ? codeMatch[1].toLowerCase() : undefined;
-      if (!id) return children;
-      const openTag = children.match(/^<h[1-6]/);
-      if (!openTag) return children;
-      const insertAt = openTag[0].length;
-      return children.slice(0, insertAt) + ` id="${escapeHtml(id)}"` + children.slice(insertAt);
+      return renderer.renderChildren(node);
     },
 
     thematic_break: (_node: ThematicBreak, _renderer: HTMLRenderer): string => {

--- a/build/filters/endnotes.ts
+++ b/build/filters/endnotes.ts
@@ -63,6 +63,14 @@ function sizeToClass(size: string): string {
   }
 }
 
+/** Flatten a heading's inline children to plain text for id generation. */
+function extractHeadingText(node: any): string {
+  if (!node) return '';
+  if (typeof node.text === 'string') return node.text;
+  if (Array.isArray(node.children)) return node.children.map(extractHeadingText).join('');
+  return '';
+}
+
 /** Check if a para contains only a single art span. */
 function isArtPara(node: Para): boolean {
   return (
@@ -195,7 +203,21 @@ export function epubOverrides(
     },
 
     section: (node: Section, renderer: HTMLRenderer): string => {
-      return renderer.renderChildren(node);
+      // Hoist an id onto the first heading so cross-references can link
+      // directly to a skill section. Prefer a code-based slug (e.g. "H-2"
+      // or "Ho-7") extracted from the heading text — that gives stable,
+      // predictable anchors that match the code used in cross-refs.
+      const children = renderer.renderChildren(node);
+      const first = node.children?.[0] as any;
+      if (first?.tag !== 'heading') return children;
+      const headingText = extractHeadingText(first);
+      const codeMatch = headingText.match(/^([A-Za-z]{1,3}-\d+[a-z]?):/);
+      const id = codeMatch ? codeMatch[1].toLowerCase() : undefined;
+      if (!id) return children;
+      const openTag = children.match(/^<h[1-6]/);
+      if (!openTag) return children;
+      const insertAt = openTag[0].length;
+      return children.slice(0, insertAt) + ` id="${escapeHtml(id)}"` + children.slice(insertAt);
     },
 
     thematic_break: (_node: ThematicBreak, _renderer: HTMLRenderer): string => {
@@ -279,12 +301,30 @@ export function renderNotesSection(
     };
     const content = renderHTML(tempDoc);
     const escaped = escapeHtml(label);
+    const numLabel = `<span class="endnote-num">[${num}]</span> `;
     const backlink =
       `<a epub:type="backlink" role="doc-backlink" class="endnote-backlink" ` +
       `href="#fnref-${escaped}" aria-label="Back to reference ${num}">\u21a9</a>`;
 
+    // Inject the visible number label inside the first paragraph and the
+    // backlink inside the last — both inline so they flow with the prose
+    // instead of sitting on their own lines.
+    let rendered = content;
+    const openPMatch = rendered.match(/<p(\s[^>]*)?>/);
+    if (openPMatch && openPMatch.index != null) {
+      const insertAt = openPMatch.index + openPMatch[0].length;
+      rendered = rendered.slice(0, insertAt) + numLabel + rendered.slice(insertAt);
+    } else {
+      rendered = numLabel + rendered;
+    }
+    const lastPIdx = rendered.lastIndexOf('</p>');
+    rendered =
+      lastPIdx >= 0
+        ? rendered.slice(0, lastPIdx) + backlink + rendered.slice(lastPIdx)
+        : rendered.replace(/\s+$/, '') + backlink;
+
     notes.push(
-      `<aside epub:type="endnote" role="doc-endnote" id="en-${escaped}" class="endnote">\n${content}${backlink}\n</aside>`
+      `<aside epub:type="endnote" role="doc-endnote" id="en-${escaped}" class="endnote">\n${rendered}</aside>`
     );
   }
 

--- a/build/filters/ref-links.test.ts
+++ b/build/filters/ref-links.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { parse, renderHTML, applyFilter } from '@djot/djot';
+import { buildRefRegistry, refLinksFilter } from './ref-links.js';
+import type { RefWarning } from './ref-links.js';
+
+const render = (dj: string, opts: {
+  registry?: ReturnType<typeof buildRefRegistry>;
+  warnings?: RefWarning[];
+  sourceFile?: string;
+} = {}): string => {
+  const doc = parse(dj);
+  if (opts.registry) {
+    applyFilter(doc, refLinksFilter(opts.registry, opts.warnings ?? [], opts.sourceFile));
+  }
+  return renderHTML(doc);
+};
+
+describe('ref-links filter', () => {
+  it('builds a registry from heading codes across chapters', () => {
+    const registry = buildRefRegistry([
+      { slug: '01-health', content: '#### H-2: Preparing Questions\n\nBody.\n' },
+      { slug: '05-life', content: '#### Li-1: Difficult Conversations\n\nBody.\n' },
+      { slug: '09-irl-interactions', content: '#### IRL-1: Government Offices\n\nBody.\n' },
+    ]);
+    expect(registry.size).toBe(3);
+    expect(registry.get('h-2')).toEqual({ slug: '01-health', anchor: 'h-2' });
+    expect(registry.get('li-1')).toEqual({ slug: '05-life', anchor: 'li-1' });
+    expect(registry.get('irl-1')).toEqual({ slug: '09-irl-interactions', anchor: 'irl-1' });
+  });
+
+  it('rewrites ref: links to concrete chapter anchors', () => {
+    const registry = buildRefRegistry([
+      { slug: '01-health', content: '#### H-2: Preparing Questions\n\nBody.\n' },
+    ]);
+    const html = render('See [H-2](ref:h-2) for prep.', { registry });
+    expect(html).toContain('href="01-health.xhtml#h-2"');
+    expect(html).not.toContain('ref:h-2');
+  });
+
+  it('strips unresolved refs to plain text and collects a warning', () => {
+    const registry = buildRefRegistry([]);
+    const warnings: RefWarning[] = [];
+    const html = render('See [Cr-4 (Writing a Book)](ref:cr-4) for craft.', {
+      registry,
+      warnings,
+      sourceFile: 'test.dj',
+    });
+    expect(html).not.toContain('href');
+    expect(html).not.toContain('ref:cr-4');
+    expect(html).toContain('Cr-4 (Writing a Book)');
+    expect(warnings).toEqual([{ tag: 'cr-4', sourceFile: 'test.dj' }]);
+  });
+
+  it('leaves non-ref links untouched', () => {
+    const registry = buildRefRegistry([]);
+    const html = render('See [docs](https://example.com/docs).', { registry });
+    expect(html).toContain('href="https://example.com/docs"');
+  });
+});

--- a/build/filters/ref-links.ts
+++ b/build/filters/ref-links.ts
@@ -76,6 +76,25 @@ type FilterPart = Record<string, Transform>;
 type Filter = () => FilterPart | FilterPart[];
 
 /**
+ * Djot filter that assigns `id="<code>"` to headings whose text starts with
+ * a code prefix like `H-2:` or `Ho-7:`. Runs before render so the standard
+ * djot renderer emits the id naturally — no string hoisting required.
+ * Preserves any id already set by explicit djot `{#id}` attributes.
+ */
+export function headingIdsFilter(): Filter {
+  return () => ({
+    heading: (node: any): void => {
+      const text = extractText(node);
+      const m = text.match(/^([A-Za-z]{1,3}-\d+[a-z]?):/);
+      if (!m) return;
+      if (!node.attributes) node.attributes = {};
+      if (node.attributes.id) return;
+      node.attributes.id = m[1].toLowerCase();
+    },
+  });
+}
+
+/**
  * Djot filter that rewrites `ref:` URLs to concrete chapter anchors.
  * Emits warnings into the supplied array; unresolved links are replaced
  * by their text content so the reader still sees something sensible.
@@ -89,7 +108,7 @@ export function refLinksFilter(
     link: (node: any): void | AstNode[] => {
       const dest: unknown = node.destination;
       if (typeof dest !== 'string' || !dest.startsWith('ref:')) return;
-      const tag = dest.slice('ref:'.length);
+      const tag = dest.slice('ref:'.length).toLowerCase();
       const target = registry.get(tag);
       if (target) {
         node.destination = `${target.slug}.xhtml#${target.anchor}`;

--- a/build/filters/ref-links.ts
+++ b/build/filters/ref-links.ts
@@ -1,0 +1,102 @@
+import { parse } from '@djot/djot';
+import type { AstNode } from '@djot/djot';
+
+/**
+ * AppleRef-style semantic cross-reference system.
+ *
+ * Source writes links with a `ref:` URL scheme — e.g. `[H-2](ref:h-2)`.
+ * A pre-render pass scans every chapter for heading codes (`H-2`, `Ho-7`,
+ * `IRL-1`, …) and builds a registry mapping `code → {slug, anchor}`. At
+ * render time, a filter rewrites every `ref:` link to a concrete
+ * `slug.xhtml#anchor` URL. Unresolved refs emit a warning and degrade to
+ * plain text (link unwrapped, label kept) rather than shipping a dead
+ * anchor.
+ */
+
+export interface RefTarget {
+  slug: string;
+  anchor: string;
+}
+
+export type RefRegistry = Map<string, RefTarget>;
+
+export interface RefWarning {
+  tag: string;
+  sourceFile?: string;
+}
+
+/**
+ * Walk an AST visiting every node.
+ */
+function walk(node: any, visit: (n: any) => void): void {
+  visit(node);
+  if (Array.isArray(node.children)) node.children.forEach((c: any) => walk(c, visit));
+}
+
+function extractText(node: any): string {
+  if (!node) return '';
+  if (typeof node.text === 'string') return node.text;
+  if (Array.isArray(node.children)) return node.children.map(extractText).join('');
+  return '';
+}
+
+/**
+ * Scan every chapter's djot source for heading codes and build the registry.
+ * The anchor id matches the lowercase code, mirroring the id hoisted onto
+ * headings by the section renderer override.
+ */
+export function buildRefRegistry(
+  chapters: Array<{ slug: string; content: string }>
+): RefRegistry {
+  const registry: RefRegistry = new Map();
+  for (const { slug, content } of chapters) {
+    const doc = parse(content) as any;
+    walk(doc, (n) => {
+      if (n.tag !== 'section') return;
+      const first = n.children?.[0];
+      if (first?.tag !== 'heading') return;
+      const text = extractText(first);
+      const m = text.match(/^([A-Za-z]{1,3}-\d+[a-z]?):/);
+      if (!m) return;
+      const code = m[1].toLowerCase();
+      const existing = registry.get(code);
+      if (existing && existing.slug !== slug) {
+        console.warn(
+          `[ref] duplicate code "${code}" — already registered in ${existing.slug}, now also in ${slug}`
+        );
+      }
+      registry.set(code, { slug, anchor: code });
+    });
+  }
+  return registry;
+}
+
+type Transform = (node: any) => void | AstNode | AstNode[];
+type FilterPart = Record<string, Transform>;
+type Filter = () => FilterPart | FilterPart[];
+
+/**
+ * Djot filter that rewrites `ref:` URLs to concrete chapter anchors.
+ * Emits warnings into the supplied array; unresolved links are replaced
+ * by their text content so the reader still sees something sensible.
+ */
+export function refLinksFilter(
+  registry: RefRegistry,
+  warnings: RefWarning[],
+  sourceFile?: string
+): Filter {
+  return () => ({
+    link: (node: any): void | AstNode[] => {
+      const dest: unknown = node.destination;
+      if (typeof dest !== 'string' || !dest.startsWith('ref:')) return;
+      const tag = dest.slice('ref:'.length);
+      const target = registry.get(tag);
+      if (target) {
+        node.destination = `${target.slug}.xhtml#${target.anchor}`;
+        return;
+      }
+      warnings.push({ tag, sourceFile });
+      return Array.isArray(node.children) ? node.children : [];
+    },
+  });
+}

--- a/build/index.ts
+++ b/build/index.ts
@@ -13,7 +13,7 @@ import {
   discoverBriefs,
   prepareArtContext,
   discoverChapters,
-  processChapter,
+  processChapterFromSource,
   parseSlug,
   sortChapters,
   optimizeImages,
@@ -80,24 +80,32 @@ async function build(): Promise<void> {
   const files = await discoverChapters();
   console.log(`Found ${files.length} chapter files`);
 
-  // Build the cross-reference registry from every chapter's heading codes
-  // before rendering any of them, so that `ref:code` links can resolve
-  // across chapter boundaries.
-  console.log('Building ref registry...');
-  const chapterSources = await Promise.all(
-    files.map(async (f) => {
-      const raw = await readFile(f, 'utf-8');
-      const { content } = matter(raw);
-      return { slug: parseSlug(f), content };
-    })
+  // Read each source file once. The raw content feeds both the
+  // cross-reference registry pass (which scans heading codes) and the
+  // per-chapter render pass below.
+  const sources = await Promise.all(
+    files.map(async (filePath) => ({
+      filePath,
+      raw: await readFile(filePath, 'utf-8'),
+    }))
   );
-  const refRegistry = buildRefRegistry(chapterSources);
+
+  console.log('Building ref registry...');
+  const refRegistry = buildRefRegistry(
+    sources.map(({ filePath, raw }) => ({
+      slug: parseSlug(filePath),
+      content: matter(raw).content,
+    }))
+  );
   const refWarnings: RefWarning[] = [];
   console.log(`Registered ${refRegistry.size} ref target(s)`);
 
   console.log('Processing chapters...');
-  const chapters = await Promise.all(
-    files.map((f) => processChapter(f, artCtx, { registry: refRegistry, warnings: refWarnings }))
+  const chapters = sources.map(({ filePath, raw }) =>
+    processChapterFromSource(filePath, raw, artCtx, {
+      registry: refRegistry,
+      warnings: refWarnings,
+    })
   );
   const sorted = sortChapters(chapters);
 

--- a/build/index.ts
+++ b/build/index.ts
@@ -1,6 +1,8 @@
 import 'dotenv/config';
 import { accessSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import matter from 'gray-matter';
 import {
   ROOT,
   CONTENT_DIR,
@@ -12,10 +14,12 @@ import {
   prepareArtContext,
   discoverChapters,
   processChapter,
+  parseSlug,
   sortChapters,
   optimizeImages,
+  buildRefRegistry,
 } from './pipeline.js';
-import type { ArtBrief } from './pipeline.js';
+import type { ArtBrief, RefWarning } from './pipeline.js';
 import { assembleEpub } from './epub/assemble.js';
 import { generateMissingArt } from './generate-art.js';
 import { BOOK_META } from './types.js';
@@ -76,11 +80,33 @@ async function build(): Promise<void> {
   const files = await discoverChapters();
   console.log(`Found ${files.length} chapter files`);
 
+  // Build the cross-reference registry from every chapter's heading codes
+  // before rendering any of them, so that `ref:code` links can resolve
+  // across chapter boundaries.
+  console.log('Building ref registry...');
+  const chapterSources = await Promise.all(
+    files.map(async (f) => {
+      const raw = await readFile(f, 'utf-8');
+      const { content } = matter(raw);
+      return { slug: parseSlug(f), content };
+    })
+  );
+  const refRegistry = buildRefRegistry(chapterSources);
+  const refWarnings: RefWarning[] = [];
+  console.log(`Registered ${refRegistry.size} ref target(s)`);
+
   console.log('Processing chapters...');
   const chapters = await Promise.all(
-    files.map((f) => processChapter(f, artCtx))
+    files.map((f) => processChapter(f, artCtx, { registry: refRegistry, warnings: refWarnings }))
   );
   const sorted = sortChapters(chapters);
+
+  if (refWarnings.length > 0) {
+    console.warn(`\n${refWarnings.length} unresolved ref(s):`);
+    for (const w of refWarnings) {
+      console.warn(`  ref:${w.tag}${w.sourceFile ? ` in ${w.sourceFile}` : ''}`);
+    }
+  }
 
   // Fail the build if any declared accessibility feature is not satisfied.
   // The ePub OPF claims WCAG 2.0 AA; shipping a book that does not meet its

--- a/build/pipeline.ts
+++ b/build/pipeline.ts
@@ -11,6 +11,7 @@ import { EndnoteState, epubOverrides, renderNotesSection } from './filters/endno
 import {
   buildRefRegistry,
   refLinksFilter,
+  headingIdsFilter,
 } from './filters/ref-links.js';
 import type { RefRegistry, RefWarning } from './filters/ref-links.js';
 import type { ChapterMeta, ProcessedChapter } from './types.js';
@@ -123,6 +124,7 @@ export function processContent(
 
   applyFilter(doc, calloutFilter);
   applyFilter(doc, conversationFilter);
+  applyFilter(doc, headingIdsFilter());
   if (opts.refRegistry && opts.refWarnings) {
     applyFilter(
       doc,
@@ -161,12 +163,17 @@ export function parseSlug(filePath: string): string {
   return name;
 }
 
-export async function processChapter(
+/**
+ * Process a chapter from already-read raw source. Used by the ePub build
+ * to avoid reading each file twice (once for the ref registry, once for
+ * rendering); see `processChapter` for the file-reading wrapper.
+ */
+export function processChapterFromSource(
   filePath: string,
+  raw: string,
   artCtx: ArtBriefContext,
   refCtx?: { registry: RefRegistry; warnings: RefWarning[] }
-): Promise<ProcessedChapter> {
-  const raw = await readFile(filePath, 'utf-8');
+): ProcessedChapter {
   const { data, content } = matter(raw);
 
   const meta: ChapterMeta = {
@@ -196,6 +203,15 @@ export async function processChapter(
   }
 
   return { meta, html, endnotes: [] };
+}
+
+export async function processChapter(
+  filePath: string,
+  artCtx: ArtBriefContext,
+  refCtx?: { registry: RefRegistry; warnings: RefWarning[] }
+): Promise<ProcessedChapter> {
+  const raw = await readFile(filePath, 'utf-8');
+  return processChapterFromSource(filePath, raw, artCtx, refCtx);
 }
 
 export function sortChapters(chapters: ProcessedChapter[]): ProcessedChapter[] {

--- a/build/pipeline.ts
+++ b/build/pipeline.ts
@@ -8,6 +8,11 @@ import { discoverBriefs } from './filters/art-briefs.js';
 import type { ArtBrief, ArtBriefContext } from './filters/art-briefs.js';
 import { conversationFilter } from './filters/conversations.js';
 import { EndnoteState, epubOverrides, renderNotesSection } from './filters/endnotes.js';
+import {
+  buildRefRegistry,
+  refLinksFilter,
+} from './filters/ref-links.js';
+import type { RefRegistry, RefWarning } from './filters/ref-links.js';
 import type { ChapterMeta, ProcessedChapter } from './types.js';
 import { BOOK_META } from './types.js';
 import { embedXmp, readXmp, xmpMatches } from './xmp.js';
@@ -26,8 +31,8 @@ export const STYLE_GUIDE = join(
   'gem-illustration-instructions.md'
 );
 
-export { discoverBriefs };
-export type { ArtBrief };
+export { discoverBriefs, buildRefRegistry };
+export type { ArtBrief, RefRegistry, RefWarning };
 
 /** Resolve the XMP fields for a brief, applying the book-level default rights. */
 export function xmpFieldsFor(brief: ArtBrief): XmpFields {
@@ -103,10 +108,13 @@ export async function syncArtBriefXmp(
 
 /**
  * Process Djot content through the full filter pipeline and render to HTML.
+ * If a ref registry is provided, `ref:` cross-reference links are resolved
+ * to concrete chapter anchors (unresolved refs are dropped with a warning).
  */
 export function processContent(
   content: string,
-  artCtx: ArtBriefContext
+  artCtx: ArtBriefContext,
+  opts: { refRegistry?: RefRegistry; refWarnings?: RefWarning[]; sourceFile?: string } = {}
 ): string {
   // Strip HTML comments (editorial notes like RESEARCH NEEDED)
   const cleaned = content.replace(/<!--[\s\S]*?-->/g, '');
@@ -115,6 +123,12 @@ export function processContent(
 
   applyFilter(doc, calloutFilter);
   applyFilter(doc, conversationFilter);
+  if (opts.refRegistry && opts.refWarnings) {
+    applyFilter(
+      doc,
+      refLinksFilter(opts.refRegistry, opts.refWarnings, opts.sourceFile)
+    );
+  }
 
   // Render HTML with epub overrides (handles art briefs, callouts,
   // conversations, endnotes, sections, and XHTML self-closing tags)
@@ -149,7 +163,8 @@ export function parseSlug(filePath: string): string {
 
 export async function processChapter(
   filePath: string,
-  artCtx: ArtBriefContext
+  artCtx: ArtBriefContext,
+  refCtx?: { registry: RefRegistry; warnings: RefWarning[] }
 ): Promise<ProcessedChapter> {
   const raw = await readFile(filePath, 'utf-8');
   const { data, content } = matter(raw);
@@ -164,7 +179,11 @@ export async function processChapter(
     sourceFile: filePath,
   };
 
-  let html = processContent(content, artCtx);
+  let html = processContent(content, artCtx, {
+    refRegistry: refCtx?.registry,
+    refWarnings: refCtx?.warnings,
+    sourceFile: filePath,
+  });
 
   // Strip the first heading if it duplicates the frontmatter title.
   if (meta.title) {

--- a/src/content/01-strategies/00-strategy-0-specify/index.dj
+++ b/src/content/01-strategies/00-strategy-0-specify/index.dj
@@ -30,38 +30,32 @@ Every strategy in this book begins here. Before your Agent can Decode, Draft, Na
 
 The insight that makes this book work: *you do not have to write the spec.* Your Agent will interview you into one. Your job is to answer its questions honestly and tell it when the spec it proposes doesn't accurately reflect your situation. That is a human skill you already have. You know your own situation. You just needed someone to ask the right questions.
 
-_In the Field Guide: every Skill begins with a Strategy 0 specification interview. Skills using the Expert Role variant include [Ho-7: Gardening & Landscaping](04-home.xhtml), [Ch-9: Pet Care and Training](08-chores.xhtml), [Tr-2: Car Maintenance](99-transportation.xhtml), and [H-8: Wellness and Nutrition Coach](01-health.xhtml)._
+_In the Field Guide: every Skill begins with a Strategy 0 specification interview. Skills using the Expert Role variant include [Ho-7: Gardening & Landscaping](ref:ho-7), [Ch-9: Pet Care and Training](ref:ch-9), [Tr-2: Car Maintenance](ref:tr-2), and [H-8: Wellness and Nutrition Coach](ref:h-8)._
 
 ### The Specification Interview Loop
 
 Here is the full loop, annotated. This is what every `[SPEC]` sidebar in this book is showing you.
 
 ::: spec
-STEP 1: Describe your situation loosely.
+1. Describe your situation loosely.
 Don't worry about being precise. Just say what's going on.
-
-STEP 2: Your Agent asks clarifying questions.
+2. Your Agent asks clarifying questions.
 Usually three to five. Answer them honestly.
 If you don't know the answer to one, say so.
-
-STEP 3: Your Agent proposes a specification.
+3. Your Agent proposes a specification.
 It will say something like: "Based on what you've told me,
 here is what I understand you need..." followed by a clear,
 structured description of the task.
-
-STEP 4: You review the spec.
+4. You review the spec.
 Ask yourself: does this accurately describe my situation?
 Does it include everything that matters?
 Does it leave out anything important?
-
-STEP 5: You correct anything that's wrong.
+5. You correct anything that's wrong.
 One or two corrections is normal. More than that means
 step back and re-describe the situation — something
 important didn't come through.
-
-STEP 6: Your Agent executes against the confirmed spec.
-
-STEP 7: You evaluate the output.
+6. Your Agent executes against the confirmed spec.
+7. You evaluate the output.
 If it's not right, the spec was incomplete.
 Ask: "What did I not tell you that would have changed this answer?"
 That question surfaces the missing piece.

--- a/src/content/01-strategies/01-strategy-1-decode/index.dj
+++ b/src/content/01-strategies/01-strategy-1-decode/index.dj
@@ -72,13 +72,14 @@ Legal boilerplate is written at a 16th-grade reading level on average — four g
 
 The hardest part of Decode is not the skill. It is the habit. The next time you receive a document from an institution — any document, any institution — paste it into your Agent before you do anything else. Before you sign. Before you pay. Before you panic. Before you throw it on the pile. Paste it. Ask what it says. That is the entire strategy.
 
-_In the Field Guide: H-3 (Medical Bills), L-1 (Contracts), C-4 (Ballot Measures), Ho-5 (Utility Bills), M-3 (Mortgages)._
+_In the Field Guide: [H-3 (Medical Bills)](ref:h-3), [L-1 (Contracts)](ref:l-1), [C-4 (Ballot Measures)](ref:c-4), [Ho-5 (Utility Bills)](ref:ho-5), [M-3 (Mortgages)](ref:m-3)._
 
 ### Example 1: An Insurance EOB After a Doctor's Visit
 
 The situation: you had blood work done at your annual physical. Three weeks later, an Explanation of Benefits arrives. It has procedure codes, columns labeled "amount billed," "plan discount," "plan paid," and "your responsibility." One number says $347. You don't know if you owe $347 or not. The document is designed to explain your benefits. It does not explain your benefits.
 
 *Your opening message:*
+
 ::: prompt
 I got this EOB from my insurance and I can't tell if I
 owe money. Here's what it says:
@@ -98,6 +99,7 @@ from your provider."
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 Good instinct to check — EOBs are designed to confuse.
 Let me clarify a couple things:
@@ -110,6 +112,7 @@ Let me clarify a couple things:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. Yes, I paid a $30 copay at the office.
 2. Not yet. Just this EOB.
@@ -117,6 +120,7 @@ Let me clarify a couple things:
 :::
 
 *Your Agent decodes:*
+
 ::: agent
 Here's what this EOB actually says:
 
@@ -154,12 +158,14 @@ should.
 :::
 
 *Your follow-up:*
+
 ::: prompt
 Wait — so the $347 was never real? Why does it even
 show that number?
 :::
 
 *Your Agent:*
+
 ::: agent
 The $347 is the "chargemaster" rate — the provider's
 list price before any insurance negotiation. Almost
@@ -191,6 +197,7 @@ When pasting an EOB, you can type the key fields (as above) or take a photo. Cla
 The situation: your landlord sent your lease renewal. You've been here two years, you like the apartment, and you're inclined to sign. The rent went up $75/month — annoying but expected. But there's a new section on page 4 that wasn't in your original lease. It's three paragraphs of dense legal text under the heading "Early Termination."
 
 *Your opening message:*
+
 ::: prompt
 My landlord sent a lease renewal. There's a new clause
 I don't remember from the original lease. Can you tell
@@ -210,6 +217,7 @@ termination of this Lease."
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 This is worth reading carefully. A few questions:
 
@@ -223,6 +231,7 @@ This is worth reading carefully. A few questions:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. No, the original lease just said I needed to give
    30 days notice if I wasn't renewing. Nothing about
@@ -232,6 +241,7 @@ This is worth reading carefully. A few questions:
 :::
 
 *Your Agent decodes:*
+
 ::: agent
 Here's what this clause actually says, line by line:
 
@@ -307,6 +317,7 @@ Contract comprehension research consistently shows that readers focus on the ter
 The situation: it's October. Your ballot arrived. There's a local measure — Measure H — that's been all over yard signs and mailers. The campaign for it says "Protect Our Neighborhoods." The campaign against it says "Stop the Housing Ban." You have no idea what it actually does. The official text is 1,400 words of legal language. You want to vote. You want to vote correctly.
 
 *Your opening message:*
+
 ::: prompt
 I'm trying to understand Measure H on my ballot.
 Here's the official summary from the voter guide:
@@ -324,6 +335,7 @@ What does this actually do?
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 Good question — the official text is doing a lot of
 work to sound neutral. Let me ask:
@@ -335,6 +347,7 @@ work to sound neutral. Let me ask:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. [City name], California.
 2. I rent.
@@ -343,6 +356,7 @@ work to sound neutral. Let me ask:
 :::
 
 *Your Agent decodes:*
+
 ::: agent
 Here's what Measure H actually does:
 
@@ -404,12 +418,14 @@ Future renters and the regional housing supply.
 :::
 
 *Your follow-up:*
+
 ::: prompt
 The mailer I got says it "protects against predatory
 developers." Is that real?
 :::
 
 *Your Agent:*
+
 ::: agent
 "Predatory developer" is a framing choice, not a
 legal term. The measure does not define it, regulate it,

--- a/src/content/01-strategies/02-strategy-2-prepare/index.dj
+++ b/src/content/01-strategies/02-strategy-2-prepare/index.dj
@@ -48,7 +48,7 @@ Patients who arrive at medical appointments with written questions report higher
 
 Preparation does not require expertise. It requires ten minutes and a list. The doctor, the HR director, and the contractor all expect you to show up without one. The list is what changes the power dynamic in the room. Every example in this chapter follows the same pattern: tell your Agent what's coming, answer its clarifying questions, and walk in with a list on your phone. That is the entire strategy.
 
-_In the Field Guide: H-2 (Doctor's Appointments), Li-1 (Difficult Conversations), IRL-1 (Government Offices), IRL-2 (Customer Service), Tr-4 (Air Travel)._
+_In the Field Guide: [H-2 (Doctor's Appointments)](ref:h-2), [Li-1 (Difficult Conversations)](ref:li-1), [IRL-1 (Government Offices)](ref:irl-1), [IRL-2 (Customer Service)](ref:irl-2), [Tr-4 (Air Travel)](ref:tr-4)._
 
 ::: tip
 For high-stakes appointments — medical, legal, financial — end your preparation spec with: "Give me the most conservative framing. I will verify everything with the professional." This ensures the question list helps you ask, not conclude.
@@ -60,6 +60,7 @@ For high-stakes appointments — medical, legal, financial — end your preparat
 The situation: your primary care doctor called about your blood work. Something is elevated. She's referring you to an oncologist. The appointment is in ten days. You don't know what to ask, what the blood work means, or what the appointment will involve. You're scared, and the fear is making it harder to think, not easier.
 
 *Your opening message:*
+
 ::: prompt
 My doctor is referring me to an oncologist because
 something in my blood work is elevated. The appointment
@@ -77,6 +78,7 @@ everything with the oncologist.
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 I understand this is stressful. Let me help you walk
 into that appointment prepared. A few questions first:
@@ -96,6 +98,7 @@ into that appointment prepared. A few questions first:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. She said elevated LDH can mean a lot of things —
    liver issues, infection, or something more serious.
@@ -110,6 +113,7 @@ into that appointment prepared. A few questions first:
 :::
 
 *Your Agent prepares you:*
+
 ::: agent
 Here's your preparation kit. Save this to your phone.
 
@@ -172,6 +176,7 @@ answered.
 :::
 
 *Your follow-up:*
+
 ::: prompt
 What if they want to schedule something right away,
 like a biopsy? How do I know if I should say yes
@@ -179,6 +184,7 @@ on the spot?
 :::
 
 *Your Agent:*
+
 ::: agent
 You don't have to decide anything in the room. The
 sentence is: "I'd like to understand the full picture
@@ -215,6 +221,7 @@ The phrase "I'd like to understand the full picture before I schedule anything" 
 The situation: you've been at your job for two years. Your annual review is next week. You've been told informally that "it went well" — but nobody has mentioned a raise, and you're making $12,000 less than market rate for your role. You've never negotiated salary before. The thought makes you nauseous.
 
 *Your opening message:*
+
 ::: prompt
 I have my annual performance review next Tuesday and
 I want to ask for a raise. I've been here 2 years,
@@ -233,6 +240,7 @@ Details:
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 This is exactly the kind of conversation that
 preparation changes completely. A few questions:
@@ -254,6 +262,7 @@ preparation changes completely. A few questions:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. I looked on Glassdoor and it says $72,000-78,000
    for Marketing Coordinator in Denver. So I'm about
@@ -273,6 +282,7 @@ preparation changes completely. A few questions:
 :::
 
 *Your Agent prepares you:*
+
 ::: agent
 Here's your preparation for Tuesday. Practice saying
 these out loud once — not to memorize, but so the
@@ -358,6 +368,7 @@ This turns a no into a documented roadmap.
 :::
 
 *Your follow-up:*
+
 ::: prompt
 I'm worried that if I ask for a raise right after a
 good review it'll seem like I'm only in it for the
@@ -365,6 +376,7 @@ money. Is that a real concern?
 :::
 
 *Your Agent:*
+
 ::: agent
 No. The annual review exists for this conversation.
 This is the institutionally designated time to discuss
@@ -391,6 +403,7 @@ Salary negotiation research consistently shows that employees who negotiate rece
 The situation: your kitchen faucet has been leaking for a month. You called a plumber. He's coming Thursday for a "walkthrough and estimate." You have no idea what a reasonable price is, what questions to ask, or how to tell if he's recommending work you don't need. Your last contractor experience ended with a $3,000 bill for what turned out to be a $400 repair.
 
 *Your opening message:*
+
 ::: prompt
 A plumber is coming Thursday to look at my leaking
 kitchen faucet and give me an estimate. Last time I
@@ -408,6 +421,7 @@ Here's what I know:
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 Good — getting prepared before the plumber arrives
 saves money directly. A few questions:
@@ -427,6 +441,7 @@ saves money directly. A few questions:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. I'll check — I think it says Moen on the front.
 2. Just the spout.
@@ -438,6 +453,7 @@ saves money directly. A few questions:
 :::
 
 *Your Agent prepares you:*
+
 ::: agent
 Here's your preparation for Thursday.
 
@@ -512,12 +528,14 @@ rent deduction, you want a paper trail.
 :::
 
 *Your follow-up:*
+
 ::: prompt
 What if he says the whole faucet needs replacing and
 quotes me $800? How do I push back without being rude?
 :::
 
 *Your Agent:*
+
 ::: agent
 You don't push back. You ask questions. The questions
 do the work.

--- a/src/content/01-strategies/03-strategy-3-draft/index.dj
+++ b/src/content/01-strategies/03-strategy-3-draft/index.dj
@@ -50,7 +50,7 @@ Bluma Zeigarnik's 1927 research established that the brain actively maintains in
 
 [^s3-1]: Zeigarnik, B. (1927). "Über das Behalten von erledigten und unerledigten Handlungen." _Psychologische Forschung_, 9, 1-85. Masicampo, E.J. & Baumeister, R.F. (2011). "Consider it done! Plan making can eliminate the cognitive effects of unfulfilled goals." _JPSP_, 101(4), 667-683.
 
-_In the Field Guide: H-4 (Insurance Appeals), Li-2 (Eulogies), C-5 (Public Comments), L-3 (Demand Letters), W-1 (Job Search)._
+_In the Field Guide: [H-4 (Insurance Appeals)](ref:h-4), [Li-2 (Eulogies)](ref:li-2), [C-5 (Public Comments)](ref:c-5), [L-3 (Demand Letters)](ref:l-3), [W-1 (Job Search)](ref:w-1)._
 
 *Worked examples:* A demand letter to a landlord. A Medicare denial appeal. A public comment for a city council meeting.
 
@@ -61,6 +61,7 @@ In Strategy 1: Decode, you found a new early termination clause buried in your l
 This is the gap Draft closes. You have the analysis. You have the position. You do not have the first sentence. The first sentence is the most expensive part of the email---not because it's hard to write, but because the blank screen turns "I know what I want to say" into "I don't know how to start." Your Agent writes the first sentence. You write everything after that.
 
 *Your opening message:*
+
 ::: prompt
 In my last conversation with you, we decoded an early
 termination clause in my lease renewal. You flagged the
@@ -77,6 +78,7 @@ leave. I'm proposing changes that make the clause fair.
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 I can draft that. A few things will make the email
 land better:
@@ -96,6 +98,7 @@ land better:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. Firm but not hostile. I want them to take it
    seriously but I don't want to blow up the
@@ -115,6 +118,7 @@ land better:
 :::
 
 *Your Agent drafts:*
+
 ::: agent
 Here's a draft. Read it, change anything that doesn't
 sound like you, and don't send it until it does.
@@ -175,6 +179,7 @@ yours.
 :::
 
 *Your follow-up:*
+
 ::: prompt
 This is good but it sounds too formal. I usually just
 text my landlord. Can you make it more casual but keep
@@ -182,6 +187,7 @@ the substance?
 :::
 
 *Your Agent:*
+
 ::: agent
 Here's a casual version. Same substance, different
 register.
@@ -240,6 +246,7 @@ In Strategy 0: Specify, you decoded an insurance denial---an MRI your doctor ord
 You have been fighting this for weeks. The first appeal felt like filling out a form---follow the steps, attach the letter, submit. This one is different. The external appeal goes to an independent medical reviewer, not customer service. It is a formal document with real requirements and a real audience: a physician who will read your case and decide whether the denial stands. The blank page is harder this time because the stakes are higher, the format is less familiar, and you have already been told no twice.
 
 *Your opening message:*
+
 ::: prompt
 My internal appeal for the MRI was denied. Second denial
 says the same thing---"not medically necessary"---but
@@ -253,6 +260,7 @@ draft it?
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 I can help you draft that. I need to understand exactly
 what you're working with:
@@ -273,6 +281,7 @@ what you're working with:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. Same reason: "not medically necessary." Then it says
    "The documentation provided does not support medical
@@ -291,6 +300,7 @@ what you're working with:
 :::
 
 *Your Agent drafts the appeal letter:*
+
 ::: agent
 Here's the appeal letter. It's addressed to the external
 review organization. Read it carefully---every claim in
@@ -399,12 +409,14 @@ date it was received. Keep copies of everything you send.
 :::
 
 *Your follow-up:*
+
 ::: prompt
 This is really long. Will someone actually read all of
 this?
 :::
 
 *Your Agent:*
+
 ::: agent
 Yes. The external reviewer is a physician. They read
 dozens of these. They are looking for three things:
@@ -447,11 +459,13 @@ The appeal letter that wins is written at a level most patients cannot produce w
 In Strategy 1: Decode, you translated Measure H---a zoning downzone that would reduce housing supply in your neighborhood. You learned what it actually does: caps density at eight units per acre, requires conditional use permits for four or more units, and limits height to 35 feet in R-3 zones within 500 feet of single-family areas. You learned that "predatory developer" is campaign language, not a legal term. You learned the measure protects existing homeowners at the expense of future renters and housing supply. Now your city council is holding a public hearing before the vote. You have two minutes at the microphone. You've never spoken at a public hearing. You know what you think---the measure hurts renters---but you cannot get past the first sentence. The room will be full. A timer will count down. Your name and address go on the public record. Knowing the policy is one skill. Saying it out loud to a row of council members is a different one.
 
 *Your opening message:*
+
 ::: prompt
 Remember when we decoded Measure H---the zoning downzone on my ballot? The city council is holding a public hearing on it next Tuesday. I want to speak against it. I have two minutes. I've never spoken at a public hearing before. I don't want to sound like a policy wonk---I want to sound like a person who lives there.
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 I remember the Measure H analysis. Good---you already know the substance. Now we need to turn that into something you can say out loud under pressure. A few questions before I draft:
 
@@ -467,6 +481,7 @@ I remember the Measure H analysis. Good---you already know the substance. Now we
 :::
 
 *Your answers:*
+
 ::: prompt
 Yes, renter in an R-3 zone. Four years in my apartment. This neighborhood is where I want to stay long-term.
 
@@ -480,6 +495,7 @@ Not sure if anyone else is going. I don't know anyone else planning to speak aga
 :::
 
 *Your Agent drafts:*
+
 ::: agent
 Here's a two-minute comment written for speaking, not reading. Practice it once out loud---time yourself. If it runs over 1:45, we'll cut.
 
@@ -503,11 +519,13 @@ This runs about a minute. You have margin. Do not fill it---short and clear beat
 :::
 
 *Your follow-up:*
+
 ::: prompt
 This sounds like a policy paper. I want to sound like a person who lives in the neighborhood, not someone who studied zoning law.
 :::
 
 *Your Agent:*
+
 ::: agent
 Fair. Here's the revision.
 

--- a/src/content/01-strategies/04-strategy-4-navigate/index.dj
+++ b/src/content/01-strategies/04-strategy-4-navigate/index.dj
@@ -43,19 +43,21 @@ including any deadlines or time-sensitive elements I should know about.
 :::
 
 
-_In the Field Guide: W-2 (If You're Let Go), H-4 (Insurance Appeals), L-2 (Small Claims Court), Ho-6 (Getting a Home), IRL-1 (Government Offices)._
+_In the Field Guide: [W-2 (If You're Let Go)](ref:w-2), [H-4 (Insurance Appeals)](ref:h-4), [L-2 (Small Claims Court)](ref:l-2), [Ho-6 (Getting a Home)](ref:ho-6), [IRL-1 (Government Offices)](ref:irl-1)._
 
 ### Example 1: Filing for Unemployment Benefits
 
 The situation: you were let go last Friday. An email from the CEO said "position eliminated, replaced by AI." You have never filed for unemployment. You don't know if you qualify, where to start, or what the deadlines are.
 
 *Your opening message:*
+
 ::: prompt
 I just lost my job. I think I can file for unemployment
 but I don't know how.
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 I can help you navigate this. A few questions first:
 
@@ -67,6 +69,7 @@ I can help you navigate this. A few questions first:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. California
 2. Laid off — they said "position eliminated."
@@ -76,6 +79,7 @@ I can help you navigate this. A few questions first:
 :::
 
 *Your Agent proposes the navigation:*
+
 ::: agent
 Here's your step-by-step path. California unemployment
 is handled through the EDD (Employment Development
@@ -118,11 +122,13 @@ adjust — for example, did you receive any severance?
 :::
 
 *Your correction:*
+
 ::: prompt
 Yes, I did get two weeks severance. Does that change anything?
 :::
 
 *Your Agent adjusts:*
+
 ::: agent
 Severance can delay when benefits start, depending on
 how your employer reports it. In California, if the
@@ -148,12 +154,14 @@ Research on administrative burden (Herd & Moynihan, 2018) shows that complex app
 The situation: your insurance denied coverage for an MRI your doctor ordered. The letter says "not medically necessary." You know you can appeal but have no idea what the process looks like or how long you have.
 
 *Your opening message:*
+
 ::: prompt
 My insurance denied my MRI. The letter says I can appeal.
 How do I do this?
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 I'll walk you through the process. Let me ask:
 
@@ -168,6 +176,7 @@ I'll walk you through the process. Let me ask:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. Employer-provided — through work.
 2. Anthem Blue Cross.
@@ -179,6 +188,7 @@ I'll walk you through the process. Let me ask:
 :::
 
 *Your Agent proposes the navigation:*
+
 ::: agent
 Good — you have time and your doctor is willing to
 support the appeal. Here's the path:
@@ -224,12 +234,14 @@ to gather the information from Steps 1 and 2 first?
 :::
 
 *Your evaluation:*
+
 ::: prompt
 I'll get the info first. But — what if the external
 review also denies it?
 :::
 
 *Your Agent:*
+
 ::: agent
 After external review, you have two more escalation
 paths most people never reach:
@@ -256,6 +268,7 @@ The question "what happens if this step fails?" is the Navigate power move. Ever
 The situation: your former landlord kept your $2,400 security deposit. It's been 45 days. You sent a demand letter (see Strategy 3: Draft). No response. You want to take them to small claims court but have never done it.
 
 *Your opening message:*
+
 ::: prompt
 My landlord kept my security deposit. I sent a demand
 letter three weeks ago, no response. I want to file
@@ -263,6 +276,7 @@ in small claims court. I've never done this.
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 Small claims court is designed for exactly this. Let me
 confirm a few details:
@@ -278,6 +292,7 @@ confirm a few details:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. Santa Clara County, California.
 2. $2,400.
@@ -288,6 +303,7 @@ confirm a few details:
 :::
 
 *Your Agent proposes the navigation:*
+
 ::: agent
 You have a strong case. In California, a landlord must
 return the deposit OR provide an itemized statement of

--- a/src/content/01-strategies/05-strategy-5-decide/index.dj
+++ b/src/content/01-strategies/05-strategy-5-decide/index.dj
@@ -49,13 +49,14 @@ Decision fatigue — the degradation of decision quality after a sustained perio
 
 [^s5-1]: Baumeister, R.F. et al. (1998). "Ego depletion: Is the active self a limited resource?" _JPSP_, 74(5), 1252-1265. Danziger, S. et al. (2011). "Extraneous factors in judicial decisions." _PNAS_, 108(17), 6889-6892.
 
-_In the Field Guide: M-5 (Retirement), M-1 (Banking), Li-9 (Household Budget), Ch-1 (Shopping Your Values), Tr-1 (Car Ownership)._
+_In the Field Guide: [M-5 (Retirement)](ref:m-5), [M-1 (Banking)](ref:m-1), [Li-9 (Household Budget)](ref:li-9), [Ch-1 (Shopping Your Values)](ref:ch-1), [Tr-1 (Car Ownership)](ref:tr-1)._
 
 ### Example 1: Repair or Replace a Washing Machine
 
 The situation: your washing machine stopped draining mid-cycle. It's 8 years old — a basic top-loader you bought at a big-box store. A repair tech came out, diagnosed a failed drain pump, and quoted $380 for parts and labor. A new comparable machine is $650. You're not sure which option is smarter.
 
 *Your opening message:*
+
 ::: prompt
 My washing machine broke. The repair is $380, a new one
 is $650. The machine is 8 years old. Should I fix it or
@@ -63,6 +64,7 @@ replace it?
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 I can lay out the tradeoffs. A few things will sharpen
 the analysis:
@@ -79,6 +81,7 @@ the analysis:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. It's a Whirlpool WTW4816FW. Basic model.
 2. No other repairs. This is the first problem.
@@ -89,6 +92,7 @@ the analysis:
 :::
 
 *Your Agent maps the options:*
+
 ::: agent
 Here are your two paths with the actual numbers:
 
@@ -144,11 +148,13 @@ right now is not something I can calculate.
 
 
 *Your follow-up:*
+
 ::: prompt
 What if I repair it and something else breaks in a year?
 :::
 
 *Your Agent:*
+
 ::: agent
 Then you've spent $380 + whatever the next repair costs.
 If the next repair is another $300+, you've crossed the
@@ -175,6 +181,7 @@ All four major AI tools handle decision-mapping well. If you want to compare opt
 The situation: you started a new job with a 401(k) match. Your coworker mentioned you should also open an IRA. You've heard of Roth and traditional but don't really understand the difference — something about taxes. You have about $200 a month you could put somewhere. You don't have a financial advisor. You don't have a trust fund. You have a paycheck and a vague sense that you should be doing something with it.
 
 *Your opening message:*
+
 ::: prompt
 I can save about $200/month and someone told me to open
 an IRA. I don't understand the difference between Roth
@@ -183,6 +190,7 @@ Can you explain my options without telling me what to do?
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 A few things will make the comparison specific to
 your situation:
@@ -199,6 +207,7 @@ your situation:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. About $62,000.
 2. Single.
@@ -208,6 +217,7 @@ your situation:
 :::
 
 *Your Agent maps the options:*
+
 ::: agent
 Here's the comparison in plain language:
 
@@ -292,12 +302,14 @@ The behavioral economics finding most relevant to retirement saving is not about
 [^s5-2]: Madrian, B.C. & Shea, D.F. (2001). ["The Power of Suggestion: Inertia in 401(k) Participation and Savings Behavior."](https://doi.org/10.1162/00335530152466232) _Quarterly Journal of Economics_, 116(4), 1149-1187.
 
 *Your follow-up:*
+
 ::: prompt
 Wait — should I be maxing out my 401(k) match before
 I do any of this?
 :::
 
 *Your Agent:*
+
 ::: agent
 Yes. The 401(k) match is not an investment option — it
 is free money with a 100% immediate return. Your employer
@@ -327,6 +339,7 @@ Financial advice from any source — human or AI — carries implicit assumption
 The situation: your apartment has had a persistent mold problem in the bathroom. You reported it 4 months ago. The landlord sent someone who painted over it. The mold came back within 3 weeks. You reported it again. The landlord hasn't responded in 6 weeks. Your kid has been coughing more. You want it fixed. You're also afraid of retaliation — you're month-to-month, and you know the landlord can end your tenancy with 60 days notice.
 
 *Your opening message:*
+
 ::: prompt
 My apartment has mold that my landlord won't fix. I've
 reported it twice. I'm worried about my kid's health but
@@ -335,6 +348,7 @@ What are my options?
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 This is a situation with real health and housing stakes,
 so let me be precise. A few questions:
@@ -351,6 +365,7 @@ so let me be precise. A few questions:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. California.
 2. Month-to-month. I was on a 1-year lease that
@@ -365,6 +380,7 @@ so let me be precise. A few questions:
 :::
 
 *Your Agent maps the options:*
+
 ::: agent
 You have more protection than you think. Let me lay out
 three paths with their real tradeoffs.
@@ -453,6 +469,7 @@ I will verify with a legal aid organization before acting.
 :::
 
 *Your correction:*
+
 ::: prompt
 I didn't know about the retaliation protection. That
 changes things. But what if I do Option A and the
@@ -460,6 +477,7 @@ landlord just ignores the code enforcement notice too?
 :::
 
 *Your Agent:*
+
 ::: agent
 If the landlord ignores a code enforcement notice,
 the stakes escalate — for the landlord, not for you:

--- a/src/content/01-strategies/06-strategy-6-diagnose/index.dj
+++ b/src/content/01-strategies/06-strategy-6-diagnose/index.dj
@@ -45,13 +45,14 @@ I actually need a professional or can handle this myself.
 :::
 
 
-_In the Field Guide: Ho-1 (Home Maintenance), Ho-2 (Home Repair), Tr-2 (Car Maintenance), Ch-3 (House Plants), Ch-6 (Optimizing Chores)._
+_In the Field Guide: [Ho-1 (Home Maintenance)](ref:ho-1), [Ho-2 (Home Repair)](ref:ho-2), [Tr-2 (Car Maintenance)](ref:tr-2), [Ch-3 (House Plants)](ref:ch-3), [Ch-6 (Optimizing Chores)](ref:ch-6)._
 
 ### Example 1: A Washing Machine Making a Grinding Noise
 
 The situation: your washing machine started making a loud grinding noise during the spin cycle two days ago. It still runs. You don't know if it's about to die, if you can fix it, or if you need to call someone. A repair visit starts at $150.
 
 *Your opening message:*
+
 ::: prompt
 My washing machine is making a grinding noise during
 the spin cycle. It started two days ago. I don't know
@@ -59,6 +60,7 @@ if this is serious or something I can fix.
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 I can help you narrow this down before you call anyone.
 A few questions:
@@ -77,6 +79,7 @@ A few questions:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. Front-loading.
 2. About six years old. It's a Samsung — I don't know
@@ -89,6 +92,7 @@ A few questions:
 :::
 
 *Your Agent's diagnosis:*
+
 ::: agent
 Based on what you've described, the most likely causes
 in order of probability:
@@ -138,12 +142,14 @@ specifically.
 :::
 
 *Your follow-up:*
+
 ::: prompt
 I checked — there's a small wire stuck in the gasket.
 Could that be it?
 :::
 
 *Your Agent:*
+
 ::: agent
 Very possibly. Remove it carefully with needle-nose
 pliers, run a short empty cycle, and listen. If the
@@ -162,6 +168,7 @@ The diagnostic questions your Agent asks are the same ones a good repair technic
 The situation: you've had headaches nearly every day for two weeks. They weren't there before. You're caught between "it's probably nothing" and "what if it's serious" — the exact paralysis that makes people either ignore symptoms for months or go to the ER for something that's a Tuesday PCP visit.
 
 *Your opening message:*
+
 ::: prompt
 I've been having headaches almost every day for about
 two weeks. This isn't normal for me. I don't know if
@@ -169,6 +176,7 @@ I should be worried.
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 I can help you think through this, though I want to be
 clear: I'm not diagnosing you. I'm helping you figure
@@ -192,6 +200,7 @@ what to tell your doctor. A few questions:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. Mostly temples and forehead.
 2. Dull pressure, like a band around my head.
@@ -205,6 +214,7 @@ what to tell your doctor. A few questions:
 :::
 
 *Your Agent's assessment:*
+
 ::: agent
 Based on your description, this pattern is most
 consistent with tension-type headaches — the most
@@ -265,6 +275,7 @@ Research on symptom presentation consistently shows that patients who arrive wit
 The situation: your air conditioning stopped cooling. You called an HVAC company. The technician came out, spent twenty minutes, and quoted you $8,200 to replace the entire system. You have no idea if the system actually needs replacing or if the quote is fair. You're about to spend more than you've ever spent on a single purchase based on one person's assessment.
 
 *Your opening message:*
+
 ::: prompt
 I got a quote for $8,200 to replace my HVAC system.
 The tech said the compressor is shot and it's not
@@ -273,6 +284,7 @@ this price is reasonable.
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 That's a big number to commit to on one opinion.
 Let me help you evaluate it. A few questions:
@@ -292,6 +304,7 @@ Let me help you evaluate it. A few questions:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. About 14 years old.
 2. It's a Carrier — I can go look at the label.
@@ -305,6 +318,7 @@ Let me help you evaluate it. A few questions:
 :::
 
 *Your Agent's diagnosis of the quote:*
+
 ::: agent
 The tech may be right about the compressor, but there
 are several things to check before committing to $8,200.
@@ -362,12 +376,14 @@ you receive it?
 :::
 
 *Your follow-up:*
+
 ::: prompt
 He also mentioned something about a "conversion to
 R-410A" — is that a thing?
 :::
 
 *Your Agent:*
+
 ::: agent
 Yes. R-410A is the current standard refrigerant. Any
 new system will use it. The "conversion" isn't an

--- a/src/content/01-strategies/07-strategy-7-research/index.dj
+++ b/src/content/01-strategies/07-strategy-7-research/index.dj
@@ -55,7 +55,7 @@ Research on [health literacy](https://en.wikipedia.org/wiki/Health%5Fliteracy) c
 :::
 
 
-_In the Field Guide: H-5 (Chronic Conditions), L-1 (Contracts), M-5 (Retirement), Li-3 (Scams), C-3 (Your Rights Where You Live)._
+_In the Field Guide: [H-5 (Chronic Conditions)](ref:h-5), [L-1 (Contracts)](ref:l-1), [M-5 (Retirement)](ref:m-5), [Li-3 (Scams)](ref:li-3), [C-3 (Your Rights Where You Live)](ref:c-3)._
 
 *Worked examples:* Before a knee arthroscopy. Before signing a non-compete clause. Between two college financial aid offers.
 
@@ -64,6 +64,7 @@ _In the Field Guide: H-5 (Chronic Conditions), L-1 (Contracts), M-5 (Retirement)
 The situation: your orthopedist looked at an MRI and recommended arthroscopic surgery for a medial meniscus tear. Outpatient, routine. The scheduler called to book it before you left the office. You don't feel scared---you feel handled. Everything is moving and nobody asked if you had questions. The gap isn't fear; it's speed. The institution is optimized to move you from diagnosis to operating room. Your job is to slow down long enough to find out whether the operating room is the right next step.
 
 *Your opening message:*
+
 ::: prompt
 My doctor says I need knee surgery for a torn meniscus.
 It's arthroscopic, outpatient. They want to schedule it
@@ -71,6 +72,7 @@ for next month. What should I know before I say yes?
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 I can lay out what you need to know. A few things will
 sharpen the research:
@@ -89,6 +91,7 @@ sharpen the research:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. MRI says medial meniscus tear. Didn't say what kind
    of surgery they're planning.
@@ -101,6 +104,7 @@ sharpen the research:
 :::
 
 *Your Agent:*
+
 ::: agent
 Here is what you need to know before you say yes:
 
@@ -169,12 +173,14 @@ with my orthopedist before deciding.
 :::
 
 *Your follow-up:*
+
 ::: prompt
 Wait---my doctor didn't mention physical therapy as
 an option. Is that normal?
 :::
 
 *Your Agent:*
+
 ::: agent
 Yes, common. Orthopedic surgeons recommend surgery---that's
 their training and their practice. That doesn't
@@ -208,6 +214,7 @@ All four major AI tools can read medical documents. Upload your MRI report as a 
 The situation: you're a vet tech who's been offered a new job. Better pay, better hours, better commute. The employment agreement arrived by email---"please review and sign before your start date." Standard onboarding language. Page 6, paragraph 14: a non-compete clause. You noticed it because the language was unusually specific: "shall not engage in competitive employment within a radius of twenty (20) miles for a period of eighteen (18) months following termination of employment." You don't know if this is standard, aggressive, or meaningless. You don't want to make trouble before your first day. You also don't want to sign something that could prevent you from working if this job doesn't work out.
 
 *Your opening message:*
+
 ::: prompt
 I'm starting a new job as a vet tech and the employment
 agreement has a non-compete clause. It says I can't work
@@ -216,6 +223,7 @@ I leave. Is this normal? Should I be worried?
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 This is worth understanding before you sign. A few
 things will sharpen the research:
@@ -233,6 +241,7 @@ things will sharpen the research:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. Texas.
 2. $48,000.
@@ -244,6 +253,7 @@ things will sharpen the research:
 :::
 
 *Your Agent:*
+
 ::: agent
 Here is what you need to know before you sign:
 
@@ -304,6 +314,7 @@ WHAT TO VERIFY INDEPENDENTLY
 :::
 
 *Your follow-up:*
+
 ::: prompt
 Can I actually negotiate this? I'm a vet tech, not
 a lawyer. I don't want to lose the job offer by
@@ -311,6 +322,7 @@ making waves before I even start.
 :::
 
 *Your Agent:*
+
 ::: agent
 The fear is real---the power dynamic is real. You
 need the job; they have other applicants. That's
@@ -346,6 +358,7 @@ Non-competes disproportionately bind workers with the least negotiating power. A
 The situation: you are a first-generation college parent at the kitchen table---maybe with your daughter, maybe alone at midnight after she went to bed. Two acceptance letters. Two financial aid award letters. Both look generous. School B's package covers more of the sticker price, and you want to feel good about that. But something doesn't add up. One school calls it "Institutional Grant." The other calls it "Merit Scholarship." One includes "Federal Work-Study" in the total. The other doesn't. You are trying to compare two documents that were designed, by two different institutions, to resist comparison. The numbers in the two letters don't seem to mean the same things. They don't. This is the deepest information gap in the chapter.
 
 *Your opening message:*
+
 ::: prompt
 My daughter got into two schools and we got the
 financial aid letters. I'm trying to compare them
@@ -387,6 +400,7 @@ Remaining Cost: $9,405
 :::
 
 *Your Agent's clarifying questions:*
+
 ::: agent
 This is exactly the right instinct---these two
 letters are not telling you the same story in the
@@ -408,6 +422,7 @@ comparison:
 :::
 
 *Your answers:*
+
 ::: prompt
 1. Yes, in-state for School A. School B is out
    of state.
@@ -421,6 +436,7 @@ comparison:
 :::
 
 *Your Agent:*
+
 ::: agent
 Here is the full comparison. Your instinct that
 something feels off is correct---the two letters
@@ -523,12 +539,14 @@ financial aid office before committing.
 :::
 
 *Your follow-up:*
+
 ::: prompt
 School B looks cheaper in year one but you're
 saying it might not be in year two?
 :::
 
 *Your Agent:*
+
 ::: agent
 That's the pattern. Some schools use large
 institutional grants in year one to attract

--- a/src/content/01-strategies/08-strategy-8-assert/index.dj
+++ b/src/content/01-strategies/08-strategy-8-assert/index.dj
@@ -55,7 +55,7 @@ When asking about legal rights, always follow up with: _"Is this answer the same
 
 [^s8-1]: Herd, P. & Moynihan, D.P. (2018). _Administrative Burden: Policymaking by Other Means._ Russell Sage Foundation.
 
-_In the Field Guide: Ho-4 (Renter Rights), W-2 (If You're Let Go), M-4 (Collections), C-1 (Police Encounters), H-15 (Drug Laws)._
+_In the Field Guide: [Ho-4 (Renter Rights)](ref:ho-4), [W-2 (If You're Let Go)](ref:w-2), [M-4 (Collections)](ref:m-4), [C-1 (Police Encounters)](ref:c-1), [H-15 (Drug Laws)](ref:h-15)._
 
 *Worked examples:* Tenant rights when a landlord refuses repairs. Employee rights when let go without a clear reason. Consumer rights when disputing a charge.
 

--- a/src/content/01-strategies/09-strategy-9-create/index.dj
+++ b/src/content/01-strategies/09-strategy-9-create/index.dj
@@ -36,7 +36,7 @@ The failure mode — "I asked it to write me a story and it was generic" — hap
 
 This strategy is about keeping both jobs clearly assigned.
 
-_In the Field Guide: Cr-4 (Writing a Book), Cr-2 (Visual Design), Cr-3 (Editing a Movie), WB-5 (Building a Website), WB-8 (Blogging)._
+_In the Field Guide: [Cr-4 (Writing a Book)](ref:cr-4), [Cr-2 (Visual Design)](ref:cr-2), [Cr-3 (Editing a Movie)](ref:cr-3), [WB-5 (Building a Website)](ref:wb-5), [WB-8 (Blogging)](ref:wb-8)._
 
 ---
 

--- a/src/content/02-field-guide/01-health/index.dj
+++ b/src/content/02-field-guide/01-health/index.dj
@@ -18,10 +18,12 @@ _There is a political movement to Make America Healthy Again. This book is not a
 ---
 
 #### H-1: Understanding a Diagnosis You Just Received
+
 *Strategy:* Decode
 *See also:* H-2: Preparing Questions (for your next appointment), H-5: Managing a Chronic Condition (if it's ongoing)
 *My Man Jeeves:* _The language of medical diagnosis has evolved over several centuries with the commendable aim of precision between specialists — a precision that, one might observe, extends rather less reliably to the patient. The individual in question, having just received news of some consequence regarding their own person, is moreover in a neurological state that research suggests reduces information retention by approximately half. The medical system appears to regard this arrangement as satisfactory. One's Agent, it may be observed, is rather more patient with questions than the fifteen-minute appointment permits._
 *The Spec:*
+
 ::: prompt
 My doctor just told me I have [diagnosis]. I don't fully understand
 what this means. Please explain in plain language:
@@ -37,10 +39,12 @@ I will bring this to my next appointment to verify.
 ---
 
 #### H-2: Preparing Questions Before a Doctor's Appointment
+
 *Strategy:* Prepare
 *See also:* H-1: Understanding a Diagnosis (if you just received one), H-5: Managing a Chronic Condition (for ongoing questions)
 *My Man Jeeves:* _Research across multiple medical systems has established, with some consistency, that patients who arrive with written questions receive more information, report higher satisfaction, and reach better-informed decisions than those who do not. It is perhaps worth noting that the medical system has not seen fit to adjust its appointment length to accommodate this finding. One's Agent, however, is tolerably well suited to assist in composing the list._
 *The Spec:*
+
 ::: prompt
 I have an appointment with [specialist type] on [date] about [condition
 or concern]. My main worry is [specific concern]. I want to make sure
@@ -61,10 +65,12 @@ This works well with voice mode on your phone — all major tools support it on 
 ---
 
 #### H-3: Decoding a Medical Bill or EOB (and Negotiating What You Owe)
+
 *Strategy:* Decode + Assert
 *See also:* H-4: Appealing an Insurance Denial (if something looks wrong), M-4: Collections and Bankruptcy (if the bill becomes debt), M-6: Financial Coach (for insurance and costs)
 *My Man Jeeves:* _The Explanation of Benefits is, in principle, a document intended to explain one's benefits --- a purpose it fulfills, one might venture, with considerable incompleteness. It presents procedure codes, allowed amounts, adjustments, and patient responsibility in a format that rather generously rewards confusion. The bill that follows presents a further difficulty: its stated price bears a variable, and largely notional, relation to what one might actually be asked to pay. Nonprofit hospitals are required by federal tax rule to maintain financial assistance programs; they are not, however, required to volunteer the fact at the billing window. One's Agent has read every code on the form and every provision of 26 U.S.C. § 501(r) --- and is prepared both to translate and to negotiate._
 *The Spec:*
+
 ::: prompt
 I received this medical bill / Explanation of Benefits and I don't
 understand it. [Paste the bill or EOB, removing your name and ID number.]
@@ -113,10 +119,12 @@ Under [26 U.S.C. § 501(r)](https://www.irs.gov/charities-non-profits/charitable
 ---
 
 #### H-4: Appealing an Insurance Denial
+
 *Strategy:* Navigate + Draft
 *See also:* L-1: Negotiating a Contract (for understanding the policy itself), L-3: Writing a Demand Letter (same drafting technique, different context)
 *My Man Jeeves:* _Insurance companies deny claims at a rate that, one observes, ensures a profitable percentage of denials are never contested — the appeal process requiring, as it does, that the policyholder be aware appeal is possible, conversant with the procedure for filing one, and in possession of sufficient energy to pursue the matter while already unwell. The industry appears to find this arrangement commercially sound. One's Agent is conversant with the appeal process and is not, at present, unwell._
 *The Spec:*
+
 ::: prompt
 My insurance denied [procedure/claim] with the reason: [paste denial reason].
 The procedure was ordered by my doctor for [condition].
@@ -139,10 +147,12 @@ Veterans: VA benefits denials follow a separate system. The Appeals Modernizatio
 ---
 
 #### H-5: Managing a Chronic Condition Day-to-Day
+
 *Strategy:* Research
 *See also:* H-1: Understanding a Diagnosis, H-2: Preparing Questions, H-8: Wellness and Nutrition Coach
 *My Man Jeeves:* _The diagnosis, if one may draw the distinction, is a moment. The condition is the remainder of one's life. The medical system has been constructed principally for acute care — one arrives unwell, one departs treated. Chronic conditions do not accommodate themselves to this model with any great willingness. The 15-minute appointment every three months cannot, by its nature, address the 131,400 minutes between appointments. Those minutes fall to the patient to manage, largely without assistance, armed with whatever information one carried away from the last visit. One's Agent is available for the other 131,400._
 *The Spec:*
+
 ::: prompt
 I have [chronic condition] and I've been managing it for [time period].
 My current treatment: [medications, therapy, lifestyle changes]
@@ -207,10 +217,12 @@ When patients skip medications, the medical system calls it "non-adherence." In 
 ---
 
 #### H-6: Understanding What Medicare Actually Covers
+
 *Strategy:* Decode
 *See also:* H-4: Appealing an Insurance Denial, H-6b: Understanding What Medicaid Actually Covers, Li-4: Planning Care for Aging
 *My Man Jeeves:* _Medicare is, in principle, straightforward: health insurance for Americans aged 65 and older, or younger if disabled. In practice, it is a four-part system (A, B, C, and D) with enrollment windows that close permanently, late-enrollment penalties that compound for life, and a private-plan alternative (Medicare Advantage) whose marketing budget rather substantially exceeds its obligations of transparency. The most consequential decision --- whether to enroll in Original Medicare or an Advantage plan, and whether to purchase supplemental Medigap coverage --- must be made during windows that the system does not go to great lengths to publicize. One's Agent has read the enrollment rules and can explain which decisions apply to one's circumstances before the window closes._
 *The Spec:*
+
 ::: prompt
 I [or my family member] am [turning 65 / disabled / already enrolled
 and reviewing my coverage] and I need to understand what
@@ -257,10 +269,12 @@ Free, unbiased Medicare counseling is available in every state through the [Stat
 ---
 
 #### H-6b: Understanding What Medicaid Actually Covers
+
 *Strategy:* Decode
 *See also:* H-6: Understanding What Medicare Actually Covers, H-4: Appealing an Insurance Denial, Li-4: Planning Care for Aging
 *My Man Jeeves:* _Medicaid occupies, in the public imagination, a rather narrower role than it in fact performs. It is not merely insurance for the very poor --- it is the only major federal program that covers long-term nursing-home care, a fact that approximately 62% of Americans attribute, incorrectly, to Medicare. Following the One Big Beautiful Bill Act of 2025, it is also, for the first time in its history, a program with work requirements --- requirements that the Congressional Budget Office estimates will remove 4.8 million people from coverage by 2034. The eligibility rules are state-specific, the asset limits for long-term care are unforgiving, and the application process assumes a degree of bureaucratic fluency that the populations it serves are, by definition, least likely to possess. One's Agent has read the rules for one's state and can explain what applies before the paperwork is due._
 *The Spec:*
+
 ::: prompt
 I [or my family member] am [low-income / applying for long-term care /
 helping a parent who may need a nursing home / recently lost coverage]
@@ -311,10 +325,12 @@ For World War II–era veterans --- and for those who served in Korea, Vietnam, 
 ---
 
 #### H-7: Preparing for End-of-Life Conversations with Aging Parents
+
 *Strategy:* Prepare
 *See also:* Li-1: Preparing for a Difficult Conversation, Li-2: Writing a Eulogy, Li-4: Planning Care for Aging, L-1: Negotiating a Contract (for legal documents)
 *My Man Jeeves:* _American culture maintains, as the research rather thoroughly documents, a pronounced aversion to discussing death. The consequence is that the most significant decisions of a person's life — how they wish to be cared for, who is to make medical decisions should they be unable, what measures they do and do not desire — are left to family members attempting to guess under pressure in a hospital corridor. An advance directive requires approximately 30 minutes. The conversation that precedes it presents a rather greater difficulty. One's Agent may be of assistance in preparing for it._
 *The Spec:*
+
 ::: prompt
 I need to have a conversation with [my parent / family member]
 about their end-of-life wishes. This conversation has not happened
@@ -376,10 +392,12 @@ Honorably discharged veterans and their eligible family members qualify for buri
 ---
 
 #### H-8: Wellness and Nutrition Coach
+
 *Strategy:* Research + Draft (Expert Role)
 *See also:* H-5: Managing a Chronic Condition (for condition-specific nutrition), Li-8: Wellness Coach (for mental health and journaling)
 *My Man Jeeves:* _A registered dietitian typically charges between $100 and $200 per session, with new-patient waits commonly running several weeks. A personal trainer costs $50 to $150 per hour. A wellness coach charges rather more and is, one notes, rather less regulated. One's Agent has acquainted itself with the same evidence base all three cite, and will apply it to one's particular situation without the formality of a retainer._
 *The Spec:*
+
 ::: prompt
 Act as a knowledgeable wellness and nutrition coach.
 My situation:
@@ -405,6 +423,7 @@ To make this Expert Role persistent across sessions, save it as a *Project* (Cla
 
 
 *Common wellness Expert Role specs:*
+
 ::: prompt
 Act as a nutrition coach. I want to eat better but I have
 [budget constraint / time constraint / dietary restriction].
@@ -451,10 +470,12 @@ In 2010, David Nutt and colleagues published a harm ranking of 20 drugs in _The 
 ---
 
 #### H-9: Understanding Your Prescription
+
 *Strategy:* Decode
 *See also:* H-10: Checking for Drug Interactions, H-1: Understanding a Diagnosis
 *My Man Jeeves:* _One's physician prescribed a medication in a 7-minute appointment. The pharmacist furnished a stapled printout in 8-point type listing "side effects may include" followed by what one can only describe as every symptom known to medicine. The printout, one understands, is required by law. Comprehending it is not. One's Agent, having read the pharmacology, is prepared to explain what the printout means in one's specific case._
 *The Spec:*
+
 ::: prompt
 My doctor prescribed [drug name] for [condition].
 The dose is [amount, frequency].
@@ -482,10 +503,12 @@ Photograph the pill bottle label with your phone, then copy the text from the ph
 ---
 
 #### H-10: Checking for Drug Interactions
+
 *Strategy:* Decode + Research
 *See also:* H-9: Understanding Your Prescription, H-8: Wellness and Nutrition Coach
 *My Man Jeeves:* _The liver metabolizes roughly 75% of the drugs one takes by means of a family of enzymes known as CYP450. When two substances compete for the same enzyme, one of them accumulates — a circumstance that may present certain difficulties. The prescribing physician may not be aware of the supplement one's naturopath recommended. The naturopath may not be aware of the prescription. Neither, one regrets to observe, may be aware of the grapefruit. One's Agent is aware of all three._
 *The Spec:*
+
 ::: prompt
 I am currently taking:
 — Prescription medications: [list all, with doses]
@@ -513,9 +536,11 @@ Serotonin syndrome --- caused by combining drugs that increase serotonin (SSRIs,
 ---
 
 #### H-11: Your Brain on Drugs, Simplified
+
 *Strategy:* Research
 *My Man Jeeves:* _Every psychoactive substance operates by altering the manner in which one's brain cells communicate. That sentence, one might note, contains the entirety of what the egg commercial conveyed. The subsequent questions — how, and with what consequences, and at what dose, and for what duration — are where the useful information may be said to begin. One's Agent is prepared to address them without recourse to eggs._
 *The Spec:*
+
 ::: prompt
 Explain how [substance] works in the brain.
 I want to understand:
@@ -545,10 +570,12 @@ Ask your Agent to compare two substances: _"Compare the harm profile of alcohol 
 ---
 
 #### H-12: Talking to Your Doctor About Pain Management
+
 *Strategy:* Prepare + Assert
 *See also:* H-2: Preparing Questions Before a Doctor's Appointment, H-9: Understanding Your Prescription
 *My Man Jeeves:* _The opioid crisis has, one observes, produced two populations of individuals who cannot obtain adequate care: those with addiction who require treatment, and those with pain who require management. Physicians, situated as they are between DEA scrutiny and patient suffering, now on occasion undertreat pain from what one might characterize as liability apprehension. It may prove necessary to advocate for oneself — not to obtain opioids specifically, but to secure an honest conversation regarding all available options. One's Agent can help one prepare for that conversation._
 *The Spec:*
+
 ::: prompt
 I have [type of pain: chronic back pain / post-surgical / nerve pain /
 arthritis / migraines / other] that has been going on for [duration].
@@ -578,6 +605,7 @@ Veterans: VA chronic pain management operates under the Opioid Safety Initiative
 ---
 
 #### H-13: Understanding Addiction (and Finding Help That Works)
+
 *Strategy:* Research + Navigate
 *See also:* H-14: Harm Reduction, M-6: Financial Coach (for insurance and costs)
 
@@ -588,6 +616,7 @@ _If this is an emergency:_ for an active overdose, call *911* and administer nal
 
 *My Man Jeeves:* _Addiction is not, as the relevant authorities have taken some pains to establish, a failure of willpower. The American Society of Addiction Medicine and the National Institute on Drug Abuse classify it as a chronic brain disorder involving compulsive use despite harmful consequences. The distinction is of some importance, as it determines whether the appropriate response is treatment or punishment. The United States has, for the most part, favored punishment. Where it has favored treatment, the industry it has built operates under less regulatory oversight than the restaurant industry --- some facilities excellent, some predatory, the distinction rarely apparent from the website. The task, then, is twofold: to understand the condition as medicine now describes it, and to navigate a marketplace that does not reliably distinguish evidence-based care from something else. One's Agent holds no position beyond the evidence._
 *The Spec:*
+
 ::: prompt
 I am trying to understand [my own / my loved one's] substance use,
 and/or find help.
@@ -649,10 +678,12 @@ Veterans: [Vet Centers](https://www.vetcenter.va.gov/) offer free, confidential 
 ---
 
 #### H-14: Harm Reduction
+
 *Strategy:* Research + Diagnose
 *See also:* H-13: Understanding Addiction, H-10: Checking for Drug Interactions
 *My Man Jeeves:* _In 2023, approximately 105,000 Americans died of drug overdoses — a figure exceeding car accidents and gun deaths combined. Roughly 69% involved synthetic opioids, principally fentanyl, which is frequently present in drugs sold as something else entirely.[^h14-1] Harm reduction proceeds from the premise that some people use drugs, and that the most serviceable response is to keep them alive and as healthy as circumstances permit. This remains controversial in rather the same manner that seatbelts were controversial in 1965 — opponents contending that they would encourage reckless driving. They did not. They reduced deaths. The evidence for harm reduction is, one finds, comparably robust. One's Agent can explain the evidence and the local resources without editorializing._
 *The Spec:*
+
 ::: prompt
 I want to understand harm reduction for [substance or situation].
 My situation: [I use X occasionally / someone I care about uses X /
@@ -690,10 +721,12 @@ Portugal decriminalized personal possession of all drugs in 2001. Drug-related d
 ---
 
 #### H-15: Navigating Drug Laws in Your State
+
 *Strategy:* Navigate + Assert
 *See also:* C-3: Understanding Your Rights Where You Live
 *My Man Jeeves:* _Cannabis is legal in one's state and a federal crime. Psilocybin is decriminalized in one's city yet a felony in the neighboring county. Kratom is banned in several states and available at the gas station in the other 44. The legal landscape for drugs in the United States is not, one feels compelled to observe, a landscape in any coherent sense. It is rather a patchwork quilt sewn by 50 different legislatures, several federal agencies, and occasional ballot initiatives — each operating on a different timeline and, in certain cases, a different century's understanding of pharmacology. One's Agent can clarify the law as it stands in one's specific jurisdiction, which is the only jurisdiction that matters._
 *The Spec:*
+
 ::: prompt
 I want to understand the current drug laws where I live.
 My location: [city, state]
@@ -719,10 +752,12 @@ The DEA's scheduling system was established by the Controlled Substances Act of 
 ---
 
 #### H-16: Evaluating Psychedelic Therapy
+
 *Strategy:* Research + Decide
 *See also:* H-1: Understanding a Diagnosis, H-11: Your Brain on Drugs
 *My Man Jeeves:* _Psychedelic-assisted therapy represents, one might suggest, the most promising and most overhyped development in mental health treatment since SSRIs. Clinical trials for psilocybin in depression and MDMA in PTSD have produced significant results. The FDA declined to approve MDMA therapy in 2024, citing trial design concerns, ethical violations at trial sites, and data integrity issues.[^h16-1] Psilocybin trials continue. In the meantime, unregulated ketamine clinics have proliferated, Oregon has legalized psilocybin services outside the medical system, and the gap between the research and the marketplace has grown sufficient to accommodate, one estimates, a modestly sized retreat center. One's Agent can help one evaluate the evidence for a specific treatment against its current legal and clinical standing._
 *The Spec:*
+
 ::: prompt
 I am interested in psychedelic therapy for [depression / PTSD /
 anxiety / end-of-life distress / addiction / personal growth].
@@ -756,10 +791,12 @@ Indigenous communities have used psilocybin (mushrooms), peyote, and ayahuasca i
 ---
 
 #### H-17: Talking to Your Kids About Drugs (and Unlearning What You Were Told)
+
 *Strategy:* Prepare + Research
 *See also:* Li-1: Preparing for a Difficult Conversation, Li-7: Raising Kids, H-13: Understanding Addiction, H-14: Harm Reduction
 *My Man Jeeves:* _D.A.R.E. instructed a generation that marijuana and heroin belonged to the same category of threat, and that the appropriate response to all drugs was refusal. When those children discovered that marijuana did not, in the event, ruin their lives, a considerable number concluded that the adults had been unreliable on every point --- including those substances that were genuinely dangerous. Those children are now parents. The War on Drugs that shaped their education has cost, by the Bureau of Justice Statistics, over $1 trillion and, at its peak, imprisoned 2.1 million Americans --- with Black Americans held for drug offenses at nearly six times the rate of white Americans despite comparable usage rates.[^h17-1] The task before today's parent is therefore twofold: to unlearn what D.A.R.E. taught, and to pass on to one's children what is, on the documentary record, actually the case. One's Agent has read the Bureau's own data._
 *The Spec:*
+
 ::: prompt
 I want to talk to my [age] year old about drugs.
 My situation: [they haven't asked yet / they asked about something
@@ -803,6 +840,7 @@ John Ehrlichman, Nixon's domestic policy advisor, said in a 1994 interview: _"Th
 ---
 
 #### H-22: Mental Health First Aid (Helping Someone in Crisis, Including Yourself)
+
 *Strategy:* Prepare + Assert + Navigate
 *See also:* H-13: Understanding Addiction (and Finding Help That Works), Li-1: Preparing for a Difficult Conversation, Li-7: Raising Kids
 
@@ -813,6 +851,7 @@ _If this is a crisis right now:_ call, text, or chat *988* --- the Suicide and C
 
 *My Man Jeeves:* _A mental-health crisis --- one's own, or that of a family member, a colleague, or a stranger --- tends to arrive without sufficient notice. The expectation, nevertheless, is that the bystander will know what to do; the training, however, has been reserved largely for clinicians and first responders. The 988 Suicide and Crisis Lifeline, established in July 2022 specifically to provide an alternative to the police-dispatch default, has since answered roughly 16.5 million contacts, with 72% of callers reporting substantial help and 88% of suicidal callers saying the conversation stopped them from acting --- outcomes the 911 system is not designed to produce.[^h22-1] One's Agent has read the evidence-based Mental Health First Aid curriculum and can rehearse with the reader what the crisis itself will not permit._
 *The Spec:*
+
 ::: prompt
 I am trying to prepare for --- or am currently encountering ---
 a mental health crisis.

--- a/src/content/02-field-guide/02-money/index.dj
+++ b/src/content/02-field-guide/02-money/index.dj
@@ -18,10 +18,12 @@ The [Conners](https://en.wikipedia.org/wiki/Roseanne%5F(TV%5Fseries)) were never
 ---
 
 #### M-1: Banking and Savings
+
 *Strategy:* Research + Decide
 *See also:* M-2: Credit Cards and Debt (for credit products), Li-9: Making a Household Budget That Holds
 *My Man Jeeves:* _One might observe that the typical American household leaks $200 to $300 a year in bank fees — maintenance fees, overdraft fees, minimum-balance fees, out-of-network ATM fees — for the privilege of depositing money that the bank then lends out at a considerable multiple. That this arrangement is considered normal would appear to be a triumph of institutional inertia over arithmetic. Credit unions, online banks, and high-yield savings accounts present themselves as alternatives, and yet most individuals remain with the bank at which they opened their first account — a loyalty that, if one may say so, rather resembles dining at the first restaurant one ever visited for the remainder of one's life. One's Agent can compare the alternatives in approximately the time it takes the bank to charge the next fee._
 *The Spec:*
+
 ::: prompt
 I want to make sure my banking setup is actually working for me.
 My situation:
@@ -73,10 +75,12 @@ Mint shut down in March 2024 — if you were one of its millions of users, you a
 ---
 
 #### M-2: Credit Cards and Debt
+
 *Strategy:* Decode + Assert
 *See also:* M-1: Banking and Savings, M-4: Collections and Bankruptcy (when debt goes wrong)
 *My Man Jeeves:* _It would appear that credit card statements have been arranged so as to display the minimum payment with some prominence while relegating the total interest one will pay over time to a typeface calibrated, one suspects, to discourage closer inspection. A card at a typical 21% APR — and more than 23% on new offers — transforms a $5,000 balance, at minimum payments, into a repayment spanning decades and costing thousands in interest. The instrument was marketed as a convenience. It was designed as a revenue mechanism. Appreciating the distinction between these two propositions is the first step. Disputing the errors is the second. One's Agent is prepared to assist with both._
 *The Spec:*
+
 ::: prompt
 I want to understand and manage my credit card and debt situation.
 My situation:
@@ -146,10 +150,12 @@ Financial shame is the most powerful barrier to financial literacy. People who a
 ---
 
 #### M-3: Mortgages
+
 *Strategy:* Decode + Decide
 *See also:* L-1: Negotiating a Contract (for the purchase agreement), Ho-6: Getting a Home, M-6: Financial Coach
 *My Man Jeeves:* _The word "mortgage" derives from the Old French mort gage — literally "death pledge." The name has endured, one imagines, because it is not inaccurate: one is pledging a considerable portion of one's future income, for decades, on terms the bank establishes and one signs. The bank is conversant with the rate environment, the property valuation methodology, the insurance requirements, the tax escrow mathematics, and the seventeen fees interred within the closing disclosure. The borrower, by contrast, knows principally that one desires the house. An Agent, however, is capable of reading the closing disclosure in the manner the bank's attorney reads it — which is to say, one may then negotiate in the manner the bank's attorney negotiates._
 *The Spec:*
+
 ::: prompt
 I am [thinking about buying / in the process of buying / refinancing]
 a home.
@@ -228,10 +234,12 @@ Despite the [Fair Housing Act](https://www.justice.gov/crt/fair-housing-act-2) (
 ---
 
 #### M-4: Collections and Bankruptcy
+
 *Strategy:* Assert + Decode
 *See also:* L-3: Writing a Demand Letter, M-2: Credit Cards and Debt, H-6: Understanding What Medicare Actually Covers, H-6b: Understanding What Medicaid Actually Covers (medical debt is the leading cause of bankruptcy)
 *My Man Jeeves:* _The debt collection industry, if one may characterize it plainly, is constructed upon the assumption that the person receiving the telephone call is unaware of the protections available to them. A collector who rings has, in the ordinary course of events, purchased the debt for pennies on the dollar and is now endeavoring to recover the full amount plus fees. The Fair Debt Collection Practices Act exists to regulate this interaction. That most people in collections have never encountered it is not, one ventures to suggest, accidental — the business model depends rather entirely upon the information gap. An Agent has read the FDCPA. One would recommend doing so oneself as well._
 *The Spec:*
+
 ::: prompt
 I am dealing with [debt in collections / considering bankruptcy /
 being contacted by collectors / unsure of my options].
@@ -303,10 +311,12 @@ The psychology of being in collections resembles chronic stress in a measurable 
 ---
 
 #### M-5: Retirement and Investing
+
 *Strategy:* Research + Decide
 *See also:* M-6: Financial Coach, H-6: Understanding What Medicare Actually Covers, H-6b: Understanding What Medicaid Actually Covers, Li-4: Planning Care for Aging
 *My Man Jeeves:* _One might note that the retirement system in the United States transferred the risk of retirement from employers to individuals in a single generation. One's parents may have enjoyed a pension — a defined benefit that guaranteed income for life. One now has, in its place, a 401(k) — a defined contribution that guarantees nothing beyond the certainty that one bears the investment risk, the longevity risk, and the fee structure. The financial services industry collects in excess of $100 billion per year in fees for the management of Americans' retirement savings.[^m5-5] An Agent, it is perhaps worth observing, charges no fee whatever and has read the same research the fee-charging advisors cite._
 *The Spec:*
+
 ::: prompt
 I want to understand and improve my retirement situation.
 My situation:
@@ -388,10 +398,12 @@ The anxiety of not having saved enough is one of the most pervasive financial st
 ---
 
 #### M-6: Financial Coach
+
 *Strategy:* Decide + Research (Expert Role)
 *See also:* Li-9: Making a Household Budget That Holds, M-1: Banking and Savings
 *My Man Jeeves:* _A fee-only financial advisor charges $200 to $400 per hour and is of greatest utility when one has significant assets requiring management. For the financial questions that most people actually possess — whether a debt merits early repayment, whether savings are optimally situated, whether an insurance policy represents sound value, whether one is, to put the matter delicately, being overcharged — an Agent covers the ground at no cost. The operative phrase is "fee-only": an advisor who earns commissions on the products they recommend labors under a structural conflict of interest that no quantity of good faith can altogether eliminate._
 *The Spec:*
+
 ::: prompt
 Act as a fee-only financial coach with no products to sell.
 My situation: [brief description of income, debts, savings, goals]
@@ -403,6 +415,7 @@ want to know more about before giving a final recommendation.
 *What to do with the Output:* For any financial decision over $1,000, ask the calibration question: _"How confident are you in this recommendation, and what should I verify with a professional?"_ Your Agent is good at explaining options and running numbers. It is not a fiduciary — it has no legal obligation to act in your interest. A fee-only CFP (Certified Financial Planner) does. For complex situations — estate planning, tax optimization, business finances — the cost of a professional consultation is almost always worth it.
 
 *Common financial Expert Role specs:*
+
 ::: prompt
 Act as a tax advisor. I [got married / had a kid / bought a house /
 started freelancing / got an inheritance]. What changes about
@@ -431,10 +444,12 @@ To make the Financial Coach persistent across sessions, save the Expert Role as 
 ---
 
 #### M-7: Understanding Your Taxes
+
 *Strategy:* Decode + Prepare
 *See also:* M-1: Banking and Savings (for account types that affect taxes), W-8: Freelancing (1099 vs. W-2 and self-employment tax)
 *My Man Jeeves:* _One observes that the United States is among the very few nations that requires its citizens to calculate what they owe, despite the government already possessing the relevant figures. The Internal Revenue Service knows what one earned — the W-2 and 1099 forms were filed months prior. It knows what one paid in mortgage interest, what one contributed to retirement, what one earned from a savings account. It could, if permitted, simply present the bill. That it does not is the result of a lobbying effort by the tax preparation industry — Intuit, H&R Block, and their associates — which has spent hundreds of millions of dollars ensuring that the process remains sufficiently opaque to require their services. The complexity is the product. One's Agent, however, has read the tax code in the manner the preparers have, and charges rather less for the privilege of explaining it._
 *The Spec:*
+
 ::: prompt
 I want to understand my tax situation better and make sure
 I'm not overpaying or missing anything.
@@ -505,10 +520,12 @@ Tax anxiety is real, and it is not irrational. The IRS is the only creditor in A
 ---
 
 #### M-8: Insurance You Actually Need
+
 *Strategy:* Research + Decide
 *See also:* M-3: Mortgages (homeowners insurance required for mortgage), H-4: Appealing an Insurance Denial (the appeal process applies to all insurance), Tr-1: Buying a Car (auto insurance)
 *My Man Jeeves:* _The insurance industry presents itself as protection against catastrophe — and it is, in the narrow sense that a policy, properly configured, prevents a single event from destroying one's financial position. What the marketing omits, with some care, is that the industry's profit model depends on collecting premiums from the many and paying claims to the few, and that a considerable apparatus of adjusters, exclusions, riders, and deductibles exists to widen the gap between what one believed was covered and what is. A typical American household spends several thousand dollars a year on insurance premiums outside of health coverage, a figure that varies enormously based on decisions most people made once and have not revisited. One's Agent is rather well suited to the task of revisiting them._
 *The Spec:*
+
 ::: prompt
 I want to make sure I have the right insurance and am not
 overpaying or underinsured.
@@ -592,10 +609,12 @@ Insurance is one of the few products you buy hoping never to use. Every month yo
 ---
 
 #### M-9: Navigating Financial Aid and Student Loans
+
 *Strategy:* Navigate + Assert
 *See also:* M-2: Credit Cards and Debt (debt management strategies), M-4: Collections and Bankruptcy (when student loans go to collections)
 *My Man Jeeves:* _One notes that Americans carry approximately $1.75 trillion in student loan debt — a figure that exceeds the total credit card debt of the nation and is borne disproportionately by those who were told, with some conviction, that higher education was the path to the middle class. The system for managing this debt — loan servicers, income-driven repayment plans, forgiveness programs, forbearance options — is of a complexity that rather suggests it was not designed for the benefit of the borrower. One's loan servicer, to take a single instance, is a private company paid by the government to manage one's account. Its incentive is to minimize its own cost of servicing, not to guide one toward the optimal repayment strategy. An Agent labors under no such conflict of interest, and is conversant with every repayment plan the Department of Education offers._
 *The Spec:*
+
 ::: prompt
 I need help understanding and managing my student loans.
 My situation:
@@ -677,10 +696,12 @@ The emotional weight of student loan debt is qualitatively different from credit
 ---
 
 #### M-10: Evaluating a Big Purchase
+
 *Strategy:* Research + Decide
 *See also:* Tr-1: Buying a Car (the single most common big purchase), Ch-1: Shopping Your Values (for evaluating who you're buying from), Ho-3: Right to Repair (for durability and long-term cost)
 *My Man Jeeves:* _One has observed that the phrase "0% APR for 36 months" appears in advertising with a frequency that suggests, to the casual observer, that financing large purchases at no cost has become a simple act of generosity on the part of retailers. It has not. The 0% offer is a customer acquisition tool: the retailer has calculated that a meaningful percentage of purchasers will miss a payment, triggering deferred interest — in some cases retroactively applied to the entire original balance at rates exceeding 25%. The furniture, the appliance, the automobile — whatever the object, the financing is not a courtesy extended to the buyer. It is a bet placed against them. One's Agent is rather useful for reading the terms of that bet before one accepts it._
 *The Spec:*
+
 ::: prompt
 I'm considering a major purchase and I want to make sure
 I'm thinking about it clearly.

--- a/src/content/02-field-guide/03-legal/index.dj
+++ b/src/content/02-field-guide/03-legal/index.dj
@@ -18,6 +18,7 @@ Paul and Jamie Buchman spent seven seasons of _[Mad About You](https://en.wikipe
 ---
 
 #### L-1: Negotiating a Contract
+
 *Strategy:* Decode + Assert
 *See also:* Ho-4: Knowing Your Rights as a Renter or Homeowner (for lease-specific rights), Ch-2: Understanding a Contractor Bid, M-3: Mortgages
 *My Man Jeeves:* _One might observe that a contract is, in its essential nature, a document composed by attorneys for the benefit of attorneys, with the quiet assumption that all parties to the arrangement have retained counsel of their own. When one party has not, the contract does not malfunction. It performs precisely as designed. The distinction between possessing rights under an agreement and comprehending what one has agreed to is, if one may say so, rather the point. Your Agent has read the contract. It would be pleased to translate._
@@ -25,6 +26,7 @@ Paul and Jamie Buchman spent seven seasons of _[Mad About You](https://en.wikipe
 [contract-highlighted]{.art}
 
 *The Spec:*
+
 ::: prompt
 I am about to sign this contract. [Paste the contract or
 the section you're concerned about.]
@@ -63,10 +65,12 @@ Active-duty servicemembers have contract rights most civilians do not. The [Serv
 ---
 
 #### L-2: Small Claims Court
+
 *Strategy:* Navigate + Prepare + Draft
 *See also:* L-1: Negotiating a Contract (if the dispute stems from a contract), L-3: Writing a Demand Letter (often the step before filing)
 *My Man Jeeves:* _It would appear that small claims court was designed with the admirable intention of permitting ordinary individuals to resolve disputes without the expense of legal representation. The filing fee is modest, the rules are simplified, and the presiding judge expects one to be a regular person rather than a trained advocate. The difficulty, however, presents itself in the matter of preparation. Knowing what the court expects, which evidence carries weight, and how to arrange it coherently — this information is freely available, though one finds it scattered across courthouse websites last updated, in many instances, in 2009. One might further note that the landlord's property management company has filed in small claims dozens of times, while the typical tenant has filed precisely none. The experience gap, rather than the law itself, is the genuine disadvantage. One's Agent can close it._
 *The Spec:*
+
 ::: prompt
 I want to file a small claims court case.
 My state and county: [state, county]
@@ -108,10 +112,12 @@ File and document upload — paste or attach a contract to your conversation —
 ---
 
 #### L-3: Writing a Demand Letter
+
 *Strategy:* Draft
 *See also:* L-2: Small Claims Court (the next step if the letter doesn't work), L-1: Negotiating a Contract (if the dispute involves a signed agreement)
 *My Man Jeeves:* _It is a common misapprehension that a demand letter is an instrument requiring legal credentials to compose. It is not. A demand letter is, at bottom, a written statement conveying four particulars: that a sum is owed, the basis for the obligation, the evidence supporting it, and the course of action one intends to pursue should payment not be forthcoming. Any person may write one. Any person may send one. The efficacy of such a letter derives not from legal authority but from a subtler mechanism — most people and businesses, upon reflection, would rather settle than contend with what follows. The letter itself constitutes the leverage. One might note that a well-composed demand letter resolves more disputes than small claims court, for the simple reason that most defendants perform the arithmetic and pay. One's Agent can compose the letter._
 *The Spec:*
+
 ::: prompt
 I need to write a demand letter.
 The situation: [describe the dispute — what was promised,
@@ -151,10 +157,12 @@ When the other side is a business, a demand letter alone is rarely the strongest
 ---
 
 #### L-4: Navigating a Traffic Ticket
+
 *Strategy:* Navigate + Research
 *See also:* Tr-1: Car Ownership (tickets affect total cost of ownership), C-1: Knowing Your Rights During a Police Encounter (if the ticket involves a stop), L-2: Small Claims Court (if the ticket leads to a larger dispute)
 *My Man Jeeves:* _One observes that traffic tickets occupy a rather unusual position in American law. They are, technically, criminal citations. They carry fines that function, in practice, as a regressive tax. They trigger insurance increases that frequently exceed the fine itself. And they arrive accompanied by a collection of widely circulated beliefs — "the officer must appear or the matter is dismissed," "one may have it reduced simply by requesting" — which prove sometimes accurate, sometimes not, and invariably dependent upon the jurisdiction. A difficulty presents itself in the disparity of consequence: the billionaire pays the fine and the insurance increase without particular notice. The ordinary household notices a great deal. That distinction is what the following Skill endeavors to address. One's Agent can research the options specific to one's jurisdiction and violation._
 *The Spec:*
+
 ::: prompt
 I got a traffic ticket.
 My state: [state]
@@ -216,11 +224,13 @@ Flat traffic fines are regressive by design. A $500 ticket is a rounding error f
 ---
 
 #### L-5: Understanding Your Rights as a Tenant
+
 *Strategy:* Decode + Assert
 *See also:* Ho-4: Knowing Your Rights as a Renter or Homeowner (the practical side --- maintenance, deposits, inspections), L-1: Negotiating a Contract (for reading your lease), L-3: Writing a Demand Letter (if your landlord will not act)
 *My Man Jeeves:* _One observes that the relationship between landlord and tenant is, in most American jurisdictions, governed by a rather comprehensive body of law that the landlord has read and the tenant has not. This is not, one might note, an oversight. The lease itself is the landlord's document, composed by the landlord's attorney, printed on the landlord's letterhead, and presented to the tenant at a moment of maximum vulnerability --- when one has already packed, hired movers, and informed one's current residence of departure. The implied warranty of habitability, the statutory limits on security deposits, the protections against retaliatory eviction --- these exist in every state, though they vary with a creativity that borders on the artistic. The difficulty is not that the tenant lacks rights. It is that exercising them requires knowing they exist, which the lease is under no obligation to mention. One's Agent has read your state's landlord-tenant statute. It is prepared to be specific._
 
 *The Spec:*
+
 ::: prompt
 I am a tenant and I need to understand my rights.
 My state and city: [state, city]
@@ -284,11 +294,13 @@ The landlord-tenant relationship is asymmetric in a way that does not show up in
 ---
 
 #### L-6: Navigating Family Court
+
 *Strategy:* Navigate + Prepare
 *See also:* L-1: Negotiating a Contract (settlement agreements are contracts --- read them like one), Li-1: Difficult Conversations (the emotional side of what this Skill handles procedurally)
 *My Man Jeeves:* _It is perhaps worth observing that family court occupies a singular position in the American legal system. It is the one court where both parties arrive already in crisis, where the stakes are not financial but existential --- the daily proximity to one's children --- and where the proceedings are governed by a standard, "the best interest of the child," that sounds reassuringly clear and proves, upon examination, to be interpreted differently by every judge in every county. One further notes that the system assumes both parties can afford attorneys, take time off work for hearings, and produce documentation on short notice. When one party can and the other cannot, the procedural advantage compounds with each filing. The law itself may be neutral. The capacity to navigate it is not. One's Agent cannot represent you in court. It can ensure you arrive prepared rather than bewildered, which is, if one may say so, a meaningful distinction._
 
 *The Spec:*
+
 ::: prompt
 I need to navigate family court.
 My state and county: [state, county]
@@ -357,11 +369,13 @@ Military families navigating divorce face a separate statutory layer. The [Unifo
 ---
 
 #### L-7: Dealing with Debt Collectors
+
 *Strategy:* Assert + Decode
 *See also:* M-4: Collections and Bankruptcy (the financial strategy side), M-2: Credit Card Debt (if that is the underlying debt), L-3: Writing a Demand Letter (the same technique works in reverse --- you can demand they stop)
 *My Man Jeeves:* _One might observe that the debt collection industry operates within a set of federal and state regulations that are, in their particulars, rather favorable to the debtor --- and that this fact is precisely the one the industry relies upon the debtor not knowing. The Fair Debt Collection Practices Act specifies what a collector may say, when they may call, what they must prove when challenged, and what they must cease doing when instructed. Violations of these provisions carry statutory damages. The difficulty, as so often, presents itself in the gap between the law as written and the experience of receiving a telephone call at dinner from a person whose professional training consists of creating urgency in the uninformed. The collector's advantage is not legal. It is informational. One's Agent is familiar with the FDCPA. It can level the conversation rather promptly._
 
 *The Spec:*
+
 ::: prompt
 A debt collector has contacted me.
 My state: [state]
@@ -440,11 +454,13 @@ Active-duty servicemembers get an additional lever. The [SCRA](https://www.justi
 ---
 
 #### L-8: Power of Attorney and Advance Directives
+
 *Strategy:* Draft + Prepare
 *See also:* H-7: End-of-Life Conversations (the emotional and medical side of these decisions), Li-4: Planning Care for Aging Parents (the caregiving context where these documents become urgent)
 *My Man Jeeves:* _One ventures to suggest that there are certain documents which every adult requires and which, by a most inconvenient feature of human nature, no adult wishes to contemplate. A power of attorney, a healthcare proxy, and an advance directive are not instruments of pessimism. They are instruments of agency --- they ensure that when one cannot speak for oneself, the person who speaks in one's place knows what one would have said. The difficulty is not that these documents are legally complex. A basic power of attorney is, in most states, a single form. The difficulty is that the conversation they require --- who do you trust, what do you want, under what circumstances --- is one that most families postpone until the decision must be made in a hospital corridor at two in the morning by a person who has no legal authority to make it. The documents exist to prevent that moment. One's Agent can draft them. The conversation, one regrets to observe, remains yours to have._
 
 *The Spec:*
+
 ::: prompt
 I need to create advance planning documents.
 My state: [state]
@@ -507,11 +523,13 @@ The paperwork is not the hard part. Asking someone to be your healthcare proxy i
 ---
 
 #### L-10: Navigating a Background Check
+
 *Strategy:* Decode + Assert
 *See also:* W-1: Getting a Job (where background checks gatekeep employment), Ho-6: Getting a Home (where they gatekeep housing --- rental applications)
 *My Man Jeeves:* _One cannot help but observe that the background check has become, in contemporary American life, a document of considerable consequence that the subject of the check is permitted neither to see in advance nor to review for accuracy before it is presented to the party making a decision. An employer, a landlord, or a licensing board receives a report that purports to summarize one's relationship with the law. The report may be accurate. It may not. A 2012 study by the National Consumer Law Center found error rates sufficiently alarming to suggest that accuracy is, for the industry, more of an aspiration than a practice. The Fair Credit Reporting Act provides the right to dispute errors, and many states provide the right to review one's own record. The difficulty is that most people exercise these rights after a rejection --- which is to say, after the damage is done. One's Agent can help you review your record before anyone else does._
 
 *The Spec:*
+
 ::: prompt
 I need to understand and prepare for a background check.
 My state: [state]
@@ -578,11 +596,13 @@ Tenant screening is a separate industry running in parallel to employment backgr
 ---
 
 #### L-11: Filing a Consumer Complaint
+
 *Strategy:* Assert + Navigate
 *See also:* IRL-2: Customer Service (the conversation --- try this first), L-3: Writing a Demand Letter (the written escalation --- try this second)
 *My Man Jeeves:* _One observes that the American consumer possesses, at any given moment, access to a rather formidable array of regulatory complaint mechanisms --- the Consumer Financial Protection Bureau, the Federal Trade Commission, the state attorney general's consumer protection division, and in many instances a local consumer affairs office --- and that the typical consumer, upon being wronged by a corporation, is aware of precisely none of them. This is not, one ventures to say, because the agencies are secretive. They are not. Their complaint portals are public, free, and in several cases genuinely effective. The CFPB, by way of illustration, forwards complaints to the named company with a statutory deadline for response, and publishes both the complaint and the response in a searchable public database. The difficulty is navigational: knowing which agency handles which type of complaint, what information to include, and how to frame the complaint so that it receives attention rather than a form letter. One's Agent knows the escalation ladder. It would be pleased to assist you in climbing it._
 
 *The Spec:*
+
 ::: prompt
 I need to file a consumer complaint against a company.
 The company: [name]

--- a/src/content/02-field-guide/04-home/index.dj
+++ b/src/content/02-field-guide/04-home/index.dj
@@ -18,10 +18,12 @@ Every episode of _[Home Improvement](https://en.wikipedia.org/wiki/Home%5FImprov
 ---
 
 #### Ho-1: Maintaining Your Home
+
 *Strategy:* Diagnose
 *See also:* Ho-2: Home Repair and DIY (for specific repairs), Ho-3: Right-to-Repair (for products designed to resist repair), Ch-1: Shopping Your Values (before replacing anything)
 *My Man Jeeves:* _A residence, however modest, presents a continuous programme of maintenance requirements — plumbing, electrical, HVAC, roofing, appliances — each belonging to a distinct trade. The difficulty is not that one fails to appreciate the importance of preventive care; it is that the knowledge required to perform it has traditionally been distributed across a dozen professionals, none of whom are present when the water heater chooses its moment. An Agent can provide the diagnostic step before one reaches for the telephone, which is to say, the step that most frequently renders the telephone unnecessary._
 *The Spec:*
+
 ::: prompt
 My [appliance/system] is [describing the behavior: making a noise /
 not working / leaking / etc.]. It started [when].
@@ -51,10 +53,12 @@ Paste or upload your document directly — file upload works in Claude, Gemini, 
 ---
 
 #### Ho-2: Home Repair and DIY
+
 *Strategy:* Diagnose + Navigate (Expert Role)
 *See also:* Ho-1: Maintaining Your Home (for diagnosing first), Ho-3: Right-to-Repair (when a product resists repair), Ch-2: Understanding a Contractor Bid (when to hire instead)
 *My Man Jeeves:* _Home repair knowledge was, until comparatively recently, transmitted between generations in much the way that changing a tyre or hemming a pair of trousers was once considered a baseline competency. Several decades of planned obsolescence and the gradual replacement of repairable objects with disposable ones have, one might observe, rather thoroughly interrupted that transmission. The knowledge itself, however, has not vanished — it has merely migrated. An Agent received it regardless._
 *The Spec:*
+
 ::: prompt
 Act as an experienced home repair advisor.
 The task or problem: [describe specifically]
@@ -72,6 +76,7 @@ Checking current information requires web search, which is free in Gemini, ChatG
 
 
 *Common home repair Expert Role specs:*
+
 ::: prompt
 Act as a home repair advisor. I need to [patch a hole in drywall /
 fix a running toilet / caulk a bathtub / replace a light switch /
@@ -88,10 +93,12 @@ Give me an honest assessment.
 ---
 
 #### Ho-3: Right-to-Repair
+
 *Strategy:* Diagnose + Navigate (Expert Role)
 *See also:* Ho-2: Home Repair and DIY (for the repair itself), Ho-1: Maintaining Your Home (for preventive maintenance)
 *My Man Jeeves:* _Whether one characterizes it as enshittification, planned obsolescence, or buyer lock-in, the underlying mechanism is the same: by manufacturing products that resist repair, companies ensure a recurring revenue stream at the consumer's expense. The practice is, if one may say so, rather more deliberate than the word "obsolescence" suggests. An Agent can assess, at whatever skill level one possesses, whether a given item merits repair or replacement — and, should replacement prove necessary, recommend more durable alternatives. One is not, strictly speaking, defeating the system. One is merely removing the information asymmetry upon which it depends._
 *The Spec:*
+
 ::: prompt
 Act as an experienced right-to-repair technician.
 The item I'm trying to fix: [make, model, year if applicable]
@@ -111,6 +118,7 @@ from easiest to most involved?
 
 
 *Common right-to-repair Expert Role specs:*
+
 ::: prompt
 Act as a right-to-repair technician. My [washing machine /
 dishwasher / refrigerator / dryer] is [symptom].
@@ -132,10 +140,12 @@ What should I check first?
 ---
 
 #### Ho-4: Knowing Your Rights as a Renter or Homeowner
+
 *Strategy:* Assert + Decode
 *See also:* L-1: Negotiating a Contract (for reading your lease or mortgage), C-3: Understanding Your Rights Where You Live (for rights that vary by jurisdiction), C-6: Advocating for Change (for changing the rules)
 *My Man Jeeves:* _Housing law, one might observe, is the domain in which the greatest sums change hands with the least comprehension on one side of the transaction. The landlord retains a property management company that has filed the same lease in the same county for fifteen years. The HOA board has engaged an attorney on retainer who drafted the CC&Rs. The mortgage servicer employs a compliance department that knows precisely which fees are legal and which are merely customary. The individual on the other side of the table has the document they were given and a vague apprehension that some of it is not quite right. That apprehension is, in the general course of things, well founded. The law is specific, it varies by jurisdiction, and it almost invariably provides more rights than one supposes. The difficulty has never been the law itself. The difficulty is that nobody has explained it. One's Agent has read the law and is prepared to do so._
 *The Spec:*
+
 ::: prompt
 I have a question about my rights as a [renter / homeowner / HOA member].
 My situation:
@@ -197,6 +207,7 @@ _"I'm concerned about [water quality / air quality / soil contamination / a near
 
 
 *Common housing rights Expert Role specs:*
+
 ::: prompt
 Act as a housing rights advisor. I live in [a community with
 an HOA / a condo association] in [state].
@@ -233,10 +244,12 @@ I will verify with my county assessor's office or a tax professional.
 ---
 
 #### Ho-5: Understanding Your Utility Bill and Energy Options
+
 *Strategy:* Decode + Research
 *See also:* M-6: Financial Coach (for budgeting utilities), Li-9: Making a Household Budget That Holds (utilities as a budget category)
 *My Man Jeeves:* _It would appear that energy cost burden — the percentage of household income devoted to utilities — falls with particular severity upon low-income households, who expend nearly three times the proportion of their income on energy that median-income households do, while possessing the least access to the rebate programmes designed to address this disparity. The programmes, one should note, do exist. The difficulty presents itself not in their absence but in the rather considerable effort required to locate them. One's Agent can locate them._
 *The Spec:*
+
 ::: prompt
 I want to understand my utility bill and find out if there are
 programs that could lower my costs. I'm in [state].
@@ -264,10 +277,12 @@ Paste or upload your document directly — file upload works in Claude, Gemini, 
 ---
 
 #### Ho-6: Getting a Home
+
 *Strategy:* Navigate + Research
 *See also:* M-3: Mortgages, M-6: Financial Coach, L-1: Negotiating a Contract, Ho-4: Knowing Your Rights as a Renter or Homeowner
 *My Man Jeeves:* _One might observe that finding a place to live is the most expensive decision most people make under the most considerable time pressure. The real estate industry has, over the years, perfected the art of manufacturing urgency — "multiple offers," "will not last," "act now" — in a market where the buyer or renter possesses less information than every other party at the table. The landlord knows the vacancy rate. The seller knows the inspection history. The estate agent knows the comparable sales. One knows, principally, that one requires a place to live by the first of the month. An Agent can level that asymmetry — not, it should be said, by rendering the market fair, but by ensuring that one enters it informed._
 *The Spec:*
+
 ::: prompt
 I need to find a place to live.
 My situation:
@@ -342,10 +357,12 @@ _"I'm relocating from [city, state] to [city, state] by [date]. Walk me through 
 ---
 
 #### Ho-7: Gardening & Landscaping
+
 *Strategy:* Diagnose + Research (Expert Role)
 *See also:* Ch-3: Identifying and Caring for House Plants (for houseplants), Ho-1: Maintaining Your Home (for broader property care)
 *My Man Jeeves:* _Master Gardeners are volunteers trained by the Cooperative Extension System to address precisely the questions one has regarding why one's tomatoes have assumed their present appearance. Their services are provided without charge. They are also, one regrets to note, available by appointment, a fortnight from Tuesday, during business hours. An Agent, by contrast, is available now._
 *The Spec:*
+
 ::: prompt
 Act as an experienced Master Gardener.
 Here is my situation:
@@ -370,6 +387,7 @@ To make this Expert Role persistent across sessions, save it as a *Project* (Cla
 
 
 *Extended Expert Role specs for gardening:*
+
 ::: prompt
 Act as a Master Gardener. I want to start a vegetable garden in
 [location, climate zone]. I have [square footage / container space].
@@ -387,10 +405,12 @@ What amendments should I add, and how do I apply them?
 ---
 
 #### Ho-8: Household Disaster Preparedness
+
 *Strategy:* Prepare + Research
 *See also:* M-8: Understanding Insurance (for documenting what you own before you need to), Ho-1: Maintaining Your Home (preventive maintenance is the first line of defense), IRL-9: Handling a Car Accident (the same "be ready before the crisis" mindset)
 *My Man Jeeves:* _One observes that the federal government maintains a website --- ready.gov --- which advises citizens to prepare a 72-hour emergency kit, an evacuation plan, and a communication strategy. One further observes that the overwhelming majority of households have done none of these things, not because the advice is inaccessible but because the task presents itself as a single, undifferentiated mass of anxiety rather than a series of manageable steps. The structural difficulty is familiar: the people best positioned to weather a disaster are those who can afford to outsource the planning, while the people most likely to be displaced by one are expected to assemble the plan themselves, from scattered government PDFs, during a period of calm they cannot quite believe will end. An Agent can convert the undifferentiated mass into a checklist, prioritized by consequence, completed in stages, and tailored to the specific threats that apply where one actually lives._
 *The Spec:*
+
 ::: prompt
 I want to create a household emergency preparedness plan.
 My situation:
@@ -438,10 +458,12 @@ Disaster impact is not distributed equally. Eric Klinenberg's _Heat Wave_ (2002)
 ---
 
 #### Ho-9: Decluttering and Organizing
+
 *Strategy:* Diagnose + Navigate
 *See also:* Ch-6: Optimizing Manual Chores (for maintaining systems once you build them), Ho-1: Maintaining Your Home (decluttering is maintenance, not renovation)
 *My Man Jeeves:* _One hesitates to suggest that the billion-dollar decluttering industry has a financial incentive to make the problem feel spiritual rather than logistical, but one does observe that the rhetoric of "sparking joy" has been rather more profitable for its inventor than for the average person standing in a 400-square-foot apartment wondering where the winter coats are meant to reside. The difficulty is not an excess of sentiment. The difficulty is an insufficiency of space, compounded by an absence of systems. An Agent can assess the space one actually has, propose storage arrangements that function within its constraints, and maintain the one-in-one-out discipline that prevents the problem from recurring --- all without requiring that one hold each object and interrogate one's feelings about it._
 *The Spec:*
+
 ::: prompt
 I need help organizing and decluttering my [room / apartment /
 house / specific area like garage, closet, kitchen].
@@ -496,10 +518,12 @@ Hoarding disorder is a recognized mental-health condition in DSM-5, not a lifest
 ---
 
 #### Ho-10: Home Security and Safety
+
 *Strategy:* Research + Decide
 *See also:* Ho-1: Maintaining Your Home (smoke detector batteries are maintenance, not security), Ho-8: Household Disaster Preparedness (security is one layer of a broader safety plan), Ho-4: Knowing Your Rights as a Renter or Homeowner (what your landlord is legally required to provide)
 *My Man Jeeves:* _The residential security-alarm industry in the United States generates upwards of $38 billion annually --- a figure that should prompt the observation that its primary product is not security but the feeling of security, a distinction upon which rather a lot of profit depends.[^ho10-1] A deadbolt, properly installed, does more than a subscription camera service. A smoke detector with a functioning battery does more than a monitored alarm system. The fundamentals are mechanical, inexpensive, and effective. The industry prefers to sell past them. An Agent can assess what one actually needs --- based on one's housing type, neighbourhood, and specific concerns --- and distinguish the measures that reduce risk from those that merely reduce anxiety at a monthly fee._
 *The Spec:*
+
 ::: prompt
 I want to make my home safer and more secure.
 My situation:

--- a/src/content/02-field-guide/05-life/index.dj
+++ b/src/content/02-field-guide/05-life/index.dj
@@ -13,10 +13,12 @@ _The systems that govern health, money, and legal standing get their own domains
 ---
 
 #### Li-1: Preparing for a Difficult Conversation
+
 *Strategy:* Prepare + Draft
 *See also:* W-3: Working with Human Resources (for workplace conversations), H-7: Preparing for End-of-Life Conversations (for the hardest one). Russ Harris, [_The Happiness Trap_](https://www.amazon.com/Happiness-Trap-Stop-Struggling-Start/dp/1590305841) (managing the emotions that make you avoid the conversation). [_Read This and You Will Be Happier_](https://www.theguardian.com/books/2026/jan/17/read-this-and-you-will-be-happier-experts-pick-the-self-help-books-that-really-work) (Guardian, 2026) on Monkey/T-Rex/Lion/Mouse personality types (reading your counterpart's communication style)
 *My Man Jeeves:* _One might observe that forty years of research on interpersonal conflict converge upon a single finding of some consequence: how a difficult conversation begins predicts its outcome with approximately 96% accuracy. The words selected in the first three minutes, it would appear, determine most of what follows.[^li1-2] It is perhaps worth noting, then, that preparation is not a matter of personal preference. It is the intervention itself. One's Agent can help one prepare._
 *The Spec:*
+
 ::: prompt
 I need to have a difficult conversation with [relationship] about [topic].
 My goal is [specific outcome -- not "fix everything," something concrete].
@@ -44,10 +46,12 @@ This works well with voice mode on your phone — all major tools support it on 
 ---
 
 #### Li-2: Writing a Eulogy
+
 *Strategy:* Draft
 *See also:* Li-1: Preparing for a Difficult Conversation (the emotional preparation applies here too), H-7: Preparing for End-of-Life Conversations
 *My Man Jeeves:* _A difficulty presents itself in that the eulogy is, for most persons, the one composition for which there is no second draft, no opportunity to revise after observing the reaction, and no possibility of beginning again. One might further note that it is composed under conditions of considerable emotional impairment and preserved online indefinitely. Your Agent is equipped to furnish the structure. The life, however, only you are in a position to supply._
 *The Spec:*
+
 ::: prompt
 I need to write a eulogy for [relationship -- "my father," "my friend"].
 Here are the things about them that I most want people to remember:
@@ -72,10 +76,12 @@ For honorably discharged veterans: military funeral honors (two-person detail, f
 ---
 
 #### Li-3: Recognizing a Scam
+
 *Strategy:* Research + Draft
 *See also:* Li-1: Preparing for a Difficult Conversation (for talking to a loved one who has been targeted)
 *My Man Jeeves:* _It would appear that the efficacy of the modern scam rests upon exploiting responses that are, in every other context, entirely wholesome: trust, urgency, deference to authority, the desire to be of assistance. The person who succumbs was not, one ventures to suggest, being foolish. They were being human in circumstances engineered by professionals to weaponize that humanity. The FTC reports that Americans lost over $10 billion to fraud in 2023. The shame that follows a successful scam suppresses reporting, with the result that the actual figure is rather higher. The shame, one might observe, is the second scam. One's Agent can help one recognize the pattern before it completes and, should it have already completed, navigate the reporting and recovery process without judgment._
 *The Spec:*
+
 ::: prompt
 I think I [or someone I care about] may be dealing with a scam.
 Here is what happened: [describe the situation — the initial contact,
@@ -106,10 +112,12 @@ Your Agent may describe common scam demographics in ways that reinforce stereoty
 ---
 
 #### Li-4: Planning Care for Aging
+
 *Strategy:* Research + Navigate
 *See also:* H-7: Preparing for End-of-Life Conversations, M-6: Financial Coach (for Social Security and inheritance planning), L-1: Negotiating a Contract (for care facility agreements)
 *My Man Jeeves:* _There arrives, in the course of most lives, a period when the person who attended to everything becomes the person who requires attending to. The reversal presents itself without training, without documentation, and without the emotional infrastructure one might reasonably expect. The American system, it would appear, assumes families will contrive a solution. Other nations constructed eldercare systems. You have your Agent and the Skills that follow._
 *The Spec:*
+
 ::: prompt
 I am [beginning to plan for / currently managing] care for
 [my parent / relative / spouse] who is [age] and dealing with
@@ -164,10 +172,12 @@ Veterans: cross-reference H-6 for VA Aid and Attendance. Additional programs inc
 ---
 
 #### Li-5: Planning Trips
+
 *Strategy:* Prepare + Navigate
 *See also:* Li-10: Language Learning Partner, Tr-2: Public Transit and Cycling
 *My Man Jeeves:* _One observes that the travel planning enterprise has been divided between two industries: the agencies that charge for expertise and the search engines that charge for attention. Both, it would appear, optimize for their own revenue rather than one's experience. Your Agent maintains no advertising revenue, no partner hotels, and no particular reason to recommend the flight with the most disagreeable layover on the grounds that it pays a higher affiliate commission._
 *The Spec:*
+
 ::: prompt
 I am planning a trip to [destination] for [number of people]
 from [dates]. My budget is [range].
@@ -203,10 +213,12 @@ Checking current information requires web search, which is free in Gemini, ChatG
 ---
 
 #### Li-6: Finding Restaurants
+
 *Strategy:* Research + Decide
 *See also:* Li-5: Planning Trips (for restaurants while traveling), Ch-5: Cooking and Culinary Skills (for eating in)
 *My Man Jeeves:* _It would appear that the prevailing restaurant recommendation algorithms optimize for establishments that pay for placement or generate engagement, rather than for the most suitable meal in one's vicinity at one's price point for one's actual preferences. Your Agent maintains no paid placements. It will also, one feels compelled to note, refrain from passing judgment should one desire chicken fingers at an establishment with tablecloths._
 *The Spec:*
+
 ::: prompt
 I'm looking for a restaurant in [location] for [occasion:
 date night / family dinner / quick lunch / celebration / solo meal].
@@ -239,10 +251,12 @@ Eating alone in public is culturally coded as failure in America and normalized 
 ---
 
 #### Li-7: Raising Kids
+
 *Strategy:* Research + Navigate
 *See also:* Li-1: Preparing for a Difficult Conversation (for the hard talks), Li-4: Planning Care for Aging (the other end of the caregiving spectrum), H-17: Talking to Your Kids About Drugs
 *My Man Jeeves:* _One might observe that every generation of parents is persuaded they are doing it wrong. This is not, one ventures to suggest, neurosis — it is a rational response to the circumstance that the stakes are a human life and the research continues to evolve. [Dr. Spock](https://en.wikipedia.org/wiki/Benjamin%5FSpock) advised the postwar generation to trust their instincts, which was considered revolutionary at the time. The current research indicates that instincts are a promising foundation but not, in themselves, sufficient. The billionaire class retains nannies, tutors, and developmental consultants on a permanent basis. Your Agent has read the same developmental psychology they cite._
 *The Spec:*
+
 ::: prompt
 I am a parent of a [age] child and I'm dealing with
 [specific situation: behavioral issue, school decision,
@@ -279,10 +293,12 @@ Parenting research has historically oversampled white, middle-class, two-parent 
 ---
 
 #### Li-8: Wellness Coach
+
 *Strategy:* Research + Draft (Expert Role)
 *See also:* H-8: Wellness and Nutrition Coach (for physical health), H-13: Understanding Addiction, H-1: Understanding a Diagnosis. Russ Harris, [_The Happiness Trap_](https://www.amazon.com/Happiness-Trap-Stop-Struggling-Start/dp/1590305841) (the ACT framework this Skill's thought-pattern work builds on)
 *My Man Jeeves:* _A difficulty of some consequence presents itself in the matter of mental health care in America, where the median wait for a new patient appointment is, by research estimates, between six and ten weeks[^li8-1] and a single therapy session costs $100 to $250 out of pocket. One cannot help but observe that the persons who require assistance most urgently — the isolated, the overwhelmed, the financially strained — face the most formidable barriers to obtaining it. Your Agent is not a therapist. It is, however, available at 2 AM when the therapist is not, and it is capable of performing several things a therapist would recommend one do between sessions._
 *The Spec:*
+
 ::: prompt
 Act as a supportive wellness coach. I am not in crisis —
 I want to work on [specific goal: managing stress, building
@@ -306,6 +322,7 @@ Your Agent will recommend therapy when appropriate. If cost or access is the bar
 
 
 *Common wellness Expert Role specs:*
+
 ::: prompt
 Act as a cognitive behavioral coach. I keep having this thought
 pattern: [describe the loop — catastrophizing, rumination,
@@ -336,10 +353,12 @@ If you or someone you know is in crisis: *988 Suicide & Crisis Lifeline* (call o
 ---
 
 #### Li-9: Making a Household Budget That Holds
+
 *Strategy:* Draft + Decide
 *See also:* M-6: Financial Coach, Ho-5: Understanding Your Utility Bill
 *My Man Jeeves:* _The prevailing budgeting counsel, one might observe, assumes the difficulty is a matter of discipline. For most households, however, the difficulty is arithmetic — income that does not cover expenses, regardless of how disciplined the allocation. Your Agent will not presume to lecture on the subject of lattes. It will assist in identifying where the money actually goes, determine the three largest levers available, and construct a plan that survives contact with reality._
 *The Spec:*
+
 ::: prompt
 I want to build a household budget that actually works.
 My situation:
@@ -369,10 +388,12 @@ Mullainathan & Shafir (2013) document "scarcity mindset" — financial stress me
 ---
 
 #### Li-10: Learn a language
+
 *Strategy:* Research + Navigate (Expert Role)
 *See also:* Li-5: Planning Trips (for travel-specific language prep)
 *My Man Jeeves:* _Language immersion programmes, one notes, cost thousands of dollars. [Duolingo](https://en.wikipedia.org/wiki/Duolingo) is free and instructs one in how to say “the elephant drinks milk” in more than forty languages. Private tutors charge $40 to $80 per hour and are available when their schedule permits. Your Agent, by contrast, is available at once, possesses inexhaustible patience, betrays no visible disappointment when one conjugates the same verb incorrectly for the fifth time, and will conduct an actual conversation about the things one actually needs to say — rather than the things a textbook believes one should practise._
 *The Spec:*
+
 ::: prompt
 Act as a patient language tutor for [language].
 My current level: [complete beginner / basic phrases / conversational]
@@ -384,6 +405,7 @@ How would you suggest we work together in our conversations?
 *What to do with the Output:* Start using it immediately. Language learning research consistently shows that production — trying to say things, getting them wrong, trying again — beats passive study. Your Agent can do something no textbook can: respond to what you say, correct you in real time, and adjust the difficulty to where you actually are rather than where a curriculum assumes you should be.
 
 *Common language Expert Role specs:*
+
 ::: prompt
 I’m traveling to [country] in [timeframe]. Teach me the 20 phrases
 that will make the biggest difference — greetings, ordering food,
@@ -421,11 +443,13 @@ Your Agent’s language ability varies by language. It is strongest in English, 
 ---
 
 #### Li-11: Escaping Social Media
+
 *Strategy:* Research + Decide
 *See also:* Li-7: Raising Kids (for the screen time conversation), Li-8: Wellness Coach (for compulsive behavior patterns). Oliver Burkeman, [_Four Thousand Weeks_](https://www.amazon.com/Four-Thousand-Weeks-Management-Mortals/dp/0374159122) (why the attention economy works and what to do instead)
 *My Man Jeeves:* _The popular discourse, one observes, employs the phrase “screen time.” The research employs the phrase “social media.” These are not the same variable. Using the internet to ascertain how a carburetor functions is a rather different neurological event from scrolling a feed engineered to make one feel slightly worse about oneself at intervals calibrated to sustain the scrolling. The former is the most capable self-education infrastructure ever constructed. The latter is an engagement-optimization engine that colonized it. The intervention, it would appear, is not less internet. It is better internet. One's Agent can help one construct it._
 
 *The Spec:*
+
 ::: prompt
 I want to reduce my social media use [or help my kid reduce theirs].
 My current situation:
@@ -479,6 +503,7 @@ The web evolved from text to graphics to audio to video to interactive simulatio
 *See also:* Li-8: Wellness Coach (for the emotional side), Li-11: Escaping Social Media (for breaking habits). Oliver Burkeman, [_Four Thousand Weeks_](https://www.amazon.com/Four-Thousand-Weeks-Management-Mortals/dp/0374159122) (why systems beat willpower — same thesis, different angle)
 *My Man Jeeves:* _The self-help industry, one might note, generates roughly $13 billion a year on the premise that one lacks willpower. The applications, the courses, the thirty-day challenges — each monetizes the gap between intention and behaviour. Behavioural science has known for decades that the difficulty is not motivation. It is environment design, cue management, and identity. The research is clear and largely disregarded by the industry, for the understandable reason that “redesign your cues” does not sell books in the manner that “unleash your potential” does. Your Agent has read the actual research. It will assist in designing a system rather than deliver a lecture on discipline._
 *The Spec:*
+
 ::: prompt
 I want to build a habit of [specific habit: exercising, reading,
 journaling, cooking at home, practicing an instrument, meditating,
@@ -524,10 +549,12 @@ Habit advice assumes discretionary time. If you are working two jobs or caregivi
 ---
 
 #### Li-13: Using Your Public and Academic Library
+
 *Strategy:* Navigate + Research
 *See also:* WB-10: Doing Real Research with Your Agent (the matched companion — Agent surfaces the claim, library hands you the source), Li-10: Learn a Language (many libraries include Mango and Pimsleur for free), Li-9: Making a Household Budget That Holds (the library replaces several paid subscriptions), M-6: Financial Coach (libraries often host free tax prep and financial counseling)
 *My Man Jeeves:* _A peculiarity of the American civic landscape, one might venture to note, is that a considerable portion of the population pays a monthly fee for streaming services, audiobook subscriptions, and newspaper access while remaining entirely unaware that the building with the flag and the reading room provides most of it gratis. The public library is, in the plainest accounting, the single best deal available to the ordinary citizen — a tax-funded institution that lends books, audiobooks, films, museum passes, internet access, meeting rooms, and the professional assistance of a reference librarian whose job, one feels obliged to mention, is to answer the question one is reluctant to admit one has. The academic library, should one be within driving distance of a state university, is in many jurisdictions equally available — one simply needs to know to walk in. One's Agent can be of considerable assistance in discovering what one's particular library actually offers, which is, as a rule, rather more than one supposed._
 *The Spec:*
+
 ::: prompt
 I want to use my local library more effectively — and any
 academic libraries I'm entitled to use.

--- a/src/content/02-field-guide/06-work/index.dj
+++ b/src/content/02-field-guide/06-work/index.dj
@@ -18,10 +18,12 @@ George Jetson worked a few hours a day, a few days a week, pushing a single butt
 ---
 
 #### W-9: Navigating a Performance Review
+
 *Strategy:* Prepare + Assert
 *See also:* W-3: Working with Human Resources (when the review triggers an HR process), W-2: Leaving a Job (if the review is the writing on the wall), Li-1: Preparing for a Difficult Conversation (same preparation framework)
 *My Man Jeeves:* _The performance review is an exercise in which the employee is asked to demonstrate, retroactively and on a deadline, that the work performed over the preceding twelve months was both valuable and visible — two qualities that are, one notes, not always correlated. The criteria by which one is evaluated are frequently unwritten. The rating scale compresses a year of labor into a number that determines the raise, the bonus, and the promotion timeline. The manager, who is often conducting the review with limited memory and considerable time pressure, relies upon whatever documentation exists — and if the employee has not provided it, the documentation that exists is whatever the manager recalls, which is to say, the last six weeks. One's Agent can ensure that the documentation is complete, the accomplishments are quantified, and the self-review is written with the precision the process rewards but never teaches._
 *The Spec:*
+
 ::: prompt
 I have a performance review coming up [or: I just received
 a performance review I want to respond to].
@@ -84,10 +86,12 @@ If you are placed on a Performance Improvement Plan, read it as what it usually 
 
 
 #### W-10: Dealing with Workplace Conflict
+
 *Strategy:* Prepare + Navigate
 *See also:* W-3: Working with Human Resources (when the conflict reaches the threshold for HR involvement), Li-1: Preparing for a Difficult Conversation (the underlying skill), W-6: Workplace Safety (when conflict becomes harassment or threats). Russ Harris, [_The Happiness Trap_](https://www.amazon.com/Happiness-Trap-Stop-Struggling-Start/dp/1590305841) (accepting the discomfort of having the conversation instead of avoiding it)
 *My Man Jeeves:* _It would not be unreasonable to suggest that the modern workplace places individuals of varying temperaments, incentives, and communication styles into sustained proximity and then expresses surprise when friction results. The passive-aggressive email. The manager who provides feedback through silence. The colleague who takes credit in meetings with the casual confidence of someone who has never been questioned. These are not, one hastens to observe, HR matters — they are below the threshold of formal complaint but above the threshold of comfort, which is to say, they occupy precisely the space in which no institutional mechanism exists to address them. One's Agent can assist in preparing for the conversation one has been avoiding — drafting the language, anticipating the responses, and distinguishing between the conflicts worth addressing and those best managed through strategic indifference._
 *The Spec:*
+
 ::: prompt
 I am dealing with a workplace conflict that I need to handle
 myself — it is not an HR-level issue (yet).
@@ -145,10 +149,12 @@ The advice "just talk to them" assumes equal power. The three directions of work
 
 
 #### W-2: Leaving a Job
+
 *Strategy:* Assert + Decode
 *See also:* L-1: Negotiating a Contract (for the severance agreement), M-1: Banking and Savings (emergency fund while unemployed), W-5: Unions (if you have a CBA)
 *My Man Jeeves:* _It would not be inaccurate to observe that employment law is among those areas in which the distance between what most employees believe their rights to be and what those rights actually are is widest — and where the consequences of the misapprehension are most immediate. The severance agreement carries a signing deadline. The WARN Act notice carries a claim deadline. The clock, one feels compelled to note, begins whether the individual is aware of it or not. One's Agent can read the agreement and identify the deadlines before they expire._
 *The Spec:*
+
 ::: prompt
 I was just [laid off / fired / asked to resign] from my job at [type of company]
 in [state]. I was there for [X years]. I was given [severance offer / no offer].
@@ -179,10 +185,12 @@ Reservists and National Guard members are protected by USERRA (the Uniformed Ser
 
 
 #### W-1: Getting a Job
+
 *Strategy:* Draft + Prepare
 *See also:* L-1: Negotiating a Contract (for offer letters and non-competes), Li-1: Preparing for a Difficult Conversation (same preparation technique)
 *My Man Jeeves:* _One might observe that the job search is a system designed by employers, for employers, in which the candidate is expected to perform enthusiasm for a position required for survival while conducting oneself as though the power dynamic did not exist. The résumé, it would appear, is a marketing document upon which judgment is passed in approximately six seconds. The cover letter is a genre governed by rules that are nowhere made explicit. The salary negotiation rewards the party in possession of superior information regarding the market rate. The reader's Agent addresses this information asymmetry — which is, one ventures to suggest, the entire purpose of this volume._
 *The Spec:*
+
 ::: prompt
 I am looking for a job in [field/role]. My experience: [brief summary].
 What I'm working with: [currently employed / unemployed / career change /
@@ -255,10 +263,12 @@ Veterans receive Federal Veterans' Preference in competitive federal hiring: 5 p
 
 
 #### W-3: Working with Human Resources
+
 *Strategy:* Draft + Assert
 *See also:* W-2: Leaving a Job, Li-1: Preparing for a Difficult Conversation
 *My Man Jeeves:* _It may be useful to note that Human Resources exists to protect the company. This is not a matter of cynicism — it is the department's actual mandate. An HR representative who assists an employee does so because assisting the employee also serves the company's interest, which is, one acknowledges, frequently the case. An understanding of this alignment — the occasions upon which one's interests and the company's overlap, and those upon which they diverge — represents the difference between employing HR effectively and finding oneself somewhat surprised by the outcome. One's Agent can help one prepare for the interaction with a clear understanding of which category it falls into._
 *The Spec:*
+
 ::: prompt
 I need to deal with an HR situation at work.
 My situation: [performance review / workplace conflict /
@@ -298,10 +308,12 @@ Documenting workplace harassment or discrimination has specific requirements und
 
 
 #### W-6: Workplace Safety
+
 *Strategy:* Assert + Navigate
 *See also:* W-2: Leaving a Job (if retaliation follows), L-3: Writing a Demand Letter
 *My Man Jeeves:* _One's body is, if one may be permitted the observation, the asset one brings to work. The employer's obligation not to damage it is codified in law, implemented through OSHA, and enforced through a system that requires the worker to know it exists and how to employ it. Workers' compensation is insurance the employer is required to carry. Filing a claim is not an adversarial act — it is the use of the system as designed. The adversarial dimension, one regrets to note, tends to present itself later, should the claim be denied, and it is denied with a frequency that warrants preparation. One's Agent has read the relevant OSHA regulations and can assist with both the filing and the appeal._
 *The Spec:*
+
 ::: prompt
 I have a workplace safety concern [or: I was injured at work].
 My situation: [describe — unsafe conditions, injury type, when it
@@ -346,10 +358,12 @@ Workers' comp claim denials follow the same pattern as health insurance denials 
 
 
 #### W-11: Understanding Your Benefits
+
 *Strategy:* Decode + Decide
 *See also:* M-5: Retirement and Investing (the 401k match is free money — literally), M-8: Insurance (the full picture beyond employer-provided), H-6: Medicare and Medicaid (for comparison if you are approaching 65 or qualifying by income)
 *My Man Jeeves:* _It has been one's observation that the benefits enrollment period is a masterwork of information asymmetry, in which the employee is presented with a forty-page document, given fourteen days to make decisions that will affect one's financial position for the following twelve months, and offered as guidance a thirty-minute webinar conducted by a vendor whose incentives are not, one feels, perfectly aligned with one's own. The HSA and the FSA sound similar but differ in ways that cost the inattentive reader several thousand dollars. The vesting schedule appears generous until one calculates the probability of remaining at the firm long enough to collect. The disability insurance that seemed optional becomes, upon reflection, the only benefit that replaces income when the others cannot. The money left on the table, compounded over a career, is quietly staggering. One's Agent can read the benefits summary, explain what each option actually does, and calculate which combination serves the reader's specific situation — which is, one gathers, what the benefits webinar was meant to accomplish._
 *The Spec:*
+
 ::: prompt
 I need to understand my workplace benefits and make decisions
 about them.
@@ -436,10 +450,12 @@ Service members and veterans have a parallel benefits track worth naming. TRICAR
 
 
 #### W-5: Unions
+
 *Strategy:* Navigate + Assert
 *See also:* C-6: Advocating for Change (same organizing skills), L-1: Negotiating a Contract (for reading the CBA)
 *My Man Jeeves:* _A union is, at its foundation, a group of employees who arrived at the conclusion that negotiating individually was not producing satisfactory results. The information asymmetry between an employer and a single employee is structural and permanent — the employer is aware of the budget, the market rate, the headcount plan, and the legal landscape. The employee is aware of one's own salary. The union exists to address this disparity. One might gently observe that everything the reader has been told about unions — whether favorable or otherwise — was communicated by a party holding a position on whether that disparity ought to close. The reader's Agent holds no such position. It has the NLRA, the relevant case law, and the current data._
 *The Spec:*
+
 ::: prompt
 I want to understand [my rights regarding unionizing / how to
 start a union / how my existing union works / how to get involved
@@ -492,10 +508,12 @@ The last decade has brought a visible resurgence: Starbucks Workers United has o
 
 
 #### W-4: Work from Home or RTO?
+
 *Strategy:* Research + Decide
 *See also:* Li-1: Preparing for a Difficult Conversation (if you need to negotiate)
 *My Man Jeeves:* _One could not help but observe that the remote work debate is conducted primarily by executives possessed of home offices and opinion columnists enjoying flexible schedules, regarding employees whose commute carries a financial cost and whose childcare arrangements permit no margin. The research on productivity, collaboration, and wellbeing is, it would appear, rather more nuanced than either party to the argument is inclined to acknowledge. The reader's Agent may be of assistance in evaluating the evidence, weighing the specifics of one's situation, and — should the need arise to present a case to one's employer — constructing one that relies upon data rather than preference._
 *The Spec:*
+
 ::: prompt
 My company is [requiring return to office / offering hybrid /
 I'm choosing between a remote and in-office role / debating
@@ -540,10 +558,12 @@ Remote-work isolation is real. Surgeon General Vivek Murthy's 2023 advisory on t
 
 
 #### W-8: Freelancing and Self-Employment
+
 *Strategy:* Navigate + Prepare
 *See also:* M-7: Taxes (1099 complexity is a different animal), L-1: Negotiating a Contract (every engagement needs one), M-8: Insurance (no employer, no group rate)
 *My Man Jeeves:* _One might observe that the freelancer occupies a position of some structural peculiarity in the American labor market — performing the same work as an employee while receiving none of the infrastructure that employment provides. There is no HR department to explain the benefits, because there are no benefits to explain. There is no payroll department to withhold taxes, because the withholding is now the freelancer's responsibility, as is the estimation, the quarterly filing, and the penalty for underestimation. The 1099 form, one ventures to suggest, is not merely a tax classification but a transfer of administrative burden from the entity that profits from the work to the individual who performs it. One's Agent can assist in managing that burden — the contracts, the invoices, the rate calculations, the quarterly estimates — so that one's attention remains upon the work itself rather than the paperwork surrounding it._
 *The Spec:*
+
 ::: prompt
 I am [freelancing / self-employed / considering going independent]
 in [field or industry].

--- a/src/content/02-field-guide/07-civic/index.dj
+++ b/src/content/02-field-guide/07-civic/index.dj
@@ -15,10 +15,12 @@ _Some companies and governments are now proposing a "Right to AI" --- that acces
 ---
 
 #### C-1: Knowing Your Rights During a Police Encounter
+
 *Strategy:* Assert + Research
 *See also:* C-3: Understanding Your Rights Where You Live
 *My Man Jeeves:* _A difficulty presents itself in the matter of police encounters: the distance between what an officer may legally do and what officers routinely do during a stop constitutes one of the more consequential information asymmetries in American civic life. A knowledge of one's rights does not, it must be acknowledged, guarantee that those rights will be respected. It does, however, establish a record --- verbal or otherwise --- that assumes considerable importance afterward. One would venture to suggest that the appropriate moment for acquiring this knowledge is well before the occasion arises. One's Agent can provide it now._
 *The Spec:*
+
 ::: prompt
 I want to understand my rights during a police encounter.
 My situation: [traffic stop / stopped while walking / police
@@ -70,10 +72,12 @@ _"I want to record [a police interaction / a public official / an encounter] in 
 ---
 
 #### C-2: Knowing Your Voter Rights
+
 *Strategy:* Assert + Research
 *See also:* C-4: Understanding a Ballot Measure (know what you're voting on), C-6: Advocating for Change
 *My Man Jeeves:* _One might observe that voter suppression in America does not, as a general matter, present itself as someone blocking the door. It assumes the form of a polling place relocated without notice, a registration purge conducted quietly, an identification requirement that carries a cost to satisfy, and a queue that extends three hours in one neighborhood while lasting fifteen minutes in another. An awareness of one's rights as a voter serves, in effect, as a defense against a system that --- one could not avoid noticing --- renders participation most difficult for precisely those persons who would alter it. One's Agent can verify one's registration, locate one's polling place, and explain what is on the ballot before one arrives._
 *The Spec:*
+
 ::: prompt
 I want to make sure I can vote and that my vote counts.
 My state: [state]
@@ -118,10 +122,12 @@ Felon disenfranchisement varies wildly by state. Maine and Vermont allow voting 
 ---
 
 #### C-3: Understanding Your Rights Where You Live
+
 *Strategy:* Research + Assert
 *See also:* C-1: Knowing Your Rights During a Police Encounter, C-2: Knowing Your Voter Rights, L-1: Negotiating a Contract (for lease and employment agreements)
 *My Man Jeeves:* _It would be uncontroversial to observe that every human on Earth possesses rights. Some are inalienable --- the [Universal Declaration of Human Rights](https://en.wikipedia.org/wiki/Universal%5FDeclaration%5Fof%5FHuman%5FRights) enumerates thirty of them. Some are constitutional. Some are statutory. Some depend upon one's state, county, city, employer, and landlord. The practical experience of those rights varies so dramatically by jurisdiction that two persons holding the same citizenship may find themselves living under meaningfully different legal regimes depending upon which side of a state line they happen to sleep on. The billionaire class is, one might note, well aware of this circumstance --- it is the reason they select their residence with such care. It would seem prudent for the reader to be similarly informed. One's Agent can explain which rights apply in one's specific jurisdiction._
 *The Spec:*
+
 ::: prompt
 I want to understand what rights and protections I actually have
 where I live [or: where I'm considering moving].
@@ -176,10 +182,12 @@ Legal aid exists but does not reach everyone who needs it. LSC-funded legal aid 
 ---
 
 #### C-4: Understanding a Ballot Measure in Plain Language
+
 *Strategy:* Decode
 *See also:* C-2: Knowing Your Voter Rights (for the voting process), C-5: Writing a Public Comment (for weighing in before it's on the ballot)
 *My Man Jeeves:* _One might observe that ballot measure language is composed by attorneys whose principal concern is surviving legal challenge rather than informing the electorate. The official title, it would appear, frequently describes something approaching the opposite of what the measure accomplishes. The fiscal analysis, while commendably accurate, presupposes a familiarity with the very system it purports to analyze. That this arrangement is regarded as democratic participation is, perhaps, a matter upon which reasonable persons might reflect. One's Agent, having no particular allegiance to either side of the measure, is tolerably well equipped to render the language into English._
 *The Spec:*
+
 ::: prompt
 I am trying to understand [Measure/Proposition name or number]
 on my ballot. [Paste the official text or describe what you know about it.]
@@ -205,10 +213,12 @@ This same framework works on any policy proposal, white paper, or think-tank rep
 ---
 
 #### C-5: Writing a Public Comment for a City Council Meeting
+
 *Strategy:* Draft
 *See also:* C-4: Understanding a Ballot Measure (for understanding what you're commenting on), C-6: Advocating for Change (for sustained advocacy beyond a single meeting)
 *My Man Jeeves:* _It may be worth noting that public comment periods exist as a matter of law, though one could not help but observe that they are scheduled at hours that present considerable difficulty for persons who are employed. The allotted time --- two to three minutes, as a rule --- is not generous. They remain, however, among the few mechanisms through which a citizen may address local decisions that bear directly upon daily life. The distinction between having prepared a written comment and having merely attended is, one finds, the distinction between participation and presence. One's Agent can draft that comment._
 *The Spec:*
+
 ::: prompt
 My city council is voting on [issue] at their meeting on [date].
 I want to speak during public comment.
@@ -235,10 +245,12 @@ This is not just for city hall. Federal agencies accept public comments on propo
 ---
 
 #### C-6: Advocating for Change
+
 *Strategy:* Draft + Navigate
 *See also:* C-5: Writing a Public Comment, C-4: Understanding a Ballot Measure, W-5: Unions (collective action uses the same skills)
 *My Man Jeeves:* _The most frequently offered political counsel in America is "vote." One would not wish to dispute the necessity of this advice, merely to observe that it is, by itself, wildly insufficient. Between elections, decisions are made by those persons who attend meetings, submit comments, telephone offices, organize their neighbors, and apply sustained pressure to specific officials regarding specific matters. These individuals are not, it would appear, possessed of any extraordinary qualities. They are informed, persistent, and --- a point that merits emphasis --- typically fewer in number than one might suppose. In most local decisions, the margin between prevailing and not is measured in single-digit persons. One's Agent can help one become one of them._
 *The Spec:*
+
 ::: prompt
 I want to advocate for [specific change] in my [city / county /
 school district / state / workplace].
@@ -288,10 +300,12 @@ When a politician, company, or think tank proposes a new safety net, benefit, or
 ---
 
 #### C-7: Understanding Jury Duty
+
 *Strategy:* Decode + Navigate
 *See also:* C-3: Understanding Your Rights Where You Live (for jurisdiction-specific requirements), C-1: Knowing Your Rights During a Police Encounter (for understanding the criminal justice system)
 *My Man Jeeves:* _It may not be widely appreciated that jury duty represents the sole context in American civic life in which ordinary citizens exercise direct, binding power over an outcome that the government cannot override. A jury's acquittal, one might note, is not subject to appeal. This power is entirely real, it belongs to the juror, and one cannot help but observe that the system takes some pains to present it as an inconvenience --- an informed jury being, perhaps, rather more difficult to predict than an uninformed one. One's Agent can explain the process, the terminology, and the law before one walks in._
 *The Spec:*
+
 ::: prompt
 I [received a jury duty summons / am currently serving on a jury /
 want to understand the jury system].
@@ -347,10 +361,12 @@ AI-generated evidence and algorithmic tools are entering the courtroom. Predicti
 ---
 
 #### C-8: Participating in AI Policy
+
 *Strategy:* Research + Draft + Navigate
 *See also:* C-5: Writing a Public Comment (the core skill), C-6: Advocating for Change (for sustained engagement), C-4: Understanding a Ballot Measure (for decoding proposals)
 *My Man Jeeves:* _It would appear that governments at every level are, at this moment, determining how AI will be regulated, who will have access to it, and what guardrails will be established. These decisions proceed through the same mechanisms as every other policy matter: legislative hearings, agency rulemaking, public comment periods, and lobbying. The companies building AI maintain full-time policy teams who draft language, attend hearings, and submit comments measured in hundreds of pages. The public comment period is, one might mention, open to the reader as well. It is not a formality --- agencies are legally required to consider substantive comments, and a carefully specified comment from a person who will actually live under the rule carries a weight that a form letter, one ventures to suggest, does not. One's Agent can help one write one._
 *The Spec:*
+
 ::: prompt
 I want to participate in AI policy decisions that affect me.
 My level: [I'm new to this / I've been following AI policy /

--- a/src/content/02-field-guide/08-chores/index.dj
+++ b/src/content/02-field-guide/08-chores/index.dj
@@ -13,10 +13,12 @@ _The domestic labor that keeps a household running — shopping, cooking, cleani
 ---
 
 #### Ch-1: Shopping Your Values
+
 *Strategy:* Research + Decide
 *See also:* Ch-5: Cooking and Culinary Skills (for what to do with what you bought), Ho-3: Right-to-Repair (for durable goods), H-8: Wellness and Nutrition Coach (for dietary needs)
 *My Man Jeeves:* _One might observe that every purchase constitutes a small policy decision, conducted under time pressure with information that is, at best, inadequate. The distinction between "free range" and "cage-free" eggs, for instance, is a regulatory matter that costs the consumer $2 per dozen and approximately an hour of research to verify --- a ratio that would give any reasonable person pause. The difference between a $40 toaster that expires in two years and a $90 toaster that endures for fifteen is, regrettably, invisible at point of sale and conspicuous only in retrospect. In well-staffed households, procurement is handled by persons who source by quality, ethics, durability, and price in whatever combination the household prefers. The remainder of the population is furnished with a label, a search engine optimized for advertising revenue, and eleven minutes before the shop closes. It may be worth noting that one's Agent is capable of evaluating all four dimensions simultaneously, unencumbered by sponsored results._
 *The Spec:*
+
 ::: prompt
 I need to buy [product or grocery item].
 My priorities, in order: [rank these or remove ones you
@@ -51,10 +53,12 @@ Take a photo of the grocery aisle shelf or the product label and send it to your
 ---
 
 #### Ch-2: Understanding a Contractor Bid
+
 *Strategy:* Decode + Research
 *See also:* L-1: Negotiating a Contract (the bid becomes a contract), Ho-2: Home Repair and DIY (should you even hire someone?), Ho-1: Maintaining Your Home (for diagnosing the problem first)
 *My Man Jeeves:* _A contractor bid is a document that proceeds on the assumption that one knows what one is looking at. It enumerates materials one cannot evaluate, labor rates one cannot benchmark, and timelines one cannot verify, then requests a signature at the bottom. The contractor, one might note, has composed hundreds of such documents. The homeowner has perhaps encountered three in a lifetime, all for different trades, none of which adequately prepared one for the present specimen. This asymmetry is not, in the main, a matter of dishonesty --- the majority of contractors are perfectly reputable --- but it does present a difficulty: the honest tradesman and the dishonest one produce documents of remarkably similar appearance, and distinguishing between the two requires research that most households have neither the time nor the background to conduct. One's Agent, having reviewed thousands of such bids, is rather better positioned to assess what each line item ought to cost in one's area._
 *The Spec:*
+
 ::: prompt
 I received a contractor bid. [Paste the bid text, or describe
 the line items and totals.]
@@ -100,10 +104,12 @@ Ask your Agent to review any design PDFs or architectural drawings attached to t
 ---
 
 #### Ch-3: Identifying and Caring for House Plants
+
 *Strategy:* Diagnose + Research (Expert Role)
 *See also:* Ho-7: Gardening & Landscaping (for outdoor plants), Ch-1: Shopping Your Values (before buying the next one)
 *My Man Jeeves:* _It would appear that the houseplant industry sells one a living organism accompanied by a plastic tag reading "bright indirect light" and "water when dry" --- instructions of such imprecision that they might apply equally to a cactus or a fern, two species whose survival requirements are, if one may say so, diametrically opposed. The plant then expires, and the owner arrives at the conclusion that they lack a "green thumb," which is a character trait the horticultural trade appears to have invented to account for the fact that they sold one a tropical understory species and disclosed nothing material about it. An interior landscaper in a properly staffed household would know the species, the light requirements, the humidity range, and the watering schedule. One's Agent possesses the same knowledge and is, moreover, capable of identifying the plant from a photograph._
 *The Spec:*
+
 ::: prompt
 Act as an experienced indoor plant specialist.
 Here is my situation:
@@ -150,10 +156,12 @@ To make this Expert Role persistent across sessions, save it as a *Project* (Cla
 ---
 
 #### Ch-5: Cooking and Culinary Skills
+
 *Strategy:* Research + Diagnose (Expert Role)
 *See also:* Ch-1: Shopping Your Values (for sourcing ingredients), H-8: Wellness and Nutrition Coach (for dietary guidance)
 *My Man Jeeves:* _Culinary school, one might note, costs between $20,000 and $100,000. The core knowledge it transmits -- the reasons things cook as they do, the method of correcting a dish that has gone astray, which substitutions succeed and on what principle -- is thoroughly documented and has been set forth in considerable detail by every food science writer since [Harold McGee](https://en.wikipedia.org/wiki/Harold%5FMcGee). One's Agent has read Harold McGee._
 *The Spec:*
+
 ::: prompt
 Act as a culinary instructor.
 The dish or technique I'm working on: [describe]
@@ -163,6 +171,7 @@ What am I doing wrong, and what should I do differently?
 :::
 
 *Common culinary Expert Role specs:*
+
 ::: prompt
 Act as a culinary instructor. I want to learn [technique:
 how to properly sauté / how to make a pan sauce / how to
@@ -187,10 +196,12 @@ To make this Expert Role persistent across sessions, save it as a *Project* (Cla
 ---
 
 #### Ch-6: Optimizing Manual Chores
+
 *Strategy:* Diagnose + Navigate (Expert Role)
 *See also:* Ho-1: Maintaining Your Home (for home systems maintenance), H-8: Wellness and Nutrition Coach (when physical limitations affect chore capacity). Oliver Burkeman, [_Four Thousand Weeks_](https://www.amazon.com/Four-Thousand-Weeks-Management-Mortals/dp/0374159122) (accepting finite capacity instead of optimizing your way to burnout)
 *My Man Jeeves:* _Domestic labor presents itself as perhaps the only category of work that is simultaneously essential, unpaid, invisible, and expected to organize itself. A factory managing the same number of recurring tasks --- laundry, dishes, floors, surfaces, bathrooms, refuse, meals, groceries --- would employ a process engineer, maintain a schedule, and follow a workflow. A household, by contrast, has one person who noticed the bathroom required attention and two who did not, together with a vague mutual understanding that "we should be better about this" --- an understanding that has not, in recorded history, produced a system. In a properly staffed household, one finds task lists, schedules, and supply inventories. One's Agent is capable of constructing the same infrastructure for the staff one actually has, which is to say, oneself._
 *The Spec:*
+
 ::: prompt
 Act as a household operations consultant.
 My household: [how many people, ages, any mobility or
@@ -240,10 +251,12 @@ The unequal distribution of domestic labor is one of the most documented finding
 ---
 
 #### Ch-7: Meal Planning and Grocery Shopping
+
 *Strategy:* Research + Prepare
 *See also:* Ch-5: Cooking and Culinary Skills (for what to do once you're in the kitchen), Ch-1: Shopping Your Values (for sourcing and certification), Li-9: Household Budget (for the financial side), H-8: Wellness and Nutrition Coach (for dietary needs)
 *My Man Jeeves:* _One observes that the average household disposes of roughly 30% of the food it purchases --- a figure that would prompt an inquiry at any reasonably managed institution. The difficulty is not, in the main, one of appetite or intention. It is a planning problem conducted under conditions that would defeat most logistics professionals: variable schedules, unpredictable preferences, perishable inventory with no standardized shelf life, and a weekly budget that must account for nutrition, taste, household politics, and whatever happens to be on sale. The household that employs a cook also employs a person who plans meals before writing the shopping list, not after. This is the sequence that matters. One's Agent is capable of working backward from what one wishes to eat, through what one already has, to what one actually needs to buy --- a reversal that reliably reduces both the bill and the bin._
 *The Spec:*
+
 ::: prompt
 I need to plan meals for the week and build a grocery list.
 My household: [number of people, ages, any dietary
@@ -289,10 +302,12 @@ Grocery budgets are not equal, and "healthy eating on a budget" advice that assu
 ---
 
 #### Ch-8: Cleaning and Laundry
+
 *Strategy:* Research + Navigate (Expert Role)
 *See also:* Ch-6: Optimizing Manual Chores (for scheduling and systems), Ho-1: Maintaining Your Home (cleaning is maintenance)
 *My Man Jeeves:* _It is perhaps worth observing that garment care labels employ a system of hieroglyphics that the International Organization for Standardization published in 1971 and has not, in any meaningful sense, explained to the public since. The triangle means bleach. The circle means dry clean. The number of dots inside the iron means something one has either memorized or has not --- and the consequence of guessing incorrectly is a $60 sweater reduced to a size suitable for a medium-sized cat. Similarly, the cleaning product aisle offers approximately 40 specialized solutions for surfaces that require, in practice, about four. The household that employs staff finds these matters handled by persons who know that wool felts in hot water, that bleach and ammonia must never meet, and that the "stainless" in stainless steel is aspirational. One's Agent possesses this same knowledge and is available at the moment the red wine hits the white shirt, which is to say, the moment it is actually needed._
 *The Spec:*
+
 ::: prompt
 Act as a textile care and cleaning specialist.
 My situation: [choose one or more]
@@ -335,10 +350,12 @@ Bleach and ammonia together produce chloramine gas. This is not a cleaning hack.
 ---
 
 #### Ch-9: Pet Care and Training
+
 *Strategy:* Research + Navigate (Expert Role)
 *See also:* H-8: Wellness and Nutrition Coach (same Expert Role pattern for a different species), Ch-1: Shopping Your Values (pet food and products), Li-1: Difficult Conversations (for end-of-life decisions with your vet)
 *My Man Jeeves:* _The pet industry generates approximately $150 billion in annual revenue in the United States alone --- a figure that rather complicates the notion that one is simply caring for an animal. One is, in fact, navigating a market that sells grain-free dog food for $80 a bag on the basis of a theory whose scientific support remains contested --- the FDA's investigation found a correlation with dilated cardiomyopathy but not definitive causation, training services at $150 per session from practitioners who may hold no credential of any kind, and "wellness plans" at the veterinary office that bundle services one's pet may not require. Meanwhile, the questions that actually determine an animal's quality of life --- appropriate nutrition for the species and breed, exercise requirements, behavioral needs, when a symptom warrants a vet visit and when it does not --- are answerable from the veterinary literature, which the average pet owner has neither the time nor the training to consult. One's Agent has read the literature. It cannot examine your pet, but it can prepare you for every conversation with someone who can._
 *The Spec:*
+
 ::: prompt
 Act as a veterinary-informed pet care advisor.
 (You are not a veterinarian. You cannot diagnose or treat.
@@ -368,6 +385,7 @@ Please:
 *What to do with the Output:* For health concerns, your Agent is triage, not treatment. If it says "see your vet," see your vet --- and bring the Agent's summary with you. For training, consistency matters more than technique: get everyone in the household on the same protocol before you start. For nutrition, make one change at a time and observe for two weeks. For end-of-life decisions, your Agent can walk you through quality-of-life assessment scales and help you prepare for the conversation with your vet — but it cannot make the decision. See Li-1: Difficult Conversations.
 
 *Common pet care Expert Role specs:*
+
 ::: prompt
 Act as a veterinary-informed pet care advisor. I just adopted a
 [species, age, breed]. What do I need for the first two weeks ---
@@ -410,10 +428,12 @@ To make this Expert Role persistent across sessions, save it as a *Project* (Cla
 ---
 
 #### Ch-10: Seasonal Maintenance
+
 *Strategy:* Prepare + Navigate
 *See also:* Ho-1: Maintaining Your Home (for ongoing maintenance), Ho-2: Home Repair and DIY (for when maintenance reveals a repair), Ch-6: Optimizing Manual Chores (for scheduling the recurring tasks)
 *My Man Jeeves:* _A house, if one may observe, operates on a calendar that its occupants rarely consult. The gutters require attention in autumn. The HVAC filters require replacement quarterly. The water heater requires flushing annually --- a task that a vanishingly small fraction of homeowners perform, the remainder discovering the consequence when the unit fails, which it does, on average, at the ten-year mark, on a Saturday, when plumbers charge emergency rates. The difficulty is not that these tasks are complex. Most require thirty minutes and no specialized skill. The difficulty is that no one tells you they need doing until the consequence arrives, at which point the cost of the repair is several multiples of the cost of the prevention. In a properly maintained household, one finds a seasonal checklist and a person who follows it. One's Agent can produce the checklist. The person, regrettably, must be supplied independently._
 *The Spec:*
+
 ::: prompt
 I need a seasonal home maintenance checklist.
 My home: [house / apartment / condo / rental — if renting,
@@ -460,10 +480,12 @@ Renters: most of this checklist is your landlord's responsibility, and they may 
 ---
 
 #### Ch-11: Managing Subscriptions and Recurring Costs
+
 *Strategy:* Decode + Assert
 *See also:* M-1: Understanding Your Bank Account (for spotting charges), M-2: Understanding Your Credit Card Statement (for the audit trail), IRL-2: Customer Service Calls (for the cancellation call)
 *My Man Jeeves:* _One might observe that the subscription model has achieved a remarkable efficiency: it converts a single purchasing decision into an indefinite revenue stream, secured by the knowledge that the consumer will, in the majority of cases, forget it exists. The average American maintains approximately 12 paid subscriptions and underestimates the monthly total by roughly 80% --- a gap between perception and expenditure that the industry has, one cannot help but notice, very little incentive to close. Cancellation, when attempted, encounters a friction that is precisely calibrated: not so difficult as to invite regulatory scrutiny, but sufficiently inconvenient to discourage all but the most determined. In well-managed households, a financial officer reviews recurring charges quarterly. One's Agent is capable of conducting this audit in approximately ten minutes, provided one is willing to look at the number._
 *The Spec:*
+
 ::: prompt
 I need to audit my subscriptions and recurring charges.
 Here is my information: [choose one or more]

--- a/src/content/02-field-guide/09-irl-interactions/index.dj
+++ b/src/content/02-field-guide/09-irl-interactions/index.dj
@@ -13,10 +13,12 @@ _Your Agent can draft the letter, research the law, prepare the argument, and re
 ---
 
 #### IRL-1: Navigating Government Offices
+
 *Strategy:* Prepare + Navigate
 *See also:* C-3: Understanding Your Rights Where You Live, H-6: Understanding What Medicare Actually Covers
 *My Man Jeeves:* _One might observe that the DMV, the Social Security office, the county clerk, the courthouse, and the unemployment office represent the physical interfaces of government — designed, it would appear, with the same attentiveness to the visitor's experience as a website of the 1997 vintage. The forms are available online, though the answers, regrettably, are not. The hours are limited. The queues are considerable. The individual behind the counter has fielded one's question some four hundred times previously and may or may not possess the authority to be of assistance. A difficulty presents itself: the distinction between a single visit and three lies entirely in knowing what to bring, what to request, and what to say when the initial response is "no." One's Agent can tell one all three before one walks in._
 *The Spec:*
+
 ::: prompt
 I need to go to [DMV / Social Security office / county clerk /
 courthouse / unemployment office / other government office]
@@ -50,10 +52,12 @@ Government services are distributed unequally by geography and funding. Wealthie
 ---
 
 #### IRL-2: Getting Help from Customer Service
+
 *Strategy:* Prepare + Assert
 *See also:* L-3: Writing a Demand Letter (when the call doesn't work), H-4: Appealing an Insurance Denial (same escalation technique)
 *My Man Jeeves:* _It would not be inaccurate to characterize customer service as a system arranged to resolve the least costly complaints while gently exhausting those individuals whose difficulties prove more expensive. The first-tier representative is authorized to perform approximately three actions. The supervisor, perhaps six. The retention department — which one reaches only by employing certain specific phrases — is capable of considerably more. The architecture, one might note, rewards those who are familiar with the escalation path. Your Agent is familiar with the escalation path._
 *The Spec:*
+
 ::: prompt
 I need to resolve a problem with [company] about [issue:
 billing error, defective product, canceled service, denied claim,
@@ -93,10 +97,12 @@ If direct customer service fails, file a complaint at [consumerfinance.gov](http
 ---
 
 #### IRL-3: First-Time Situations
+
 *Strategy:* Prepare + Research
 *See also:* Li-5: Planning Trips (same preparation pattern), H-2: Preparing Questions Before a Doctor's Appointment
 *My Man Jeeves:* _There exists a variety of apprehension that has, to date, received no clinical designation, yet it would appear to affect nearly everyone: the discomfort of not knowing how a place operates. Upon entering a courtroom, a therapist's office, a car dealership, a parent-teacher conference, a funeral home, a real estate closing, a voting booth, or a gymnasium for the first time, one finds oneself uncertain where to stand, what to say initially, what the unwritten conventions are, or what everyone else seems already to know. This apprehension, one might observe, suppresses action. Individuals delay medical appointments, forgo voting, avoid the gymnasium, and accept less favorable terms in negotiations — the unknown procedure proving more daunting than the known unsatisfactory outcome. Your Agent, however, has attended all of these situations. It is in a position to describe precisely what to expect._
 *The Spec:*
+
 ::: prompt
 I am about to [go to / do / attend] [specific situation] for
 the first time and I don't know what to expect.
@@ -133,11 +139,13 @@ This works well with voice mode on your phone — all major tools support it on 
 ---
 
 #### IRL-4: Negotiating a Price
+
 *Strategy:* Prepare + Assert
 *See also:* Tr-1, M-3, H-3. [_Read This and You Will Be Happier_](https://www.theguardian.com/books/2026/jan/17/read-this-and-you-will-be-happier-experts-pick-the-self-help-books-that-really-work) (Guardian, 2026) on Monkey/T-Rex/Lion/Mouse personality types (reading the person across the table)
 *My Man Jeeves:* _One observes that every price in the American economy falls into one of two categories: the fixed and the negotiable. The distinction, however, is rarely advertised. The sticker on the car, the estimate from the surgeon, the first month's rent, the figure on the mattress tag — each represents not a fact but an opening position. The party who knows this negotiates. The party who does not pays the posted amount and is regarded, by the system, as having consented. It is perhaps worth noting that the billionaire class does not pay sticker price for anything, including, one might add, their tax obligations. Your Agent has read the negotiation research. It can tell you the fair price, the walk-away number, and the sentence that moves the conversation._
 
 *The Spec:*
+
 ::: prompt
 I need to negotiate a price for [car / furniture / medical bill /
 rent renewal / appliance / contractor work / other].
@@ -179,10 +187,12 @@ Negotiation outcomes track with race, gender, and class. Research consistently s
 ---
 
 #### IRL-5: Rehearsing What to Say
+
 *Strategy:* Prepare + Draft
 *See also:* Li-1: Preparing for a Difficult Conversation, IRL-2: Getting Help from Customer Service, IRL-4: Negotiating a Price
 *My Man Jeeves:* _One might observe that the individuals with whom one interacts in the course of daily commerce --- the customer service representative, the mechanic, the landlord, the administrator behind the counter --- have rehearsed their side of the exchange. If not formally, then through repetition: the representative has recited the refusal script two hundred times this quarter; the landlord has fielded the repair request before; the doctor has delivered the diagnosis to someone who is not you. The individual on the other side of the encounter, however --- which is to say, oneself --- is performing without benefit of a single rehearsal. It is perhaps unsurprising that the party who has practiced maintains composure while the party who has not does not. Your Agent, one might note, is capable of playing the opposing role with some conviction --- permitting one to rehearse the encounter as many times as necessary before entering the room where it matters._
 *The Spec:*
+
 ::: prompt
 I want to practice a conversation before I have it for real.
 The situation: [describe --- returning a defective product,
@@ -235,11 +245,13 @@ Rehearsal is especially valuable for people navigating conversations across a po
 ---
 
 #### IRL-6: Navigating a Hospital Visit
+
 *Strategy:* Prepare + Navigate
 *See also:* H-2: Preparing Questions Before a Doctor's Appointment, H-3: Decoding a Medical Bill or EOB, H-7
 *My Man Jeeves:* _The hospital is, one might observe, the only institution in which an individual is expected simultaneously to make consequential decisions about their own care, recall unfamiliar terminology under duress, track which of the several individuals entering the room is authorized to make which determinations, and do so while wearing a garment that opens at the back. The system presumes an advocate — a spouse, a parent, a friend who knows what questions to ask. Many individuals arrive without one. Your Agent cannot accompany you into the room, but it can tell you, beforehand, everything the advocate would have known._
 
 *The Spec:*
+
 ::: prompt
 I [am going to the hospital / am accompanying someone] for
 [scheduled surgery / ER visit / labor and delivery /
@@ -286,11 +298,13 @@ Hospital outcomes correlate with race, income, and insurance status. Black patie
 ---
 
 #### IRL-7: Talking to a Mechanic
+
 *Strategy:* Prepare + Decode
 *See also:* Tr-2, Ch-2
 *My Man Jeeves:* _The automobile repair industry operates upon a remarkably efficient information asymmetry: the mechanic possesses specialized knowledge regarding the vehicle's condition, and the vehicle's owner possesses, in the main, the awareness that a sound has begun that was not previously present. Into this gap, one observes, a considerable amount of revenue flows. Not all of it is unwarranted — the profession is skilled and the work is genuinely necessary. But the distinction between "your brake pads are worn and you will die" and "this cabin air filter could be fresher" is one the owner ought to be equipped to make. Your Agent has read every Technical Service Bulletin for your vehicle. The mechanic may not expect that._
 
 *The Spec:*
+
 ::: prompt
 I need to take my car to a mechanic and I want to be prepared.
 The situation:
@@ -330,11 +344,13 @@ Auto repair is one of the most heavily gendered information asymmetries in Ameri
 ---
 
 #### IRL-8: Navigating a Parent-Teacher Conference
+
 *Strategy:* Prepare + Assert
 *See also:* Li-7, IRL-3: First-Time Situations
 *My Man Jeeves:* _The parent-teacher conference presents itself as a collaborative exchange regarding the child's progress. In practice, one observes, it is a twenty-minute encounter in which the teacher has prepared remarks and the parent is expected to receive them. The parent who arrives with questions — specific, informed, documented — shifts the conversation from monologue to dialogue. When the matter involves an IEP or a 504 plan, the shift is not merely social but legal: the parent is a required member of the team, with rights established by federal statute, and the school is obligated to respond to their concerns in writing. Many parents are not informed of this. The school system does not appear to regard the omission as urgent. Your Agent has read IDEA. It can prepare you to exercise rights you may not know you have._
 
 *The Spec:*
+
 ::: prompt
 I have a parent-teacher conference coming up for my
 [age/grade] child.
@@ -385,11 +401,13 @@ Parents who speak the school's language — literally and figuratively — get b
 ---
 
 #### IRL-9: Handling a Car Accident
+
 *Strategy:* Prepare + Navigate
 *See also:* Tr-1, L-4, M-8
 *My Man Jeeves:* _The fifteen minutes following a motor vehicle collision are, one might venture, among the least suitable for clear decision-making in the entire human experience — and yet they are precisely the interval during which the decisions that determine the subsequent six months of insurance negotiations, potential litigation, and financial exposure are made. What one says to the other driver, to the police officer, and to one's insurance company in those first minutes becomes the record. The record is remarkably difficult to amend. Your Agent cannot be consulted at the moment of impact, but it can be consulted ten minutes later, in the passenger seat, while you are waiting for the police to arrive._
 
 *The Spec:*
+
 ::: prompt
 I was just in a car accident. [Or: I want to be prepared
 in case I'm in one.]
@@ -431,11 +449,13 @@ After an accident, police reports and insurance adjusters introduce human judgme
 ---
 
 #### IRL-10: Attending a Funeral or Memorial
+
 *Strategy:* Prepare + Navigate
 *See also:* Li-2, IRL-3: First-Time Situations
 *My Man Jeeves:* _There exists no social occasion at which the fear of saying the wrong thing is more acute, or at which the wrong thing is more frequently said. Funerals and memorial services operate according to customs that vary by religion, culture, region, and family — and one is expected to navigate these customs while managing one's own grief, or supporting someone else who is managing theirs. The system provides no orientation. One arrives, one is uncertain whether to speak or remain silent, whether to bring food or flowers or neither, what to wear, what to say to the family, and what, precisely, one does with one's hands. Your Agent cannot grieve with you. It can tell you what to expect so that your attention is free for the only thing that matters: being present._
 
 *The Spec:*
+
 ::: prompt
 I am attending a funeral or memorial service and I want to
 be prepared.
@@ -474,11 +494,13 @@ The most useful thing you can do after a funeral is not say "let me know if you 
 ---
 
 #### IRL-11: Job Interviews In Person
+
 *Strategy:* Prepare + Assert
 *See also:* W-1, Li-1
 *My Man Jeeves:* _The in-person interview is, one might observe, a performance in which both parties have agreed to pretend that the exchange of pleasantries, the firm handshake, and the question regarding one's greatest weakness constitute a reliable method of evaluating professional competence. Research suggests they do not. The interview persists, nevertheless, because the hiring manager believes in it, and the hiring manager is the audience. What this means, practically, is that preparation for an interview is not preparation to demonstrate competence — it is preparation to demonstrate the appearance of competence to a specific person, in a specific room, for approximately forty-five minutes. Your Agent has read every question they are likely to ask. It can rehearse your answers until they sound unrehearsed._
 
 *The Spec:*
+
 ::: prompt
 I have an in-person job interview coming up and I want to
 be fully prepared.

--- a/src/content/02-field-guide/10-computer-and-web/index.dj
+++ b/src/content/02-field-guide/10-computer-and-web/index.dj
@@ -36,6 +36,7 @@ The internet was supposed to be [Geocities](https://en.wikipedia.org/wiki/GeoCit
 *See also:* WB-7: Writing in CommonMark (a specific digital skill), W-5: Learning a New Professional Skill
 *My Man Jeeves:* _One might observe that software manuals expired in the early 2000s and were replaced by nothing of consequence. YouTube tutorials proceed on the assumption that one already possesses the vocabulary. Official documentation is composed for developers. The result, if one may say so, is a population that employs approximately 10% of the tools for which it pays --- not through any incapacity to master the remaining 90%, but because no one has undertaken to explain it at the level where the learner actually stands, without judgment, for as long as the matter requires. One's Agent will._
 *The Spec:*
+
 ::: prompt
 I want to learn [app or skill: Photoshop / Excel / video editing /
 graphic design basics / email management / a new phone feature /
@@ -95,6 +96,7 @@ The digital skills gap is a class issue. The OECD's Survey of Adult Skills (2024
 *See also:* WB-5: Building Your Own Website (for web-scale projects), WB-7: Writing in CommonMark
 *My Man Jeeves:* _Programming formerly required a computer science degree, or at minimum the temperament that finds pleasure in reading documentation for its own sake. It would appear that this is no longer the case. One's Agent is capable of writing small programs --- scripts --- that attend to the tedious portions of one's digital life: renaming five hundred photographs, sorting a spreadsheet, converting files from one format to another, retrieving a price from a website each morning. One need not learn to code. One need only learn to describe what one wishes the code to do. Which is --- and this, if one may venture the observation, is the point of this entire book --- specification._
 *The Spec:*
+
 ::: prompt
 I have a repetitive task I want to automate:
 [describe the task in plain language — e.g., "every week I download
@@ -166,6 +168,7 @@ Vibe coding evolved. Professional engineers now practice _agentic coding_ — wr
 *See also:* WB-4: Learn to Work Better with AI Agents, Chapter 2: Your First Three Conversations, Chapter 4: How to Ask for What You Actually Want
 *My Man Jeeves:* _When the billionaire class engaged a personal assistant, the first week served as an audition --- not of competence, but of fit. Does she send bullet points or paragraphs? Does he say "Mr. Arnault" or "Bernard"? Does she flag difficulties immediately or reserve them for the morning briefing? The assistant who survived the probationary period was the one who matched the principal's communication rhythm without requiring instruction twice. One's Agent possesses the same capacity for customization --- and unlike a human assistant, it is not in the least disposed to take the feedback personally. The difference, one might note, is that the billionaire invested in a three-month trial period. One receives a settings panel and ten minutes._
 *The Spec:*
+
 ::: prompt
 I want to set up my AI assistant's profile so every conversation
 starts with it already knowing who I am and how I communicate.
@@ -234,6 +237,7 @@ The billionaire class treated the personal assistant hire like a casting call �
 *See also:* Strategy 0: Specify (the full specification interview method), Chapter 4: How to Ask for What You Actually Want
 *My Man Jeeves:* _This is the Skill that instructs one in the use of the tool upon which every other Skill depends. If the book may be likened to a workshop, this would be the safety orientation for the power tools. The billionaire class had no occasion to acquire this practice --- they already maintained a staff that translated vague instructions into precise tasks. The chief of staff, the executive assistant, the law clerk --- these are, in essence, human specification interfaces. One is learning the same practice, applied to a rather different kind of assistant._
 *The Spec:*
+
 ::: prompt
 I want to get better at working with AI Agents — not just
 using them, but understanding how to get consistently useful
@@ -299,6 +303,7 @@ Research on expertise development (Ericsson et al., 1993) identifies _deliberate
 *See also:* WB-7: Writing in CommonMark (for writing your content), WB-8: Blogging and Journaling
 *My Man Jeeves:* _The billionaire class has always maintained a web presence managed by professionals. The remainder of the population received Facebook pages and LinkedIn profiles --- land one rents on platforms that may alter the terms, throttle the reach, or cause the content to vanish at any moment. Owning one's own website is the digital equivalent of owning one's home rather than renting it. It has always been possible. It has not, until recently, been this straightforward. The [IndieWeb](https://indieweb.org/) is the movement that holds a simple principle: publish on one's own site first, syndicate to the platforms second, and never lose one's words because a company pivoted. One's Agent can build the site._
 *The Spec:*
+
 ::: prompt
 I want to build my own personal website. I have never done this before.
 I want it to be simple, fast, and mine — not hosted on someone else's
@@ -365,6 +370,7 @@ The web was designed as a decentralized system — [RFC 2616](https://en.wikiped
 *See also:* Li-11: Escaping Social Media (for reducing compulsive consumption), WB-5: Build a Website, Own Your Corner of the Internet
 *My Man Jeeves:* _Before the algorithm, there existed RSS --- a protocol that permitted one to subscribe to any website and receive its updates in a single reader, in chronological order, with no advertisements, no ranking, no engagement optimization, and no company determining what one should see next. RSS, one feels compelled to mention, still works. It never stopped working. The platforms merely ceased to promote it, as a protocol that places control in the hands of the user does not, regrettably, generate advertising revenue. One's Agent can help one set it up._
 *The Spec:*
+
 ::: prompt
 I want to read the web on my own terms — without algorithms
 deciding what I see and without social media feeds.
@@ -381,6 +387,7 @@ Please help me:
 *What to do with the Output:* Set up a feed reader and add ten sources. That is your starting library. Within a week, you will notice a change: you are reading what you chose, not what an algorithm chose for you. The difference in signal quality — and in how you feel afterward — is immediate and measurable.
 
 *Common reading Expert Role specs:*
+
 ::: prompt
 Act as my research librarian. Here are the topics I care about:
 [list]. Find me the best independent sources — blogs, newsletters,
@@ -426,6 +433,7 @@ The wealthy and educated have always curated their information sources — subsc
 *See also:* WB-5: Building Your Own Website, WB-8: Blogging and Journaling
 *My Man Jeeves:* _[CommonMark](https://commonmark.org/) serves as the universal language of AI in much the way English serves as the universal language of air traffic control --- not because it is the finest available, but because all parties agreed upon it and it functions reliably. It is plain text with a modest number of symbols that carry meaning. One can acquire the entire language in ten minutes. This book was written in [Djot](https://djot.net), a related format created by the same author --- but that is a digression. One's Agent thinks in CommonMark. When one writes in CommonMark, one is writing in the lingua franca of every AI system on the market --- which is to say, one's Agent can process, format, and transform one's writing with fewer tokens and greater precision than any other format permits._
 *The Spec:*
+
 ::: prompt
 I want to learn CommonMark so I can write content for my website
 and communicate more effectively with my AI Agent.
@@ -474,6 +482,7 @@ In the pre-web era, citation was gatekept by publishers, editors, and academic i
 *See also:* WB-7: Writing in CommonMark, WB-5: Build a Website, Own Your Corner of the Internet, Li-8: Wellness Coach (journaling as mental health practice)
 *My Man Jeeves:* _One observes that every sitcom family maintained a room where the substantive conversations took place. For the [Conners](https://en.wikipedia.org/wiki/Roseanne) it was the kitchen table. For the [Seinfelds](https://en.wikipedia.org/wiki/Seinfeld) it was the apartment. For the [Simpsons](https://en.wikipedia.org/wiki/The%5FSimpsons) it was the couch. A blog, if one may draw the parallel, is that room --- except one has built it oneself, one owns the walls, and no one is in a position to cancel the programme. A journal is the same room with the door closed. Both represent acts of thinking, whether in public or in private, and both are rather more valuable than one might suppose. One's Agent can help one start, and — should one prefer the door closed — it will not read over one's shoulder unless asked._
 *The Spec:*
+
 ::: prompt
 I want to start [blogging publicly / journaling privately / both].
 My situation:
@@ -537,10 +546,12 @@ Research on [reflective practice](https://en.wikipedia.org/wiki/Reflective%5Fpra
 ---
 
 #### WB-9: Preservation and Legacy
+
 *Strategy:* Research + Navigate
 *See also:* WB-5: Building Your Own Website (owning vs. renting), H-7: Preparing for End-of-Life Conversations (the analog equivalent)
 *My Man Jeeves:* _The [Library of Alexandria](https://en.wikipedia.org/wiki/Library%5Fof%5FAlexandria) burned. The Dead Sea Scrolls survived in clay jars for two thousand years. MySpace lost 50 million songs in a server migration. [GeoCities](https://en.wikipedia.org/wiki/GeoCities) was deleted by Yahoo in 2009. The lesson, one ventures to suggest, has been consistent across millennia: what survives is what someone deliberately chose to preserve. The internet remembers everything and nothing --- everything that someone took the trouble to archive, nothing that was left on a platform that shut down, pivoted, or mislaid a database. One's Agent can help one make the deliberate choice._
 *The Spec:*
+
 ::: prompt
 I want to make sure my online work — writing, photos, creative
 projects — survives beyond any single platform or service.
@@ -591,10 +602,12 @@ The grief of digital loss — lost photos, deleted accounts, inaccessible archiv
 ---
 
 #### WB-10: Doing Real Research with Your Agent
+
 *Strategy:* Research + Decode
 *See also:* Li-13: Using Your Public and Academic Library (where the Agent's summary ends and the primary source begins), WB-6: Stop Doomscrolling the Algorithmic Feed (the upstream version of this Skill), WB-7: Write in CommonMark, the language of AI (for taking notes the Agent can read back), WB-1: Learning Any App or Digital Skill
 *My Man Jeeves:* _A distinction of some consequence has long obtained between *searching* and *researching*. The former returns ten links ranked by the advertising market; the latter requires one to formulate a question, locate the relevant literature, weigh the contradictory findings, and arrive at a position one can defend. The former has, since approximately 2001, been available to everyone; the latter has remained the province of those with access to a research librarian, a university subscription, and the unhurried hours in which to use them. One's Agent does not make one a scholar. It does, however, perform the preliminary work that a graduate student would once have performed for a professor — framing the question, surveying the field, identifying the disagreements, and indicating where one ought to read next. The reader is then in a position to do the reading._
 *The Spec:*
+
 ::: prompt
 I want to research [topic / question / decision] thoroughly,
 not just look it up.

--- a/src/content/02-field-guide/11-creative/index.dj
+++ b/src/content/02-field-guide/11-creative/index.dj
@@ -20,6 +20,7 @@ _Creativity was never the exclusive domain of artists, writers, and filmmakers. 
 *See also:* WB-1: Learning Any App or Digital Skill, Li-5: Planning Trips (for travel photography)
 *My Man Jeeves:* _One might observe that a professional portrait photographer commands $200 to $500 per session, that a wedding photographer expects $2,000 to $5,000, and that photography courses range from $20 online to $500 and up in person, proceeding upward with some enthusiasm in either direction. The difficulty, if one may say so, has never been the camera — the device in one's pocket has been more than adequate for some years now. The difficulty is that composition, light, and the rather undervalued discipline of knowing what to exclude from the frame are learnable skills that have historically required either formal instruction or prolonged apprenticeship to acquire. It would appear that those of considerable means retain a personal photographer for such purposes. The reader, however, now has access to a tutor of considerable patience, one that has studied every composition technique Annie Leibovitz ever employed and is prepared to explain them in terms of the photograph one is about to take._
 *The Spec:*
+
 ::: prompt
 I want to take better photos with [my phone / my camera].
 My situation:
@@ -67,10 +68,12 @@ The gap between a snapshot and a photograph is not equipment or talent — it is
 ---
 
 #### Cr-2: Learning Visual Design
+
 *Strategy:* Create + Research (Expert Role)
 *See also:* Cr-1: Taking Better Photos (the same compositional principles apply), WB-5: Build a Website, Own Your Corner of the Internet (for applying design to your site), WB-1: Learning Any App or Digital Skill (for learning design software)
 *My Man Jeeves:* _It may be worth noting that a graphic designer charges $25 to $150 an hour, and that a brand identity package — logo, colors, typography, templates — begins at $5,000 with a willingness to ascend from there. Design school, one understands, is a four-year degree that imparts principles one might acquire in an afternoon, along with taste, which one develops only through practice. The principles themselves are not closely guarded. Hierarchy, contrast, alignment, proximity, repetition — five words that govern every poster, website, business card, and yard sale flyer one has ever encountered. The distinction between the yard sale flyer that produces results and the one that goes unread is not a matter of talent. It is a matter of knowing those five words and what they mean. Those of substantial means maintain a design team on retainer. The reader has an Agent, and it is conversant with the same principles._
 *The Spec:*
+
 ::: prompt
 Act as an expert visual designer. I need help with
 [a website / a poster / a flyer / a business card /
@@ -100,6 +103,7 @@ Please:
 *What to do with the Output:* Make the thing. Then screenshot it and send it back to your Agent: _"Here's what I made. What would a professional designer change?"_ Design is iterative — the first version is never the final one. Each round of feedback teaches you something the principles alone cannot: how to see what is wrong. That skill transfers to everything you design after this.
 
 *Common visual design Expert Role specs:*
+
 ::: prompt
 Act as a brand designer. I'm starting a [small business /
 nonprofit / community organization] called [name]. Help me
@@ -139,6 +143,7 @@ Design tools like [Canva](https://en.wikipedia.org/wiki/Canva) are free and powe
 *See also:* Cr-1: Taking Better Photos (the visual skills transfer), WB-1: Learning Any App or Digital Skill (for learning the software)
 *My Man Jeeves:* _A difficulty presents itself in the matter of film editing. Film school costs six figures and requires four years. YouTube tutorials on the subject proceed from the assumption that one already knows what a "J-cut" is and why one might desire one. Professional editors charge $50 to $150 an hour and are engaged months in advance. The software, one might observe, is now free — [DaVinci Resolve](https://en.wikipedia.org/wiki/DaVinci%5FResolve) accomplishes what a $100,000 Avid suite accomplished in 1995 — yet the storytelling craft of editing, the part in which raw footage becomes something a viewer wishes to watch, has not been similarly democratized. It remains the province of film schools and editing suites. One's Agent, however, is conversant with the craft. It is prepared to explain why the pacing feels wrong, what to cut, and where the story actually begins. It is never the first clip._
 *The Spec:*
+
 ::: prompt
 I want to edit a video.
 My situation:
@@ -187,6 +192,7 @@ For editing advice and step-by-step software guidance, any major AI tool works w
 *See also:* Cr-11: Learning an Instrument (the performance side), Cr-6: Podcasting and Audio Production (audio skills transfer), WB-1: Learning Any App or Digital Skill
 *My Man Jeeves:* _One observes that a recording studio charges $50 to $500 an hour, that a music production course at a community college runs $800 to $2,000 per semester, and that the instruments alone — even before one considers microphones, cables, and the various boxes that make sounds louder or different — represent an investment that has historically excluded anyone who could not first afford the investment. The difficulty, if one may say so, is not musical. [GarageBand](https://en.wikipedia.org/wiki/GarageBand) ships free with every Apple device. [BandLab](https://en.wikipedia.org/wiki/BandLab_Technologies) runs in a browser and costs nothing. Between them, one has access to more instruments, effects, and recording capability than the Beatles had at Abbey Road in 1967. What one does not have — and what no free tool provides — is the craft knowledge: why a chord progression feels finished, why a rhythm track feels alive or mechanical, why a melody stays in someone's head or doesn't. Those of considerable means retain a producer. The reader now has an Agent conversant with music theory, arrangement, and the specific capabilities of whichever free tool sits open on their screen._
 *The Spec:*
+
 ::: prompt
 I want to make music.
 My situation:
@@ -250,6 +256,7 @@ GarageBand ships free on every Apple device. [BandLab](https://www.bandlab.com/)
 *See also:* Cr-5: Making Music (audio skills transfer), WB-5: Build a Website, Own Your Corner of the Internet, Cr-3: Editing a Movie (same storytelling principles)
 *My Man Jeeves:* _It may be worth observing that podcasting is the most democratic broadcast medium to emerge in some time. The equipment required is a telephone and a quiet room. The cost of distribution is zero — [RSS](https://en.wikipedia.org/wiki/RSS) is an open standard that no company owns and no company can revoke. A radio license costs hundreds of thousands of dollars and requires federal permission. A YouTube channel requires a camera, lighting, and the willingness to be looked at. A podcast requires a voice, a topic, and the ability to press record. The difficulty, if one may venture it, is not the recording. It is everything that separates a recording from a show: structure, pacing, the edit that removes the forty-five seconds of throat-clearing at the top, the audio quality that lets the listener forget they are listening to audio at all. Those of substantial means hire a producer. The reader has an Agent who is conversant with the entire production chain, from microphone placement to RSS feed configuration, and who has never once suggested that the reader needs a $400 microphone to begin._
 *The Spec:*
+
 ::: prompt
 I want to start a podcast.
 My situation:
@@ -305,6 +312,7 @@ Podcast discoverability algorithms favor shows that publish consistently on a sc
 *See also:* Cr-2: Learning Visual Design (principles overlap), Cr-1: Taking Better Photos (same compositional eye)
 *My Man Jeeves:* _A persistent belief holds that drawing is a talent — that one is born able to render a horse or one is not, and that no instruction can bridge the distance between the two conditions. One might gently observe that this belief is incorrect. Betty Edwards demonstrated in 1979 that drawing is a learnable perceptual skill, not an innate gift, and that the primary obstacle is not the hand but the brain's preference for symbols over observation — one draws what one _thinks_ a face looks like rather than what one _sees_. Drawing instruction costs $30 to $80 per class at a community center, $200 to $500 for a structured course, and $40,000 to $200,000 for an art school degree that teaches the same fundamentals one might acquire with a pencil, a piece of paper, and a tutor of sufficient patience. The reader has such a tutor. It will not judge the first attempt, which is more than can be said for the average middle-school art class._
 *The Spec:*
+
 ::: prompt
 I want to learn to draw.
 My situation:
@@ -364,6 +372,7 @@ AI image generators can produce illustrations, but that is not what this Skill i
 *See also:* Ho-2: Home Repair and DIY (tool skills transfer), Ho-3: Right to Repair (same philosophy of ownership), Ch-1: Shopping Your Values (materials sourcing)
 *My Man Jeeves:* _One notes with some interest that the maker movement represents a return to a set of skills that were, within living memory, simply called "knowing how to do things." Sewing, woodworking, basic metalwork, and the repair of household objects were not hobbies in one's grandparents' generation. They were the baseline. The professionalisation of craft — and the simultaneous availability of disposable goods priced to make repair irrational — converted self-sufficiency into a specialty interest. A sewing class now costs $30 to $75 per session. A woodworking course runs $200 to $600. Access to a [makerspace](https://en.wikipedia.org/wiki/Hackerspace) with a laser cutter and 3D printer costs $50 to $150 per month in membership fees, assuming one lives near enough to one. Those of means commission bespoke furniture and tailored clothing. The reader has an Agent that can teach pattern-reading, joint selection, material calculation, and the specific operational procedures of whatever tools are available — from a $15 hand saw to a $3,000 laser cutter._
 *The Spec:*
+
 ::: prompt
 I want to make something.
 My situation:
@@ -427,6 +436,7 @@ Makerspaces are not evenly distributed. They cluster in cities, near universitie
 *See also:* WB-8: Blogging and Journaling (a regular writing practice), Li-2: Writing a Eulogy (specific application of craft under pressure)
 *My Man Jeeves:* _One observes that creative writing has always presented a particular difficulty in the matter of instruction. The craft can be taught — the evidence of university programs, workshops, and apprenticeships spanning centuries confirms as much — yet the teaching has been unevenly distributed, to put the matter with some delicacy. An MFA program costs $30,000 to $60,000 and accepts a small fraction of applicants. A community workshop, if one exists in one's vicinity, costs $200 to $500 and may or may not be led by someone who has published. The alternative has historically been to write alone, in the dark, hoping that the instincts one absorbed from reading were sufficient to produce something worth reading in return. Sometimes they were. Often they were not, and there was nobody qualified to explain why. Those of considerable means have always retained editors. Workshop seats at [Iowa](https://en.wikipedia.org/wiki/Iowa_Writers%27_Workshop) and [Bread Loaf](https://en.wikipedia.org/wiki/Bread_Loaf_Writers%27_Conference) have always gone disproportionately to those with the connections to know such things existed and the means to attend. The reader now has a writing tutor that has read more widely than any workshop instructor alive and is available at two in the morning, which is when most writing happens._
 *The Spec:*
+
 ::: prompt
 I want to write [a short story / a poem / a personal essay /
 flash fiction / a screenplay scene / I'm not sure what form yet].
@@ -492,6 +502,7 @@ Write in plain text. A `.txt` or `.md` file will outlast every proprietary forma
 *See also:* Cr-2: Learning Visual Design (the principles behind the practice), WB-5: Build a Website, Own Your Corner of the Internet, W-1: Getting a Job (resume design)
 *My Man Jeeves:* _One might draw attention to a difficulty that presents itself with some regularity in the lives of those who are not, by profession, graphic designers — which is to say, nearly everyone. The school requests a flyer for the bake sale. The union local needs a poster for the meeting. A relative's birthday requires an invitation. The small business requires a social media graphic that does not resemble a ransom note. The community garden needs a sign. In each case, the person assigned the task possesses no training in typography, layout, color theory, or the rather critical discipline of visual hierarchy. They open [Canva](https://en.wikipedia.org/wiki/Canva), stare at five thousand templates, choose one at random, change the colors until it looks worse, and publish the result with a quiet sense of defeat. Those of considerable means employ a designer. The reader has an Agent capable of diagnosing why the flyer looks wrong and providing the specific remedies — which font to use, which one to remove, where the eye is going and where it should go instead._
 *The Spec:*
+
 ::: prompt
 I need to design [a flyer / a poster / an invitation /
 a social media graphic / a resume / a business card /
@@ -547,6 +558,7 @@ Resume design deserves a specific note: applicant tracking systems (ATS) — the
 *See also:* Cr-5: Making Music (the production side), Li-12: Developing a Habit (the practice discipline)
 *My Man Jeeves:* _A matter of some delicacy arises when one considers the learning of a musical instrument as an adult. Private music lessons run $30 to $80 per session, weekly, for a duration that competent instructors describe as "indefinite" — a term that, in financial contexts, one would regard with some suspicion. Group classes at community music schools cost $150 to $400 per term and proceed at the pace of the least prepared student. The instruments themselves range from $50 for a serviceable ukulele to figures one prefers not to contemplate for a piano. The greater difficulty, however, is not financial. It is that learning an instrument as an adult is slow, physically uncomfortable, and acutely humbling in a way that few other skills replicate. One's fingers do not cooperate. The sounds one produces bear no resemblance to the sounds one intended. Progress is measured in weeks, not hours. Those who persevere acquire a skill that research identifies as uniquely beneficial to cognitive health, emotional regulation, and the particular satisfaction of making a sound that is, at last, the sound one meant to make. One's Agent cannot hold the instrument. It can, however, design the practice routine, explain the theory, diagnose the plateau, and maintain the patient, unhurried encouragement that a $60-per-hour instructor provides in rather more limited supply._
 *The Spec:*
+
 ::: prompt
 I want to learn [guitar / piano / ukulele / bass / drums /
 violin / harmonica / banjo / another instrument].

--- a/src/content/02-field-guide/99-transportation/index.dj
+++ b/src/content/02-field-guide/99-transportation/index.dj
@@ -13,10 +13,12 @@ _Getting from one place to another is the second largest expense in most America
 ---
 
 #### Tr-1: Car Ownership
+
 *Strategy:* Research + Decide + Assert
 *See also:* L-1: Negotiating a Contract (for the purchase agreement), M-6: Financial Coach (for the financing decision)
 *My Man Jeeves:* _One might observe that the automobile dealership represents perhaps the most refined information asymmetry in American commerce. The dealer is in possession of the invoice price, the holdback, the manufacturer incentives, the floor plan cost, the trade-in wholesale value, and the financing margin. The customer, by contrast, is in possession of the sticker price — a figure the dealer has placed there with the express intention that one will negotiate downward from it and experience a sense of victory. It would appear that an Agent, having access to the invoice price as well, alters the nature of the exchange rather considerably._
 *The Spec:*
+
 ::: prompt
 I need to [buy / lease / sell] a car.
 My situation:
@@ -66,10 +68,12 @@ Veterans with a service-connected disability may qualify for the VA Automobile A
 ---
 
 #### Tr-2: Car Maintenance
+
 *Strategy:* Diagnose + Research (Expert Role)
 *See also:* Tr-1: Car Ownership, L-1: Negotiating a Contract (for understanding service agreements)
 *My Man Jeeves:* _A difficulty presents itself in the automotive repair trade, which operates on the well-documented principle that most vehicle owners do not know what their car requires, cannot verify whether the work was performed, and will pay to resolve the uncertainty. One might note that an Agent, having consulted the service manual, is rather better positioned to assess the situation. It is worth observing that persons of considerable means do not, as a rule, accept the first quotation. There would seem to be no reason why anyone else should._
 *The Spec:*
+
 ::: prompt
 Act as an experienced mechanic and car maintenance advisor.
 My car: [year, make, model, approximate mileage]
@@ -96,10 +100,12 @@ To make this Expert Role persistent across sessions, save it as a *Project* (Cla
 ---
 
 #### Tr-3: Public Transit, Cycling, and Walkability
+
 *Strategy:* Research + Navigate
 *See also:* Li-5: Planning Trips (for transit in unfamiliar cities), C-6: Advocating for Change (for local transit advocacy)
 *My Man Jeeves:* _It would appear that the United States has devoted the better part of seventy years to constructing an infrastructure that assumes every adult to be in possession of a motor car. The consequence, one might observe, is a country in which not driving is regarded as a personal failing rather than a design outcome. In cities where functional transit, cycling infrastructure, and walkable neighborhoods exist, car-free or car-light living saves thousands of dollars per year and improves health outcomes measurably. In cities where these things do not exist, the absence is a policy choice, not an inevitability — and it can be altered at the local level, by those who present themselves at the relevant meetings. One's Agent can help one evaluate the options, calculate the savings, and — should advocacy be required — prepare for the meeting._
 *The Spec:*
+
 ::: prompt
 I want to [reduce my car dependence / go car-free / understand
 my transit options / make my commute better / advocate for
@@ -137,10 +143,12 @@ Transit access is deeply unequal. Wealthier neighborhoods get better service. Ca
 ---
 
 #### Tr-4: Air Travel
+
 *Strategy:* Prepare + Assert
 *See also:* Li-5: Planning Trips (for trip planning broadly), IRL-3: First-Time Situations (for first-time flyers)
 *My Man Jeeves:* _One might characterize air travel as a system that charges variable prices for the same seat, enforces rules that shift by airline, route, and day of the week, and operates under federal consumer protection laws that most passengers have not had occasion to read. The airline is aware of one's fare class, one's rebooking options, and the compensation it owes. The passenger, as a general rule, is aware of a confirmation number. An Agent, it would appear, has access to the same regulations the airline's customer service team consults — which places one in the rather more agreeable position of being able to cite them as well._
 *The Spec:*
+
 ::: prompt
 I need help with air travel.
 My situation: [booking a flight / flight was canceled or delayed /
@@ -186,10 +194,12 @@ TSA procedures are opaque by design and anxiety-producing by experience. The pro
 ---
 
 #### Tr-5: Road Trips and Long-Distance Driving
+
 *Strategy:* Prepare + Navigate
 *See also:* Tr-2: Car Maintenance, Li-5: Planning Trips
 *My Man Jeeves:* _One might observe that the interstate highway system, for all its considerable merits, was designed under the assumption that the traveler is in possession of a reliable vehicle, a full tank, and the good fortune not to require medical attention between exits. The reality, one has found, is rather less accommodating. Rest stops close without notice. Cell service evaporates for stretches that are precisely as long as one's capacity for anxiety. The distance between fuel stations in the American West can exceed the range of a vehicle whose gauge reads optimistic in the best of circumstances. An Agent, consulted before departure, can identify every one of these gaps --- and suggest what to put in the boot to address them._
 *The Spec:*
+
 ::: prompt
 I'm planning a road trip and want to be prepared.
 My route: [origin to destination, or a multi-stop itinerary]
@@ -237,10 +247,12 @@ Road trip preparation is class-coded. Wealthier families have newer cars, AAA me
 ---
 
 #### Tr-7: Understanding Rideshare and Delivery Gig Work
+
 *Strategy:* Research + Decode
 *See also:* W-8: Gig Work and Self-Employment, M-7: Taxes
 *My Man Jeeves:* _The rideshare arrangement presents a matter of some interest from both sides of the transaction. The passenger perceives a taxi that has been made more convenient; the driver perceives a job that has been made less stable. The company, one might note, has structured the arrangement so that neither party is in full possession of how the pricing works. Surge pricing is presented to the passenger as supply and demand. To the driver, the surge multiplier and the fare the passenger pays are not, as it happens, the same number. One's Agent can decode both sides of this equation --- which is rather the point._
 *The Spec:*
+
 ::: prompt
 I want to understand rideshare and delivery gig work.
 My perspective: [I'm a rider/customer / I'm considering driving /
@@ -282,10 +294,12 @@ _"I spent $[amount] on rideshares last month. Based on my typical trips, would a
 ---
 
 #### Tr-8: Navigating International Travel
+
 *Strategy:* Prepare + Navigate
 *See also:* Tr-4: Air Travel, IRL-3: First-Time Situations, Li-5: Planning Trips
 *My Man Jeeves:* _International travel, one has observed, is governed by a set of interlocking bureaucracies --- passports, visas, customs declarations, foreign transit systems, currency exchange --- each of which operates under rules that are fully public, entirely discoverable, and almost never consulted by the traveler until the evening before departure. The consequence is predictable. One finds oneself at passport control in a country whose entry requirements one has not verified, holding a document that expires in four months when the requirement is six. An Agent, consulted in advance, would have mentioned this. They are, in this respect, rather like a good valet: most useful when engaged before the crisis, not during it._
 *The Spec:*
+
 ::: prompt
 I'm planning international travel and need help preparing.
 My destination: [country or countries]
@@ -333,10 +347,12 @@ Ask your Agent to compare Global Entry, TSA PreCheck, and CLEAR. Global Entry ($
 ---
 
 #### Tr-9: Accessible Transportation
+
 *Strategy:* Assert + Navigate
 *See also:* Tr-3: Public Transit, Cycling, and Walkability, C-7: Disability Rights
 *My Man Jeeves:* _The Americans with Disabilities Act, one might observe, guarantees accessible public transportation as a matter of federal law. The distance between the guarantee and the experience, however, is considerable. Paratransit services operate within rules that are technically compliant and practically hostile --- narrow booking windows, multi-hour pickup ranges, penalties for no-shows that assume the rider's schedule is infinitely flexible. The elevator at the train station is broken again. The bus ramp does not deploy. The rideshare driver cancels upon seeing the wheelchair. These are not edge cases. They are the system as experienced by the people it claims to serve. An Agent can help one know precisely what the law requires, file the complaint when it is not provided, and identify the alternatives that actually function._
 *The Spec:*
+
 ::: prompt
 I need help with accessible transportation.
 My situation: [describe --- mobility aid user, visual impairment,
@@ -384,10 +400,12 @@ U.S. airlines mishandled 11,527 wheelchairs and scooters in 2023 --- roughly 31 
 ---
 
 #### Tr-10: Electric Vehicles and the Transition
+
 *Strategy:* Research + Decide
 *See also:* Tr-1: Car Ownership, M-10: Big Financial Decisions
 *My Man Jeeves:* _The electric vehicle market, one has observed, generates a quantity of opinion that bears very little relation to the quantity of data available. One camp insists that the technology is not ready. The other insists it will save the planet by Tuesday. Neither, it would appear, has consulted a spreadsheet. The pertinent questions are rather more pedestrian: can one charge it where one lives, what does it cost to own over five years compared to what one drives now, and does the used market offer anything that a household of ordinary means can afford. An Agent, being unburdened by ideology on the matter, can answer all three --- which places one in the agreeable position of making a decision based on arithmetic rather than allegiance._
 *The Spec:*
+
 ::: prompt
 I'm considering an electric vehicle and want the real picture.
 My situation:
@@ -436,10 +454,12 @@ The EV transition has a class problem. Federal tax credits require enough tax li
 ---
 
 #### Tr-11: Boating, RVs, and Niche Vehicles
+
 *Strategy:* Research + Navigate
 *See also:* Tr-1: Car Ownership, M-8: Insurance
 *My Man Jeeves:* _The purchase of a boat, a recreational vehicle, or a similarly specialized conveyance introduces one to a regulatory environment that appears to have been designed by a committee whose members were not on speaking terms. Registration requirements vary by state and by waterway. Insurance is mandatory in some jurisdictions, optional in others, and confusingly priced in all of them. Licensing requirements range from nonexistent to Coast Guard certification, depending on the vessel's length and one's state of residence. The RV, for its part, occupies an existential category --- part vehicle, part dwelling --- that satisfies the requirements of neither the DMV nor the building code with any particular enthusiasm. One's Agent, having no emotional attachment to the open water or the open road, can sort through the bureaucracy rather efficiently._
 *The Spec:*
+
 ::: prompt
 I'm looking into [buying / renting / maintaining] a
 [boat / RV / motorcycle / ATV / other specialty vehicle].

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -325,6 +325,11 @@ th {
   color: var(--link);
 }
 
+.endnote-num {
+  font-weight: bold;
+  margin-right: 0.3em;
+}
+
 .endnote-backlink {
   margin-left: 0.4em;
   text-decoration: none;


### PR DESCRIPTION
## Summary

- **Endnote UX:** each note now opens with a bold `[N]` label and ends with an inline `↵` backlink (both flow with the prose instead of stranded on their own lines). Mirrors the in-text `[N]` reference format.
- **Djot block-boundary fixes:** 263 `*Label:*\n::: prompt` cases were silently being absorbed into paragraphs (div never formed); 113 field-guide headings were absorbing their Strategy / See also / Jeeves passage / The Spec: metadata directly into the `<h4>` tag. Inserted the required blank lines. No regex fixes — parse-tree–confirmed violations only.
- **AppleRef-style cross-references:** new `ref:` URL scheme — source writes `[H-2 (Doctor's Appointments)](ref:h-2)`, build resolves to `01-health.xhtml#h-2`. Unresolved refs emit a warning and degrade to plain text. 49 hardcoded cross-refs migrated; 131 skill codes registered.
- Automatic heading anchor ids (derived from code prefix, e.g. `H-2` → `id="h-2"`) hoisted onto `<h4>` by the section renderer override.

One known content drift surfaced: `ref:cr-4` ("Writing a Book") in Strategy 9 has no matching skill in the Creative chapter (skips from Cr-3 to Cr-5). Build emits a clear warning; the reference renders as plain text rather than a dead anchor.

## Test plan

- [x] `npm test` — 55/55 tests pass (4 new ref-link tests, 2 new endnote tests)
- [x] `npm run build:check` — clean
- [x] `npm run build` — builds, prints the expected `cr-4` warning
- [x] Spot-checked rendered ePub: field-guide `<h4>` tags contain only heading text; endnotes render with `[N]` + `↵`; cross-refs in Strategy chapters link to correct anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)