### PR TITLE
Field Guide intro: fix en-dash-vs-em-dash, broken Eno link, number

### DIFF
--- a/src/content/02-field-guide/00-field-guide-intro/index.dj
+++ b/src/content/02-field-guide/00-field-guide-intro/index.dj
@@ -9,25 +9,25 @@ status: "draft"
 # PART TWO: THE FIELD GUIDE
 
 _"Stop thinking about art works as objects, and start thinking about them as triggers for experiences."_
-_— [Brian Eno](https://www.edge.org/conversation/brian_eno-composers-as-gardeners), "Composers as Gardeners"_
+_— [Brian Eno](https://www.edge.org/conversation/brian%5Feno-composers-as-gardeners), "Composers as Gardeners"_
 
 You are not dumb. You just don't know The System.
 
-Health insurance, mortgage lending, employment law, tax code, utility billing -- these systems were not designed to be understood by the people they affect. They were designed to be operated by the people who run them. The language is specialist. The processes are opaque. The deadlines are real. Smart people feel stupid every time they hit a system they didn't go to school for. That is not a failure of intelligence. It is an information asymmetry -- and it is the same asymmetry, every time.
+Health insurance, mortgage lending, employment law, tax code, utility billing — these systems were not designed to be understood by the people they affect. They were designed to be operated by the people who run them. The language is specialist. The processes are opaque. The deadlines are real. Smart people feel stupid every time they hit a system they didn't go to school for. That is not a failure of intelligence. It is an information asymmetry — and it is the same asymmetry, every time.
 
-The billionaire class has always had attorneys, accountants, and assistants who know these systems. That staff layer is what turns confusion into action. Your Agent is that layer. This book teaches you how to ask it about the system -- whichever system you are facing today.
+The billionaire class has always had attorneys, accountants, and assistants who know these systems. That staff layer is what turns confusion into action. Your Agent is that layer. This book teaches you how to ask it about the system — whichever system you are facing today.
 
 ## My Man Jeeves
 
 [Reginald Jeeves](https://en.wikipedia.org/wiki/Jeeves) is P.G. Wodehouse's gentleman's personal gentleman, a valet, who solves every problem his employer cannot through unflappable calm, encyclopedic knowledge, and the quiet certainty that he already knows the answer. He is the quintessential majordomo. He first appeared in print in 1915; the first collection of his stories was called, naturally, _My Man Jeeves_.[^jeeves-1]
 
-In 1997, a search engine called [Ask Jeeves](https://en.wikipedia.org/wiki/Ask.com) promised exactly what this book delivers: ask a question in plain language, get a useful answer.[^jeeves-2] The technology was not ready. Ask Jeeves was a quarter century too early -- the way [General Magic](https://en.wikipedia.org/wiki/General_Magic) was fifteen years too early for the smartphone.[^jeeves-3] The idea was right. The infrastructure had not arrived.
+In 1997, a search engine called [Ask Jeeves](https://en.wikipedia.org/wiki/Ask.com) promised exactly what this book delivers: ask a question in plain language, get a useful answer.[^jeeves-2] The technology was not ready. Ask Jeeves was a quarter century too early — the way [General Magic](https://en.wikipedia.org/wiki/General_Magic) was 15 years too early for the smartphone.[^jeeves-3] The idea was right. The infrastructure had not arrived.
 
-It has now. Every Skill in this Field Guide opens with _My Man Jeeves_ -- the majordomo's assessment of the situation you are facing. He names the system, explains why it does not work for you, and points to what does. Then the spec takes over.
+It has now. Every Skill in this Field Guide opens with _My Man Jeeves_ — the majordomo's assessment of the situation you are facing. He names the system, explains why it does not work for you, and points to what does. Then the spec takes over.
 
 ## A Note on the Word "Skill"
 
-The Field Guide is a collection of *Skills* -- small, named, self-contained recipes for navigating a specific situation. Software developers will recognize the shape: it borrows the pattern from `SKILLS.md`, the file an AI assistant reads to learn how to do something specific. This book is the human-facing version. Each Skill names a problem, gives you the spec to use, and tells you what to do with the answer. You can read one in five minutes and put it to work tonight.
+The Field Guide is a collection of *Skills* — small, named, self-contained recipes for navigating a specific situation. Software developers will recognize the shape: it borrows the pattern from `SKILLS.md`, the file an AI assistant reads to learn how to do something specific. This book is the human-facing version. Each Skill names a problem, gives you the spec to use, and tells you what to do with the answer. You can read one in five minutes and put it to work tonight.
 
 ## How to Use a Skill
 
@@ -57,12 +57,12 @@ These are the same techniques a good interviewer, a good doctor, or a good attor
 
 ## Ground Rules
 
-1. *The Scientific Method is the best tool we have.* Not perfect -- a process for being less wrong over time. When a Skill cites research, it cites the current best evidence. Better evidence can update the recommendation. That is a feature, not a weakness.
+1. *The Scientific Method is the best tool we have.* Not perfect — a process for being less wrong over time. When a Skill cites research, it cites the current best evidence. Better evidence can update the recommendation. That is a feature, not a weakness.
 
-2. *Sociology is science.* Fuzzier than physics. The variables are harder to control and the sample sizes are messier. But the methods are real and the findings are peer-reviewed. The alternative to citing social science is guessing -- and guessing is what got us the systems this book teaches you to navigate.
+2. *Sociology is science.* Fuzzier than physics. The variables are harder to control and the sample sizes are messier. But the methods are real and the findings are peer-reviewed. The alternative to citing social science is guessing — and guessing is what got us the systems this book teaches you to navigate.
 
 [^jeeves-1]: Jeeves first appeared in ["Extricating Young Gussie,"](https://en.wikipedia.org/wiki/Extricating_Young_Gussie) published in _The Saturday Evening Post_ in September 1915. [_My Man Jeeves_](https://en.wikipedia.org/wiki/My_Man_Jeeves), the first collection, followed in 1919. Wodehouse continued writing Jeeves stories until his final completed novel, _Aunts Aren't Gentlemen_ (1974).
 
-[^jeeves-2]: Ask Jeeves was founded in 1996 by Garrett Gruener and David Warthen and [launched in April 1997](https://en.wikipedia.org/wiki/Ask.com). Its premise -- natural language question answering -- was the right idea built on keyword matching and human editors. IAC acquired the company for $1.85 billion in 2005; the Jeeves character was dropped in 2006.
+[^jeeves-2]: Ask Jeeves was founded in 1996 by Garrett Gruener and David Warthen and [launched in April 1997](https://en.wikipedia.org/wiki/Ask.com). Its premise — natural language question answering — was the right idea built on keyword matching and human editors. IAC acquired the company for $1.85 billion in 2005; the Jeeves character was dropped in 2006.
 
-[^jeeves-3]: [General Magic](https://en.wikipedia.org/wiki/General_Magic) spun out of Apple in 1990 and shipped Magic Cap devices in 1994 -- touchscreen handhelds with multimedia email, networked games, and e-commerce. The iPhone arrived in 2007. The 2018 documentary [_General Magic_](https://en.wikipedia.org/wiki/General_Magic_(film)) tells the story.
+[^jeeves-3]: [General Magic](https://en.wikipedia.org/wiki/General_Magic) spun out of Apple in 1990 and shipped Magic Cap devices in 1994 — touchscreen handhelds with multimedia email, networked games, and e-commerce. The iPhone arrived in 2007. The 2018 documentary [_General Magic_](https://en.wikipedia.org/wiki/General_Magic_(film)) tells the story.


### PR DESCRIPTION
Eighteenth chapter in the editorial pass — Field Guide intro (Part Two opener).

## Audit summary

Audited against `style-guide.md`, `voice-and-audience.md`, `editorial-conventions.md`, `principles.md`, and `reginald-jeeves.voice.md`. This is the Part Two opener: Brian Eno epigraph, the "My Man Jeeves" framing, the Skill anatomy table, Ground Rules section. **One real rendering bug fixed in this PR, plus the same em-dash and number patterns from earlier PRs.**

## Suggested changes in this PR

**1. Em-dash normalization — 11 occurrences.** The chapter used ASCII double-hyphen (` -- `) for em-dashes throughout, but `--` is the **en-dash** form per Djot's smart typography (`style-guide.md` says em-dashes use ` --- ` or Unicode ` — `; en-dashes for ranges only). The rendered output before this PR was shipping en-dashes in 11 places where the prose called for em-dashes — verified by `grep -oE "[a-zA-Z] [–—] [a-zA-Z]"` against the rendered XHTML (5 sample matches all rendered as `–` en-dash). Converted all 11 to spaced Unicode em-dash (` — `).

**2. Broken Brian Eno epigraph link (line 12).** The epigraph attribution is wrapped in italics (`_— [Brian Eno](url), "..."_`). When Djot parses the line, the underscore inside the URL `https://www.edge.org/conversation/brian_eno-composers-as-gardeners` is interpreted as an italic delimiter, corrupting the link. The rendered output before this PR contained literal markdown source:

```html
<em>— [Brian Eno](https://www.edge.org/conversation/brian</em>eno-composers-as-gardeners), "Composers as Gardeners"_
```

URL-encoded the underscore to `%5F`, matching the book-wide convention for Wikipedia URLs with underscores. Now renders correctly as a proper `<a href="...">Brian Eno</a>`. Verified by inspecting the rendered XHTML after the fix.

**3. Number normalization (line 24).** *"was fifteen years too early for the smartphone"* → *"was 15 years too early for the smartphone"*. Concrete duration; parallel to changes in #88, #91, #95, #99, #102.

## Things I checked and left alone (deliberate)

- **Other URLs with raw underscores** (e.g., `https://en.wikipedia.org/wiki/General_Magic`, `My_Man_Jeeves`, `Extricating_Young_Gussie`) render correctly because they aren't inside italics-wrapped blocks. Djot's underscore-as-italic parsing only fires inside italic context. The Brian Eno line was the only failure mode.
- **`# PART TWO: THE FIELD GUIDE`** (line 9). Looks like an outlier — H1 in all caps, while other intro chapters use `## Chapter X: ...` H2 — but it's auto-stripped by `processChapterFromSource`'s regex (case-insensitive), and the template re-emits `<h1>Part Two: The Field Guide</h1>` from the frontmatter. Verified the rendered output is correct.
- **Three footnotes** (`[^jeeves-1]`, `[^jeeves-2]`, `[^jeeves-3]`) all carry hyperlinks. ✓
- **Brian Eno epigraph source.** Link target `edge.org/conversation/brian_eno-composers-as-gardeners` is Eno's own essay "Composers as Gardeners" hosted on Edge. Verifiable primary source. ✓
- **Skill anatomy table** (lines 38-44). Six rows, follows the format described in `editorial-conventions.md` § Skill anatomy.
- **Ground Rules section.** Numbered list (sequence matters), parallel structure, both items wrap-up the section's role in the book.

## Open questions for you

1. **Audit cleanup is now identifying recurring bug categories** — broken-link-by-underscore-in-italics is a new one this PR. If other epigraphs across the book use the same italicized-attribution pattern with underscore URLs, they may have the same bug. Want me to do a targeted sweep for the pattern `_.*\[.*\]\(.*_.*\).*_` across all chapters?

## Verification

- `npm run build:check`, `npm test` (55/55), and `npm run build` all clean.
- 10 line-edits in one file (11 em-dashes — some on the same line — plus the Eno URL plus the "fifteen years" → "15 years").
- Rendered XHTML inspected — em-dashes are now em-dashes, Brian Eno link is now a clickable anchor with the correct URL.

---
_Generated by [Claude Code](https://claude.ai/code/session_012gTjgDeiEzQtyuWXiN1GoR)_