### PR TITLE
Chapter 31: 10 broken `--` em-dashes + Berland and Kasparov citation links

### DIFF
--- a/src/content/03-general-method/01-chapter-31-ai-vs-human/index.dj
+++ b/src/content/03-general-method/01-chapter-31-ai-vs-human/index.dj
@@ -13,7 +13,7 @@ _— [Laurie Anderson](https://www.cbc.ca/arts/q/laurie-anderson-on-the-fantasti
 
 This is the most honest chapter in the book.
 
-AI tools like Claude are genuinely better than a human for some tasks. Humans are genuinely better for others. The mistake most people make -- in both directions -- is assuming the tool they have is the right tool for every job.
+AI tools like Claude are genuinely better than a human for some tasks. Humans are genuinely better for others. The mistake most people make — in both directions — is assuming the tool they have is the right tool for every job.
 
 ### Where AI has the edge
 
@@ -27,22 +27,22 @@ AI tools like Claude are genuinely better than a human for some tasks. Humans ar
 
 ### Where humans have the edge
 
-*Anything requiring lived experience and emotional resonance.* A eulogy that sounds like you -- not a template. A letter to your estranged father. A speech at your child's wedding. Claude can give you a structure and a starting point, but the version that matters comes from inside your actual life.
+*Anything requiring lived experience and emotional resonance.* A eulogy that sounds like you — not a template. A letter to your estranged father. A speech at your child's wedding. Claude can give you a structure and a starting point, but the version that matters comes from inside your actual life.
 
 *Situations where accountability matters.* Your lawyer has a license to lose. Your financial advisor is regulated. Your doctor carries malpractice insurance. Claude carries none of these things. When the stakes are high enough that someone needs skin in the game, get the person with skin in the game.
 
 *Creative work where surprise and imperfection are features.* The story that goes somewhere unexpected. The design that breaks the rules correctly. The solution that shouldn't work but does. Claude optimizes for coherence and appropriateness. Genuine creativity often requires incoherence and inappropriateness as a first step.
 
-*Relationships.* Claude can help you prepare for the conversation, write the first draft of the message, and think through what you want to say. It cannot have the conversation for you. The moment of human contact -- the look on someone's face when you show up and say the true thing -- is not delegatable.
+*Relationships.* Claude can help you prepare for the conversation, write the first draft of the message, and think through what you want to say. It cannot have the conversation for you. The moment of human contact — the look on someone's face when you show up and say the true thing — is not delegatable.
 
 *Ethical judgment calls where the situation is genuinely novel.* Claude will give you frameworks and considerations. It will not carry the weight of the decision for you, nor should it. Some decisions require a person who will live with the consequences.
 
 ### The honest middle
 
-Most real tasks are hybrids. Use Claude to do the structural work -- the research, the first draft, the option-mapping, the translation from jargon to plain language. Bring your own voice, judgment, and relationships to the finish line. The best outcomes from this book will come from people who treat Claude as a capable collaborator rather than an oracle or a vending machine.[^31-2]
+Most real tasks are hybrids. Use Claude to do the structural work — the research, the first draft, the option-mapping, the translation from jargon to plain language. Bring your own voice, judgment, and relationships to the finish line. The best outcomes from this book will come from people who treat Claude as a capable collaborator rather than an oracle or a vending machine.[^31-2]
 
-The practical question, then, is how to make sure the collaboration is actually reliable -- especially when the stakes are high. Chapter 32, _Getting Consistent, Reliable Answers_, covers that: specific techniques for getting consistent answers, including a single calibration question that keeps you from over-trusting or under-trusting the results.
+The practical question, then, is how to make sure the collaboration is actually reliable — especially when the stakes are high. Chapter 32, _Getting Consistent, Reliable Answers_, covers that: specific techniques for getting consistent answers, including a single calibration question that keeps you from over-trusting or under-trusting the results.
 
-[^31-1]: This is documented in research on online health information seeking: people consistently report asking questions online that they would not ask their physician, citing embarrassment and fear of judgment (Berland et al., 2001). The absence of social risk in AI interactions is not a bug -- it is a genuine access feature for populations who have historically under-utilized professional services.
+[^31-1]: This is documented in research on online health information seeking: people consistently report asking questions online that they would not ask their physician, citing embarrassment and fear of judgment ([Berland et al., 2001](https://doi.org/10.1001/jama.285.20.2612)). The absence of social risk in AI interactions is not a bug — it is a genuine access feature for populations who have historically under-utilized professional services.
 
-[^31-2]: The concept of the "centaur" -- human-AI collaboration outperforming either alone -- emerged from chess research following the introduction of computer analysis tools. Kasparov (2007) observed that amateur human players combined with chess software consistently outperformed both grandmasters and the best computers operating alone. The same principle applies here: your judgment plus Claude's analysis is better than either in isolation.
+[^31-2]: The concept of the "centaur" — human-AI collaboration outperforming either alone — emerged from chess research following the introduction of computer analysis tools. [Kasparov (2007)](https://bookshop.org/p/books/how-life-imitates-chess-making-the-right-moves-from-the-board-to-the-boardroom-garry-kasparov/10977097), _How Life Imitates Chess_, observed that amateur human players combined with chess software consistently outperformed both grandmasters and the best computers operating alone. The same principle applies here: your judgment plus Claude's analysis is better than either in isolation.


### PR DESCRIPTION
Thirtieth chapter in the editorial pass — Chapter 31 (When to Use AI and When to Use a Human).

## Audit summary

48 lines, 2 footnotes (both unlinked initially), **0 Unicode em-dashes + 10 ASCII `--` patterns** — all em-dashes rendering as en-dashes. Same bug pattern as #103, #107, #109, #110, #114. This PR fixes everything: 10 em-dashes + 2 citation links.

## Suggested changes in this PR

**1. Convert 10 broken `--` em-dashes** rendering as en-dashes in the ePub. All 10 converted to spaced Unicode em-dashes.

**2. Add citation hyperlinks to both footnotes:**

| Footnote | Citation | Link |
|---|---|---|
| `[^31-1]` | Berland et al. (2001), *Health information on the Internet*, JAMA | [DOI 10.1001/jama.285.20.2612](https://doi.org/10.1001/jama.285.20.2612) |
| `[^31-2]` | Kasparov (2007), *How Life Imitates Chess* (centaur framework) | [bookshop.org listing](`https://bookshop.org/p/books/how-life-imitates-chess-making-the-right-moves-from-the-board-to-the-boardroom-garry-kasparov`/10977097) |

## Things I checked and left alone (deliberate)

- **Rendering.** No raw markdown source in rendered XHTML after the em-dash fix.
- **Laurie Anderson epigraph** linked to CBC interview — solid primary source. ✓
- **The honest middle / centaur framing** is a strong editorial frame for the chapter.

## Open questions for you

1. **Cadence (still pending since #104).** Three more Part Three chapters (32-34), then 9 Appendices. Tell me if you want to pause.

## Verification

- `npm run build:check`, `npm test` (55/55), and `npm run build` all clean.
- Seven line-edits in one file.

---
_Generated by [Claude Code](https://claude.ai/code/session_012gTjgDeiEzQtyuWXiN1GoR)_