### PR TITLE
General Method intro: 5 broken `--` em-dashes + Klein DOI

### DIFF
--- a/src/content/03-general-method/00-general-spec-method/index.dj
+++ b/src/content/03-general-method/00-general-spec-method/index.dj
@@ -31,7 +31,7 @@ homeowner's association before...
 
 *2. What happened*
 
-The facts, as specifically as possible. Dates matter. Amounts matter. What was said or written matters. If you have a document -- a letter, a contract, a bill -- paste the relevant section directly into the conversation.
+The facts, as specifically as possible. Dates matter. Amounts matter. What was said or written matters. If you have a document — a letter, a contract, a bill — paste the relevant section directly into the conversation.
 
 ::: prompt
 ...I received a letter dated October 3rd stating that my fence
@@ -42,7 +42,7 @@ restrictions when I purchased the home...
 
 *3. What you want*
 
-The actual outcome you are trying to achieve. Not "help" -- a specific result. Do you want to understand your options? Do you want a draft letter? Do you want to know if you have grounds to dispute this? Say exactly what you want.
+The actual outcome you are trying to achieve. Not "help" — a specific result. Do you want to understand your options? Do you want a draft letter? Do you want to know if you have grounds to dispute this? Say exactly what you want.
 
 ::: prompt
 ...I want to understand whether I have grounds to dispute this
@@ -91,8 +91,8 @@ numbered list of my options, from least to most confrontational.
 This spec will produce a genuinely useful response for a situation this book does not specifically cover. The same frame works for a zoning dispute, a workers' compensation question, a complicated family business conflict, or anything else you bring to it.
 
 ::: science
-The cognitive process of translating a stressful situation into a structured written description is itself a therapeutic act. Expressive writing research (Pennebaker, 1997) consistently shows that people who write about stressful events in an organized, narrative form -- as opposed to ruminating or avoiding -- show lower stress biomarkers, improved immune function, and better problem-solving performance in the days that follow. The Five-Part Frame is not just a technique for getting better answers from Claude. It is a technique for getting clearer in your own mind about what you actually need.[^30-1]
+The cognitive process of translating a stressful situation into a structured written description is itself a therapeutic act. Expressive writing research (Pennebaker, 1997) consistently shows that people who write about stressful events in an organized, narrative form — as opposed to ruminating or avoiding — show lower stress biomarkers, improved immune function, and better problem-solving performance in the days that follow. The Five-Part Frame is not just a technique for getting better answers from Claude. It is a technique for getting clearer in your own mind about what you actually need.[^30-1]
 :::
 
 
-[^30-1]: Pennebaker, J.W. (1997). [_Opening Up: The Healing Power of Expressing Emotions._](https://bookshop.org/p/books/opening-up-by-writing-it-down-how-expressive-writing-improves-health-and-eases-emotional-pain-james-w-pennebaker/11500160) Guilford Press. See also: Klein, K. & Boals, A. (2001). "Expressive writing can increase working memory capacity." _Journal of Experimental Psychology: General_, 130(3), 520-533.
+[^30-1]: Pennebaker, J.W. (1997). [_Opening Up: The Healing Power of Expressing Emotions._](https://bookshop.org/p/books/opening-up-by-writing-it-down-how-expressive-writing-improves-health-and-eases-emotional-pain-james-w-pennebaker/11500160) Guilford Press. See also: Klein, K. & Boals, A. (2001). ["Expressive writing can increase working memory capacity."](https://doi.org/10.1037/0096-3445.130.3.520) _Journal of Experimental Psychology: General_, 130(3), 520-533.


### PR DESCRIPTION
Twenty-ninth chapter in the editorial pass — Part Three / The General Specification Method (intro to Part Three).

## Audit summary

98 lines, 1 footnote, **0 Unicode em-dashes + 5 ASCII double-hyphen ` -- ` patterns** — this chapter used `--` exclusively for em-dashes, so all 5 were rendering as en-dashes in the ePub. Same bug pattern as #103, #107, #109, #110.

## Suggested changes in this PR

**1. Convert 5 broken `--` em-dashes to spaced Unicode em-dashes:**
- Line 34 (twice): *"a document -- a letter, a contract, a bill -- paste"*
- Line 45: *"Not 'help' -- a specific result"*
- Line 94 (twice): *"narrative form -- as opposed to ruminating or avoiding --"*

**2. Add DOI to footnote `[^30-1]` for Klein & Boals (2001):**

The Pennebaker citation in `[^30-1]` was already linked to bookshop.org. Klein & Boals (2001), *Expressive writing can increase working memory capacity*, Journal of Experimental Psychology: General — DOI [10.1037/0096-3445.130.3.520](https://doi.org/10.1037/0096-3445.130.3.520).

## Things I checked and left alone (deliberate)

- **Rendering.** No raw markdown source in rendered XHTML after the em-dash fix.
- **Five-Part Frame structure** (lines 21-89) — well-organized, each section has an example `::: prompt` block. The Complete Spec demo at the end pulls it all together. Editorial structure is solid.
- **# PART THREE: THE GENERAL METHOD heading** at line 9 — auto-stripped by build (matches the case-insensitive `Part Two:` regex pattern in `processChapterFromSource`). Template re-emits `<h1>The General Specification Method</h1>` from the frontmatter title. Consistent with how Part Two intro renders.
- **`::: science` callout** (lines 93-95) does conceptual work (cognitive process of expressive writing → therapeutic act). Earns its place.

## Open questions for you

1. **Cadence (still pending since #104).** Four more Part Three chapters (31-34), then 9 Appendices. Tell me if you want to pause.

## Verification

- `npm run build:check`, `npm test` (55/55), and `npm run build` all clean.
- Four line-edits in one file (5 em-dash conversions are on 3 lines + 1 footnote citation link).

---
_Generated by [Claude Code](https://claude.ai/code/session_012gTjgDeiEzQtyuWXiN1GoR)_