### PR TITLE
Computer & Web: add DOI links to three unlinked footnote citations

### DIFF
--- a/src/content/02-field-guide/10-computer-and-web/index.dj
+++ b/src/content/02-field-guide/10-computer-and-web/index.dj
@@ -294,7 +294,7 @@ Research on expertise development (Ericsson et al., 1993) identifies _deliberate
 :::
 
 
-[^wb10-1]: Ericsson, K.A., Krampe, R.T., & Tesch-Römer, C. (1993). "The role of deliberate practice in the acquisition of expert performance." _Psychological Review_, 100(3), 363–406.
+[^wb10-1]: Ericsson, K.A., Krampe, R.T., & Tesch-Römer, C. (1993). ["The role of deliberate practice in the acquisition of expert performance."](https://doi.org/10.1037/0033-295X.100.3.363) _Psychological Review_, 100(3), 363–406.
 
 ---
 
@@ -428,7 +428,7 @@ The wealthy and educated have always curated their information sources — subsc
 :::
 
 
-[^wb2-1]: Bakshy, E., Messing, S., & Adamic, L.A. (2015). "Exposure to ideologically diverse news and opinion on Facebook." _Science_, 348(6239), 1130–1132.
+[^wb2-1]: Bakshy, E., Messing, S., & Adamic, L.A. (2015). ["Exposure to ideologically diverse news and opinion on Facebook."](https://doi.org/10.1126/science.aaa1160) _Science_, 348(6239), 1130–1132.
 
 ---
 
@@ -548,7 +548,7 @@ Research on [reflective practice](https://en.wikipedia.org/wiki/Reflective%5Fpra
 
 [^wb5-2]: Schön, D.A. (1983). [_The Reflective Practitioner._](https://archive.org/details/reflectivepracti0000scho) Basic Books. Elbow, P. (1973). [_Writing Without Teachers._](https://archive.org/details/writingwithoutte0000elbo) Oxford University Press.
 
-[^wb5-1]: Pennebaker, J.W. & Beall, S.K. (1986). "Confronting a traumatic event: Toward an understanding of inhibition and disease." _Journal of Abnormal Psychology_, 95(3), 274–281.
+[^wb5-1]: Pennebaker, J.W. & Beall, S.K. (1986). ["Confronting a traumatic event: Toward an understanding of inhibition and disease."](https://doi.org/10.1037/0021-843X.95.3.274) _Journal of Abnormal Psychology_, 95(3), 274–281.
 
 ---
 


### PR DESCRIPTION
Twenty-seventh chapter in the editorial pass — Field Guide / Computer & Web.

## Audit summary

678 lines, 15 footnotes (3 unlinked initially), 124 Unicode em-dashes, 0 ASCII em-dashes (clean). No rendering bugs. This PR closes all 3 unlinked citations — Computer & Web's largest-cite footnotes (Ericsson on deliberate practice, Bakshy on Facebook's filter bubble, Pennebaker on traumatic-event writing) now carry DOI links.

## Suggested changes in this PR

**Add DOI links to all three unlinked citations:**

| Footnote | Citation | DOI |
|---|---|---|
| `[^wb2-1]` | Bakshy, Messing & Adamic (2015), *Exposure to ideologically diverse news and opinion on Facebook*, Science | [10.1126/science.aaa1160](https://doi.org/10.1126/science.aaa1160) |
| `[^wb5-1]` | Pennebaker & Beall (1986), *Confronting a traumatic event*, J. Abnormal Psychology | [10.1037/0021-843X.95.3.274](https://doi.org/10.1037/0021-843X.95.3.274) |
| `[^wb10-1]` | Ericsson, Krampe & Tesch-Römer (1993), *The role of deliberate practice...*, Psychological Review | [10.1037/0033-295X.100.3.363](https://doi.org/10.1037/0033-295X.100.3.363) |

## Things I checked and left alone (deliberate)

- **Rendering.** No raw markdown source in rendered XHTML.
- **Em-dashes.** 124 Unicode, 0 ASCII. Internally consistent.
- **Skill anatomy** consistent across WB-1 through WB-12.
- **Cross-references** to Appendix G use the standard `.xhtml` link form.

## Open questions for you

1. **Cadence (still pending since #104).** Two more Field Guide domain chapters remaining (Creative, Transportation), then Part Three (chapters 31-34) and Appendices. Tell me if you want me to pause.

## Verification

- `npm run build:check`, `npm test` (55/55), and `npm run build` all clean.
- Three line-edits in one file.

---
_Generated by [Claude Code](https://claude.ai/code/session_012gTjgDeiEzQtyuWXiN1GoR)_