### PR TITLE
Appendix H: fix broken code-fence structure (chapter renders as one code block)

### DIFF
--- a/src/content/04-appendices/07-appendix-h-writing-guide/index.dj
+++ b/src/content/04-appendices/07-appendix-h-writing-guide/index.dj
@@ -54,8 +54,7 @@ This is a sidebar with a citation.[^1]
 
 
 [^1]: Author (Year). "Title." *Journal*, vol, pages.
-
-::: prompt
+```
 
 CommonMark compiles to XHTML. XHTML is what ePub chapters are. The pipeline is deterministic — the same input always produces the same output. The manuscript is version-controlled in Git. Every change is tracked. Every version is recoverable. Collaboration is branching, merging, and pull requests — the same tools that build software.
 
@@ -74,7 +73,7 @@ part: 2
 order: 3
 status: "draft"
 ---
-:::
+```
 
 The build pipeline reads the frontmatter, sorts by part and order, and assembles the ePub. Reorder chapters by changing a number. Add a chapter by adding a file. Remove a chapter by deleting a file. The filesystem is the table of contents. There is no separate document to maintain.
 
@@ -88,8 +87,7 @@ Every illustration is specified where it appears, as an HTML comment in the manu
 
 ```markdown
 [eob-annotated-appendix]{.art}
-
-::: prompt
+```
 
 This is Strategy 0 applied to visual content. The `alt` field is what the reader needs to know. The `brief` field is what the illustrator needs to produce. Both are written at the same time, by the same person, in the same place as the text they accompany.
 
@@ -138,7 +136,8 @@ If you are writing a guide for a community that needs it, license it so the comm
 ### The Build
 
 The entire book compiles from CommonMark source to ePub with a single command:
-:::
+
+```bash
 npm run build
 ```
 


### PR DESCRIPTION
Appendix H rendering bug — **major fix.**

## Summary

Appendix H ("Expressing Ideas Digitally") had **4 code-fence openers but only 1 closer**, so the entire middle of the chapter — roughly 96 lines, from line 46 to line 143 in source — rendered as **one giant `<pre><code>` block** in the ePub. Body prose, section headings (*Structure as Metadata*, *Art Direction as Specification*, *Self-Documenting Artifacts*, *Accessibility as Architecture*, *The License Is the Distribution*, *The Build*), bullet lists, horizontal rules — all of it rendered as literal code, since Djot doesn't process markup inside a fenced code block.

Verified by diffing rendered XHTML:
- **Before:** 1 `<pre>` block, 96 lines of content trapped inside.
- **After:** 4 `<pre>` blocks (each 3-8 lines), with proper prose paragraphs / headings / lists between them.

## Suggested changes in this PR

Four targeted fixes to close the four intended code examples:

| Location | Before | After |
|---|---|---|
| Line 57 (blank) | (nothing) | ` ``` ` (close first markdown example: sidebar + footnote demo) |
| Line 77 | `:::` (misplaced fenced-div close) | ` ``` ` (close YAML frontmatter example) |
| Line 92 | `::: prompt` (misplaced fenced-div open) | ` ``` ` (close art-ref example) |
| Lines 141-143 | `:::` followed by `npm run build` and ` ``` ` | `\`\`\`bash` open + `npm run build` + ` ``` ` close |

After the fix, the chapter's four intended code blocks are correctly bounded:
1. CommonMark example showing a chapter with sidebar + footnote.
2. YAML frontmatter example.
3. Art-ref `[eob-annotated-appendix]{.art}` example.
4. Bash `npm run build` build command.

## Things I checked and left alone (deliberate)

- **The unlinked footnote `[^1]: Author (Year). "Title." *Journal*, vol, pages.`** is *inside* the first code block intentionally — it's part of the markdown-syntax example showing how a footnote definition looks, not a real bibliographic citation. Left as-is.

## Open questions for you

1. **Verify the four code-block boundaries match your editorial intent.** I made the most-plausible interpretation, but if the author meant a different structure (e.g., a single composite example or different boundaries), the boundaries should be adjusted.

## Verification

- `npm run build:check`, `npm test` (55/55), and `npm run build` all clean.
- 5 line-edits in one file.
- Rendered XHTML inspected before/after — confirmed 4 distinct `<pre>` blocks with prose interleaved correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_012gTjgDeiEzQtyuWXiN1GoR)_