### PR TITLE
Chapter 32: 15 broken `--` em-dashes + correct Dietvorst citation

### DIFF
--- a/src/content/03-general-method/02-chapter-32-consistent-answers/index.dj
+++ b/src/content/03-general-method/02-chapter-32-consistent-answers/index.dj
@@ -11,13 +11,13 @@ status: "draft"
 _"I think the potential of what the Internet is going to do to society, both good and bad, is unimaginable. I think we're actually on the cusp of something exhilarating and terrifying."_
 _— [David Bowie](https://www.snopes.com/fact-check/david-bowie-1999-internet/), BBC Newsnight interview, 1999_
 
-Claude does not always give identical answers to identical questions. This is by design -- the same way two conversations with the same knowledgeable friend might go differently depending on how the question was framed. For most tasks in this book, that variability is fine. For others -- when you need a checklist, a step-by-step process, or a conservative interpretation of something with real stakes -- you want to reduce variability and increase reliability.
+Claude does not always give identical answers to identical questions. This is by design — the same way two conversations with the same knowledgeable friend might go differently depending on how the question was framed. For most tasks in this book, that variability is fine. For others — when you need a checklist, a step-by-step process, or a conservative interpretation of something with real stakes — you want to reduce variability and increase reliability.
 
 Here is how.
 
 ### Ask for numbered steps when sequence matters
 
-If the order of operations is important -- a legal process, a repair procedure, a medical preparation checklist -- ask explicitly for numbered steps. Claude will default to numbered steps only if you ask for them.
+If the order of operations is important — a legal process, a repair procedure, a medical preparation checklist — ask explicitly for numbered steps. Claude will default to numbered steps only if you ask for them.
 
 ::: prompt
 Please give me numbered steps, in the order I should do them,
@@ -26,7 +26,7 @@ with no steps combined.
 
 ### Ask Claude to show its work
 
-For factual claims with real stakes, ask Claude to identify the basis for each main point and flag any areas where it is less certain. This is not about doubting Claude -- it is about knowing where to verify independently.
+For factual claims with real stakes, ask Claude to identify the basis for each main point and flag any areas where it is less certain. This is not about doubting Claude — it is about knowing where to verify independently.
 
 ::: prompt
 For each main point in your answer, please tell me briefly
@@ -50,7 +50,7 @@ I would rather over-prepare than be caught off guard.
 
 ### Ask for a checklist instead of advice
 
-When you need to act on something -- not just understand it -- ask Claude to convert its answer into a yes/no or done/not-done checklist.
+When you need to act on something — not just understand it — ask Claude to convert its answer into a yes/no or done/not-done checklist.
 
 ::: prompt
 Can you turn that into a checklist I can print out and work
@@ -74,7 +74,7 @@ Your Agent will often catch its own oversights — a missed exception, an assump
 Claude can give a perfectly coherent, well-reasoned answer to the wrong version of your question. The answer _looks_ right because it _is_ right — for someone else's situation. Before you act on a plan, an interpretation, or a recommendation, ask your Agent to tell you what it thinks you asked:
 
 ::: prompt
-Before I act on this -- restate what you understood my situation
+Before I act on this — restate what you understood my situation
 to be, what you think I am trying to achieve, and what constraints
 you were working within.
 :::
@@ -90,7 +90,7 @@ Read the echo-back against what you actually said. You are looking for three thi
 When you spot one of these, you do not need to start over. Correct the specific misunderstanding:
 
 ::: prompt
-You assumed I am in California -- I am in Texas. And I asked for
+You assumed I am in California — I am in Texas. And I asked for
 options, not a step-by-step plan. Can you redo this with those
 corrections?
 :::
@@ -143,19 +143,19 @@ How confident are you in this answer, and what are the two
 or three things I should independently verify before acting on it?
 :::
 
-This single question will consistently improve the quality of the guidance you receive. Claude will tell you where its answer is reliable and where it is extrapolating. That boundary is exactly where you should apply your own judgment -- or pick up the phone and call a professional. It is the same line Chapter 31 draws from the other direction: where AI's edge ends and the human's begins.
+This single question will consistently improve the quality of the guidance you receive. Claude will tell you where its answer is reliable and where it is extrapolating. That boundary is exactly where you should apply your own judgment — or pick up the phone and call a professional. It is the same line Chapter 31 draws from the other direction: where AI's edge ends and the human's begins.
 
 ::: science
-Research on _algorithm aversion_ -- the human tendency to distrust algorithmic recommendations even when they are demonstrably more accurate -- shows that people accept algorithmic guidance more readily when they can see the reasoning behind it (Dietvorst et al., 2018). Asking Claude to show its work is not just practically useful. It also addresses the well-documented psychological resistance to following advice from a source you cannot fully understand.[^32-1]
+Research on _algorithm aversion_ — the human tendency to distrust algorithmic recommendations even when they are demonstrably more accurate — shows that people accept algorithmic guidance more readily when they can see the reasoning behind it (Dietvorst et al., 2018). Asking Claude to show its work is not just practically useful. It also addresses the well-documented psychological resistance to following advice from a source you cannot fully understand.[^32-1]
 :::
 
 
 ::: science
-The inverse phenomenon, _automation bias_ -- over-trusting algorithmic output -- is equally documented and arguably more dangerous (Cummings, 2004). The calibration question ("how confident are you, and what should I verify?") is a structured defense against automation bias. It keeps the human in the loop at exactly the moment when the stakes are highest.[^32-2]
+The inverse phenomenon, _automation bias_ — over-trusting algorithmic output — is equally documented and arguably more dangerous (Cummings, 2004). The calibration question ("how confident are you, and what should I verify?") is a structured defense against automation bias. It keeps the human in the loop at exactly the moment when the stakes are highest.[^32-2]
 :::
 
 
-[^32-1]: Dietvorst, B.J., Logg, J.M., & Lonati, S. (2018). "Algorithm aversion: People erroneously avoid algorithms after seeing them err." _Journal of Experimental Psychology: General_, 144(1), 114-126.
+[^32-1]: Dietvorst, B.J., Simmons, J.P., & Massey, C. (2015). ["Algorithm aversion: People erroneously avoid algorithms after seeing them err."](https://doi.org/10.1037/xge0000033) _Journal of Experimental Psychology: General_, 144(1), 114-126. <!-- RESEARCH NEEDED: original citation listed authors as "Dietvorst, Logg, & Lonati (2018)" and the volume/pages above match the 2015 paper by Dietvorst, Simmons & Massey — corrected the author list and year per the actual published source. Please verify before publication. -->
 
 [^32-2]: Cummings, M.L. (2004). "Automation bias in intelligent time critical decision support systems." _AIAA 1st Intelligent Systems Technical Conference._
 


### PR DESCRIPTION
Thirty-first chapter in the editorial pass — Chapter 32 (Getting Consistent, Reliable Answers).

## Audit summary

162 lines, 2 footnotes (both unlinked initially), 15 Unicode em-dashes + 15 ASCII ` -- ` patterns (mixed → all 15 ASCII rendering as en-dashes). This PR fixes the em-dash bug and corrects one citation that had incorrect author attribution.

## Suggested changes in this PR

**1. Convert 15 broken `--` em-dashes** to spaced Unicode em-dashes. Same bug pattern as #103, #107, #109, #110, #114, #115. Result: chapter is now internally consistent with 30 Unicode em-dashes and zero ASCII rendering as en-dashes.

**2. Correct the Dietvorst citation in footnote `[^32-1]`** and add the DOI.

The original footnote read: *"Dietvorst, B.J., Logg, J.M., & Lonati, S. (2018). 'Algorithm aversion: People erroneously avoid algorithms after seeing them err.' Journal of Experimental Psychology: General, 144(1), 114-126."*

That author list (Logg & Lonati, 2018) does not match a published paper. The volume / issue / pages (*JEP:General* 144(1), 114-126) match a well-known 2015 paper by **Dietvorst, Simmons & Massey** with that exact title. Corrected the author list and year to match the actual published source, added DOI [10.1037/xge0000033](https://doi.org/10.1037/xge0000033), and added a `<!-- RESEARCH NEEDED -->` comment for the author to verify the fix before publication.

## Things I checked and left alone (deliberate)

- **Rendering.** No raw markdown source in rendered XHTML after the em-dash fix.
- **Footnote `[^32-2]`** (Cummings 2004, AIAA conference paper) left unlinked. AIAA conference papers from 2004 have inconsistent canonical URLs; would need a manual check of AIAA's archive to confirm. Flagging only.
- **Calibration question** ("How confident are you in this, and what should I independently verify?") is the chapter's central artifact and reads cleanly.

## Open questions for you

1. **Dietvorst citation correction** — please verify before publication. If the original "Logg & Lonati 2018" reference was intended to be a *different* paper rather than a typo of the 2015 Simmons & Massey paper, let me know and I'll undo this change.

2. **Cadence (still pending since #104).** Two more Part Three chapters (33, 34), then 9 Appendices.

## Verification

- `npm run build:check`, `npm test` (55/55), and `npm run build` all clean.
- 10 line-edits in one file.

---
_Generated by [Claude Code](https://claude.ai/code/session_012gTjgDeiEzQtyuWXiN1GoR)_