### PR TITLE
IRL Interactions: link two unlinked citations (Grupe & Nitschke, IDEA)

### DIFF
--- a/src/content/02-field-guide/09-irl-interactions/index.dj
+++ b/src/content/02-field-guide/09-irl-interactions/index.dj
@@ -134,7 +134,7 @@ This works well with voice mode on your phone — all major tools support it on 
 :::
 
 
-[^irl3-1]: Grupe, D.W. & Nitschke, J.B. (2013). "Uncertainty and anticipation in anxiety: an integrated neurobiological and psychological perspective." _Nature Reviews Neuroscience_, 14(7), 488–501.
+[^irl3-1]: Grupe, D.W. & Nitschke, J.B. (2013). ["Uncertainty and anticipation in anxiety: an integrated neurobiological and psychological perspective."](https://doi.org/10.1038/nrn3524) _Nature Reviews Neuroscience_, 14(7), 488–501.
 
 ---
 
@@ -396,7 +396,7 @@ Parents who speak the school's language — literally and figuratively — get b
 :::
 
 
-[^irl8-1]: Individuals with Disabilities Education Act (IDEA), 20 U.S.C. §1414(d)(1)(B) — parental participation in IEP development.
+[^irl8-1]: Individuals with Disabilities Education Act (IDEA), [20 U.S.C. §1414(d)(1)(B)](https://www.law.cornell.edu/uscode/text/20/1414) — parental participation in IEP development.
 
 ---
 


### PR DESCRIPTION
Twenty-sixth chapter in the editorial pass — Field Guide / IRL Interactions.

## Audit summary

552 lines, 6 footnotes (2 unlinked initially), 66 Unicode em-dashes, 0 ASCII em-dashes (clean). No rendering bugs. This PR closes both unlinked citations — all 6 IRL footnotes now carry source hyperlinks.

## Suggested changes in this PR

**Link both remaining unlinked citations:**

| Footnote | Citation | Link |
|---|---|---|
| `[^irl3-1]` | Grupe & Nitschke (2013), *Uncertainty and anticipation in anxiety*, Nature Reviews Neuroscience | [DOI 10.1038/nrn3524](https://doi.org/10.1038/nrn3524) |
| `[^irl8-1]` | 20 U.S.C. §1414 (IDEA — parental participation in IEP development) | [law.cornell.edu/uscode/text/20/1414](https://www.law.cornell.edu/uscode/text/20/1414) |

## Things I checked and left alone (deliberate)

- **Rendering.** No raw markdown source in rendered XHTML.
- **Em-dashes.** 66 Unicode, 0 ASCII. Internally consistent.
- **Skill anatomy** consistent across IRL-1 through IRL-9.

## Open questions for you

1. **Cadence (still open since #104).** Continuing per-chapter through Computer & Web, Creative, Transportation, then Part Three (chapters 31-34) and Appendices. Tell me if you want to pause.

## Verification

- `npm run build:check`, `npm test` (55/55), and `npm run build` all clean.
- Two line-edits in one file.

---
_Generated by [Claude Code](https://claude.ai/code/session_012gTjgDeiEzQtyuWXiN1GoR)_