### PR TITLE
Strategy 4 (Navigate): link ERISA to Wikipedia per first-mention rule

### DIFF
--- a/src/content/01-strategies/04-strategy-4-navigate/index.dj
+++ b/src/content/01-strategies/04-strategy-4-navigate/index.dj
@@ -250,8 +250,8 @@ paths most people never reach:
    Insurance (CDI in California). This creates a
    regulatory record and can reopen the case.
 
-2. If your plan is employer-provided (ERISA), you may
-   have the right to file in federal court, though at
+2. If your plan is employer-provided ([ERISA](https://en.wikipedia.org/wiki/Employee%5FRetirement%5FIncome%5FSecurity%5FAct%5Fof%5F1974)), you
+   may have the right to file in federal court, though at
    that point you want a patient advocate or attorney.
 
 The escalation ladder exists. The insurance company is


### PR DESCRIPTION
Twelfth chapter in the editorial pass — Strategy 4: Navigate.

## Audit summary

Audited against `style-guide.md`, `voice-and-audience.md`, `editorial-conventions.md`, `principles.md`, and `reginald-jeeves.voice.md`. The Strategy-chapter opener structure conforms. Three worked examples (filing for unemployment in California / first-level insurance appeal / small claims for a withheld deposit) demonstrate Navigate across the procedural-bureaucracy domains the book targets. The Jeeves capstone is one of the strongest in the book — *"This has always been the difference between an institution and an individual: one knows where its own forms are kept."* — three beats cleanly. Only one small spec-compliance gap to fix.

## Suggested change in this PR

**Link `ERISA` to its Wikipedia article on first mention** (line 253). `style-guide.md`'s first-mention rule: *"When a term the reader may not know appears for the first time, define it inline or link to Wikipedia."*

```
2. If your plan is employer-provided ([ERISA](https://en.wikipedia.org/wiki/Employee%5FRetirement%5FIncome%5FSecurity%5FAct%5Fof%5F1974)), you
   may have the right to file in federal court, ...
```

The acronym ERISA isn't expanded inline, and the practical consequence the sentence describes (right to file in federal court) depends on the reader knowing the plan-type frame. Adding the Wikipedia link costs nothing for readers who already know the acronym and helps the ones who don't.

## Things I checked and left alone (deliberate)

- **Strategy-chapter opener structure.** Strict spec form: heading → subtitle → divider → TRINITRON caption → divider → "The episode:" → "The lesson:" → "My Man Jeeves:" → divider → body.
- **Jeeves capstone** (line 25). Three beats hit cleanly: validate (*"When the correct procedure is unknown to those present, the incorrect procedure is improvised on the spot with considerable confidence"*) → mechanism (*"no one had troubled to locate it before it was urgently required"*) → structural punch (*"This has always been the difference between an institution and an individual: one knows where its own forms are kept"*). No agency beat per spec.
- **Footnote `[^s4-1]`** (Herd & Moynihan, *Administrative Burden*) — linked to Russell Sage Foundation publisher page. ✓ Only one footnote in the chapter, and it carries the citation hyperlink.
- **Em-dashes.** 22 Unicode em-dashes, 0 ASCII em-dashes (spaced or unspaced). Already consistent with the book-wide convention — no normalization needed (unlike #96 Strategy 3, which had 55 unspaced ASCII em-dashes).
- **First-mention rule** for other acronyms: CDI (*"your state's Department of Insurance (CDI in California)"*) and EDD (*"EDD (Employment Development Department)"*) are both defined inline on first use. ACA appears once parenthetically as a clarifier for "marketplace," which serves as the implicit definition. MRI, CT, GPT, ID are widely-known in this chapter's context. Only ERISA was an outlier.
- **Cross-references** to Field Guide Skills use `ref:` system. ✓
- **Episode reference** *[Seinfeld:S4E20 "The Junior Mint"](url), 1993* — strict spec format. The Junior Mint anchor for Navigate is perfect (the correct procedure exists; nobody took step one).
- **Numbers.** Dollar amounts and durations in days (`$2,400`, `$75`, `$5,000`, `21 days`, `30 days`, `180 days`, `45 days`, `15 days`) all in digits per spec. Mid-sentence prose durations (`two and a half years`, `three weeks ago`) spelled out.
- **Three meme/tip/fairness/also callouts** placed across the chapter pace it well. The Jurassic Park meme on line 42 is one of the book's best meme placements — *"It's a Unix system. I know this."* maps directly to the Navigate frame.

## Open questions for you

1. **"2 years" / "2 copies" inside numbered-step lists** (lines 349, 352). The chapter uses digit form for these two under-10 numbers when they appear inside DEADLINES / instruction lists where every surrounding number is already a digit (`21 days`, `30 days`, `45 days`, `15 days`, etc.). Per strict spec reading (*"Spell out one through nine"*) these would be *"two years"* and *"two copies"*. Per list-internal consistency, the digit form matches the surrounding numbers. The author's choice; flagging only. The same question applies to other Strategy and Field Guide chapters that have numbered-step lists.

## Verification

- `npm run build:check`, `npm test` (55/55), and `npm run build` all clean.
- Two-line edit (rewrap of the bullet around the new inline link); rendered XHTML inspected — ERISA is now a clickable link.

---
_Generated by [Claude Code](https://claude.ai/code/session_012gTjgDeiEzQtyuWXiN1GoR)_