### PR TITLE
Strategy 6 (Diagnose): em-dash, number, and PCP first-mention link

### DIFF
--- a/src/content/01-strategies/06-strategy-6-diagnose/index.dj
+++ b/src/content/01-strategies/06-strategy-6-diagnose/index.dj
@@ -165,7 +165,7 @@ The diagnostic questions your Agent asks are the same ones a good repair technic
 
 ### Example 2: Persistent Headaches That Started Two Weeks Ago
 
-The situation: you've had headaches nearly every day for two weeks. They weren't there before. You're caught between "it's probably nothing" and "what if it's serious" — the exact paralysis that makes people either ignore symptoms for months or go to the ER for something that's a Tuesday PCP visit.
+The situation: you've had headaches nearly every day for two weeks. They weren't there before. You're caught between "it's probably nothing" and "what if it's serious" — the exact paralysis that makes people either ignore symptoms for months or go to the ER for something that's a Tuesday [PCP](https://en.wikipedia.org/wiki/Primary%5Fcare%5Fphysician) visit.
 
 *Your opening message:*
 
@@ -264,7 +264,7 @@ Your Agent is not a doctor. It cannot examine you, order tests, or account for y
 [^s6-1]: The red-flag screening questions in this example are drawn from standard clinical triage protocols for headache evaluation, including the [SNOOP mnemonic](https://en.wikipedia.org/wiki/SNOOP%5F(mnemonic)) (Systemic symptoms, Neurological signs, Onset sudden, Older age, Pattern change) used in primary care. Your Agent has read these protocols. Your Agent is not licensed to apply them. The distinction matters.
 
 ::: science
-Research on symptom presentation consistently shows that patients who arrive with organized, specific descriptions of their symptoms receive more accurate diagnoses and more efficient care. Langewitz and colleagues, in a widely cited _BMJ_ study, found that when patients were allowed to describe their concerns in structured, uninterrupted fashion at the start of a visit, the entire consultation worked better --- not worse --- despite the clinician's instinct to redirect early.[^s6-2]
+Research on symptom presentation consistently shows that patients who arrive with organized, specific descriptions of their symptoms receive more accurate diagnoses and more efficient care. Langewitz and colleagues, in a widely cited _BMJ_ study, found that when patients were allowed to describe their concerns in structured, uninterrupted fashion at the start of a visit, the entire consultation worked better — not worse — despite the clinician's instinct to redirect early.[^s6-2]
 :::
 
 
@@ -272,7 +272,7 @@ Research on symptom presentation consistently shows that patients who arrive wit
 
 ### Example 3: An HVAC Quote That Seems High
 
-The situation: your air conditioning stopped cooling. You called an HVAC company. The technician came out, spent twenty minutes, and quoted you $8,200 to replace the entire system. You have no idea if the system actually needs replacing or if the quote is fair. You're about to spend more than you've ever spent on a single purchase based on one person's assessment.
+The situation: your air conditioning stopped cooling. You called an HVAC company. The technician came out, spent 20 minutes, and quoted you $8,200 to replace the entire system. You have no idea if the system actually needs replacing or if the quote is fair. You're about to spend more than you've ever spent on a single purchase based on one person's assessment.
 
 *Your opening message:*
 


### PR DESCRIPTION
Fourteenth chapter in the editorial pass — Strategy 6: Diagnose.

## Audit summary

Audited against `style-guide.md`, `voice-and-audience.md`, `editorial-conventions.md`, `principles.md`, and `reginald-jeeves.voice.md`. The Strategy-chapter opener structure conforms. The Tim Taylor / Al Borland anchor is one of the strongest in the book for Diagnose — Tim's confident-theory-plus-maximum-power pattern vs. Al's polite-correct-diagnosis-spoken-and-ignored. The Jeeves capstone is wonderfully Wodehousian — *"Mr. Borland was, throughout, available at ordinary volume and without charge."* Three worked examples (washing-machine grinding noise / persistent headaches / suspicious HVAC quote) demonstrate the strategy across appliance / health / contractor domains. Three small fixes.

## Suggested changes in this PR

**1. Em-dash normalization (line 267).** One science callout had spaced-ASCII em-dashes (`worked better --- not worse ---`) while the rest of the chapter uses Unicode em-dashes. Converted both to Unicode for intra-file consistency.

**2. Number normalization (line 275).** *"spent twenty minutes"* → *"spent 20 minutes"*. Concrete duration of the HVAC technician's evaluation, parallel to the "10 minutes" / "20 minutes" changes in #88, #91, #95.

**3. PCP first-mention link (line 168).** *"go to the ER for something that's a Tuesday PCP visit"* — PCP is used twice in this chapter (lines 168, 234) without inline expansion, and earlier book chapters also use it without definition. Per `style-guide.md`'s first-mention rule, linked to the Wikipedia article on Primary Care Physician.

## Things I checked and left alone (deliberate)

- **Strategy-chapter opener structure.** Strict spec form.
- **Jeeves capstone** — three beats clean: validate (*"Mr. Taylor's approach, which consists of forming a confident theory, proceeding at maximum torque, and occasionally destroying the object under repair, has the advantage of being entirely within his control"*) → mechanism (*"The diagnostic remark that would have corrected him was, on every occasion, spoken politely and immediately by Mr. Borland and treated as an interruption"*) → structural punch (*"Mr. Borland was, throughout, available at ordinary volume and without charge"*). No agency beat per spec.
- **Footnote `[^s6-1]`** (SNOOP mnemonic) carries a Wikipedia link to the SNOOP article. ✓
- **Footnote `[^s6-2]`** (Langewitz et al.) carries a DOI link to the BMJ paper. ✓
- **Other acronyms.** HVAC and SEER are contextually scoped to Example 3 where the reader is already calling an HVAC company — terms they'd already know in the moment. OTC, ER, BMJ are widely-recognized abbreviations in the chapter's context. SNOOP is the only mnemonic that genuinely needed a link, and that link is already present.
- **Em-dashes (rest of chapter).** 42 Unicode em-dashes, 0 ASCII unspaced, 2 ASCII spaced (both on line 267 — fixed in this PR).
- **Episode reference** *[Home Improvement:S1](url), 1991* — uses the season-level reference format from the spec (*"For season-level references without a specific episode: `[Home Improvement:S1](url)`"*). ✓
- **Cross-references** to Field Guide Skills use the `ref:` system. ✓
- **California Civil Code / utility-rebate / R-22 / R-410A** references are technical-specific where appropriate; not first-mention violations.

## Open questions for you

1. **Earlier book chapters use PCP without definition.** I linked PCP on its first use within Strategy 6 because a reader could land on Strategy 6 first via the Field Guide. But ideally the first definition should be in the introduction or in the Health Field Guide chapter, with subsequent uses unlinked. A follow-up could move the PCP definition to the canonical first-mention location and remove this link.

## Verification

- `npm run build:check`, `npm test` (55/55), and `npm run build` all clean.
- Three line-edits in one file.

---
_Generated by [Claude Code](https://claude.ai/code/session_012gTjgDeiEzQtyuWXiN1GoR)_