### PR TITLE
Strategy 0 (Specify): add DOI link to Pescosolido (1992) footnote

### DIFF
--- a/src/content/01-strategies/00-strategy-0-specify/index.dj
+++ b/src/content/01-strategies/00-strategy-0-specify/index.dj
@@ -169,4 +169,4 @@ Research on informal expert consultation — asking a friend who happens to have
 :::
 
 
-[^s0-2]: Pescosolido, B.A. (1992). "Beyond rational choice: The social dynamics of how people seek help." _American Journal of Sociology_, 97(4), 1096-1138.
+[^s0-2]: Pescosolido, B.A. (1992). ["Beyond rational choice: The social dynamics of how people seek help."](https://doi.org/10.1086/229863) _American Journal of Sociology_, 97(4), 1096-1138.


### PR DESCRIPTION
Eighth chapter in the editorial pass — Strategy 0: Specify (the first Strategy chapter).

## Audit summary

Audited against `style-guide.md`, `voice-and-audience.md`, `editorial-conventions.md`, `principles.md`, and `reginald-jeeves.voice.md`. The chapter opener strictly follows the Strategy-chapter structural rules in `editorial-conventions.md`: heading → subtitle → divider → TRINITRON caption → divider → "The episode:" prose → "The lesson:" prose → "My Man Jeeves:" capstone → divider → body. The Jeeves capstone uses the spec's capstone shape (validate + mechanism + structural punch, no agency beat — *"One had only to ask five clarifying questions"*). The spec interview loop, full worked example (insurance MRI appeal), and Expert Role variant are all well-formed. One citation hyperlink gap.

## Suggested change in this PR

**Add the DOI link to footnote `[^s0-2]`** (Pescosolido 1992). The citation was bare:

```
[^s0-2]: Pescosolido, B.A. (1992). "Beyond rational choice: The social
        dynamics of how people seek help." American Journal of Sociology,
        97(4), 1096-1138.
```

`style-guide.md` § Citations: *"Every citation must include a hyperlink to the source. Journal articles: link to DOI, PubMed, or PMC."* Added the canonical DOI: `https://doi.org/10.1086/229863`. Footnote `[^s0-1]` (Kuyken et al., Guilford Press) already had a publisher-page link.

## Things I checked and left alone (deliberate)

- **Strategy-chapter opener structure** (lines 9-27). Conforms exactly to `editorial-conventions.md`:
  ```
  ## Strategy 0: Specify
  _subtitle_
  ---
  [_TRINITRON caption_]{.art stem="trinitron-s0-specify"}
  ---
  *The episode:* ...
  *The lesson:* ...
  *My Man Jeeves:* _capstone_
  ---
  body
  ```
- **Jeeves capstone voice.** Strict Jeeves register — no contractions, indirect, subordinate clauses, *"One had only to..."* phrasing. The three beats are cleanly hit: (1) validate — *"Requests conveyed without specification are, invariably, carried out"*; (2) mechanism — *"The article delivered bears to the article intended a resemblance that one might describe, generously, as figurative"*; (3) structural punch — *"One had only to ask five clarifying questions."* No agency beat, as the spec prescribes for Strategy capstones.
- **Footnote IDs** follow the `[^s{n}-{seq}]` format. Order matches source-reference order.
- **Cross-references** to Field Guide Skills use the `ref:` system (`[Ho-7 ...](ref:ho-7)`, etc.); appendix cross-reference uses the established `.xhtml` link pattern. Both consistent with book convention.
- **Worked example structure.** Five prompt/agent blocks (opening → questions → answers → proposed spec → correction) demonstrate the interview loop end-to-end. The prompt voice is appropriately casual; the agent voice is appropriately structured.
- **Callouts.** 1 science (collaborative formulation parallel — Kuyken et al.), 1 also (Project / Gem / custom GPT), 1 meme ("I know kung fu"), 1 science (informal expert consultation — Pescosolido). All earn their place.
- **Em-dashes.** 19 Unicode, 0 ASCII inline.
- **"five clarifying questions"** (Jeeves capstone) and **"three to five"** (line 43) — under 10, spelled out per spec. ✓
- **Episode reference** `[Seinfeld:S4E3 "The Pitch"](url), 1992` — strict spec format. ✓

## Open questions for you

1. None substantive — the chapter is in good shape.

## Verification

- `npm run build:check`, `npm test` (55/55), and `npm run build` all clean.
- One-line citation link added; no other source touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_012gTjgDeiEzQtyuWXiN1GoR)_