### PR TITLE
Sync Apple Books typed notes to GitHub Issues (#23)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,11 @@ State lives outside the repo:
 - `~/Library/Application Support/majordomo/notes-sync-state.json` (mtime cache, asset_id, counters)
 - `~/Library/Logs/majordomo-notes-sync.log` (structured one-line-per-event log)
 
-Requires `gh auth login` to have been run once. See [the design spec](docs/superpowers/specs/2026-05-23-apple-books-notes-sync-design.md) for the full architecture.
+Requires `gh auth login` to have been run once.
+
+**macOS Full Disk Access:** The LaunchAgent-spawned daemon needs Full Disk Access to read `~/Library/Containers/com.apple.iBooksX/`. Interactive shells inherit this from Terminal/iTerm/Claude Code; LaunchAgents are attributed to their own responsible code and need explicit grants. After running `sync:notes:install`, open **System Settings → Privacy & Security → Full Disk Access**, click **+**, navigate to (Cmd+Shift+G) the node binary path printed by the installer (e.g. `/opt/homebrew/Cellar/node@22/22.22.2_1/bin/node`), and toggle it on. Then kickstart the daemon: `launchctl kickstart -p "gui/$(id -u)/io.dwk.majordomo.notes-sync"`.
+
+See [the design spec](docs/superpowers/specs/2026-05-23-apple-books-notes-sync-design.md) for the full architecture.
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,23 @@ npm run clean        # rm dist/
 
 CI runs on every push and PR to main (`.github/workflows/build.yml`): type-check, tests, ePub build. The built ePub is uploaded as an artifact.
 
+## Apple Books Notes Sync
+
+Hourly sync from your Apple Books typed annotations on the built ePub to GitHub Issues on this repo (label `from:apple-books`). Each annotation becomes one deduped issue.
+
+```bash
+npm run sync:notes:install      # one-time: install LaunchAgent + create label
+npm run sync:notes              # force a sync now (rather than wait for next hour)
+npm run sync:notes:status       # last-run, mtime, log file size, lifetime counters
+npm run sync:notes:uninstall    # remove the LaunchAgent
+```
+
+State lives outside the repo:
+- `~/Library/Application Support/majordomo/notes-sync-state.json` (mtime cache, asset_id, counters)
+- `~/Library/Logs/majordomo-notes-sync.log` (structured one-line-per-event log)
+
+Requires `gh auth login` to have been run once. See [the design spec](docs/superpowers/specs/2026-05-23-apple-books-notes-sync-design.md) for the full architecture.
+
 ## Project Structure
 
 ```

--- a/build/notes/__fixtures__/aeannotation.sql
+++ b/build/notes/__fixtures__/aeannotation.sql
@@ -1,0 +1,69 @@
+-- Schema snapshot of the columns used from Apple Books's sqlite
+-- databases. Updates here flag schema drift on real Apple updates.
+
+CREATE TABLE ZBKLIBRARYASSET (
+  Z_PK INTEGER PRIMARY KEY,
+  ZASSETID TEXT,
+  ZTITLE TEXT
+);
+
+CREATE TABLE ZAEANNOTATION (
+  Z_PK INTEGER PRIMARY KEY,
+  ZANNOTATIONUUID TEXT,
+  ZANNOTATIONASSETID TEXT,
+  ZANNOTATIONSELECTEDTEXT TEXT,
+  ZANNOTATIONNOTE TEXT,
+  ZFUTUREPROOFING5 TEXT,
+  ZANNOTATIONLOCATION TEXT,
+  ZANNOTATIONMODIFICATIONDATE REAL,
+  ZANNOTATIONDELETED INTEGER
+);
+
+INSERT INTO ZBKLIBRARYASSET VALUES (1, 'ASSET-MAJORDOMO', 'A Majordomo for Everyone');
+INSERT INTO ZBKLIBRARYASSET VALUES (2, 'ASSET-OTHER',     'Some Other Book');
+
+INSERT INTO ZAEANNOTATION VALUES (
+  101, 'UUID-A', 'ASSET-MAJORDOMO',
+  'A library is a building; a life is a way of living.',
+  'fix this metaphor about libraries',
+  'Chapter 1: Introduction',
+  '0.12',
+  801238260.0,
+  0
+);
+INSERT INTO ZAEANNOTATION VALUES (
+  102, 'UUID-B', 'ASSET-MAJORDOMO',
+  'A bare highlight with no typed note.',
+  NULL,
+  'Chapter 1: Introduction',
+  '0.13',
+  801238300.0,
+  0
+);
+INSERT INTO ZAEANNOTATION VALUES (
+  103, 'UUID-C', 'ASSET-MAJORDOMO',
+  'Another passage I marked.',
+  'rewrite the second paragraph',
+  'Chapter 2: Engage',
+  '0.45',
+  801238400.0,
+  0
+);
+INSERT INTO ZAEANNOTATION VALUES (
+  104, 'UUID-D', 'ASSET-MAJORDOMO',
+  'A passage on a deleted annotation.',
+  'will be filtered out',
+  'Chapter 2: Engage',
+  '0.46',
+  801238500.0,
+  1
+);
+INSERT INTO ZAEANNOTATION VALUES (
+  201, 'UUID-OTHER', 'ASSET-OTHER',
+  'From a different book entirely.',
+  'should not appear',
+  'Some Chapter',
+  '0.5',
+  801238600.0,
+  0
+);

--- a/build/notes/__fixtures__/aeannotation.sql
+++ b/build/notes/__fixtures__/aeannotation.sql
@@ -58,6 +58,15 @@ INSERT INTO ZAEANNOTATION VALUES (
   1
 );
 INSERT INTO ZAEANNOTATION VALUES (
+  105, 'UUID-E', 'ASSET-MAJORDOMO',
+  'empty whitespace note',
+  'A row with a whitespace-only ZANNOTATIONNOTE.',
+  '   ',
+  'epubcfi(/6/4[00-epigraph]!/4/2/10/1,:0,:20)',
+  801238550.0,
+  0
+);
+INSERT INTO ZAEANNOTATION VALUES (
   201, 'UUID-OTHER', 'ASSET-OTHER',
   'From other',
   'From a different book entirely.',

--- a/build/notes/__fixtures__/aeannotation.sql
+++ b/build/notes/__fixtures__/aeannotation.sql
@@ -1,5 +1,4 @@
--- Schema snapshot of the columns used from Apple Books's sqlite
--- databases. Updates here flag schema drift on real Apple updates.
+-- Schema snapshot of the columns used from Apple Books's sqlite databases.
 
 CREATE TABLE ZBKLIBRARYASSET (
   Z_PK INTEGER PRIMARY KEY,
@@ -12,58 +11,58 @@ CREATE TABLE ZAEANNOTATION (
   ZANNOTATIONUUID TEXT,
   ZANNOTATIONASSETID TEXT,
   ZANNOTATIONSELECTEDTEXT TEXT,
+  ZANNOTATIONREPRESENTATIVETEXT TEXT,
   ZANNOTATIONNOTE TEXT,
-  ZFUTUREPROOFING5 TEXT,
   ZANNOTATIONLOCATION TEXT,
   ZANNOTATIONMODIFICATIONDATE REAL,
   ZANNOTATIONDELETED INTEGER
 );
 
-INSERT INTO ZBKLIBRARYASSET VALUES (1, 'ASSET-MAJORDOMO', 'A Majordomo for Everyone');
+INSERT INTO ZBKLIBRARYASSET VALUES (1, 'ASSET-MAJORDOMO', 'Majordomo');
 INSERT INTO ZBKLIBRARYASSET VALUES (2, 'ASSET-OTHER',     'Some Other Book');
 
 INSERT INTO ZAEANNOTATION VALUES (
   101, 'UUID-A', 'ASSET-MAJORDOMO',
+  'A library is a building',
   'A library is a building; a life is a way of living.',
   'fix this metaphor about libraries',
-  'Chapter 1: Introduction',
-  '0.12',
+  'epubcfi(/6/4[00-epigraph]!/4/2/6/2/1,:3,:55)',
   801238260.0,
   0
 );
 INSERT INTO ZAEANNOTATION VALUES (
   102, 'UUID-B', 'ASSET-MAJORDOMO',
+  'bare highlight',
   'A bare highlight with no typed note.',
   NULL,
-  'Chapter 1: Introduction',
-  '0.13',
+  'epubcfi(/6/4[00-epigraph]!/4/2/8/1,:0,:36)',
   801238300.0,
   0
 );
 INSERT INTO ZAEANNOTATION VALUES (
   103, 'UUID-C', 'ASSET-MAJORDOMO',
+  'Another passage',
   'Another passage I marked.',
   'rewrite the second paragraph',
-  'Chapter 2: Engage',
-  '0.45',
+  'epubcfi(/6/8[01-chapter-01]!/4/4/2,:0,:24)',
   801238400.0,
   0
 );
 INSERT INTO ZAEANNOTATION VALUES (
   104, 'UUID-D', 'ASSET-MAJORDOMO',
+  'deleted',
   'A passage on a deleted annotation.',
   'will be filtered out',
-  'Chapter 2: Engage',
-  '0.46',
+  'epubcfi(/6/8[01-chapter-01]!/4/4/4,:0,:31)',
   801238500.0,
   1
 );
 INSERT INTO ZAEANNOTATION VALUES (
   201, 'UUID-OTHER', 'ASSET-OTHER',
+  'From other',
   'From a different book entirely.',
   'should not appear',
-  'Some Chapter',
-  '0.5',
+  'epubcfi(/6/2[chapter-1]!/4/2/1,:0,:30)',
   801238600.0,
   0
 );

--- a/build/notes/github-target.test.ts
+++ b/build/notes/github-target.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IssueRecord } from './types.js';
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ spawnSync: spawnSyncMock }));
+
+const {
+  listAutoFiledIssues,
+  createIssue,
+  editIssue,
+  createLabelIfMissing,
+} = await import('./github-target.js');
+
+const okResult = (stdout: string) => ({ status: 0, stdout, stderr: '', signal: null });
+const errResult = (stderr: string) => ({ status: 1, stdout: '', stderr, signal: null });
+
+beforeEach(() => {
+  spawnSyncMock.mockReset();
+});
+
+describe('listAutoFiledIssues', () => {
+  it('invokes gh with the right flags and parses the JSON', async () => {
+    const sample = [
+      { number: 1, body: 'body 1', state: 'OPEN' },
+      { number: 2, body: 'body 2', state: 'CLOSED' },
+    ];
+    spawnSyncMock.mockReturnValueOnce(okResult(JSON.stringify(sample)));
+    const out = await listAutoFiledIssues();
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    const callArgs = spawnSyncMock.mock.calls[0];
+    expect(callArgs[0]).toBe('gh');
+    expect(callArgs[1]).toEqual([
+      'issue',
+      'list',
+      '--label',
+      'from:apple-books',
+      '--state',
+      'all',
+      '--limit',
+      '1000',
+      '--json',
+      'number,body,state',
+    ]);
+
+    expect(out).toEqual<IssueRecord[]>([
+      { number: 1, body: 'body 1', state: 'OPEN' },
+      { number: 2, body: 'body 2', state: 'CLOSED' },
+    ]);
+  });
+
+  it('throws when gh exits non-zero', async () => {
+    spawnSyncMock.mockReturnValueOnce(errResult('authentication required'));
+    await expect(listAutoFiledIssues()).rejects.toThrow(/authentication required/);
+  });
+});
+
+describe('createIssue', () => {
+  it('invokes gh issue create with the rendered title/body and label', async () => {
+    spawnSyncMock.mockReturnValueOnce(
+      okResult('https://github.com/owner/repo/issues/42\n')
+    );
+    const n = await createIssue({ title: 'fix metaphor', body: 'long body' });
+
+    expect(n).toBe(42);
+    const callArgs = spawnSyncMock.mock.calls[0];
+    expect(callArgs[1]).toEqual([
+      'issue',
+      'create',
+      '--title',
+      'fix metaphor',
+      '--body',
+      'long body',
+      '--label',
+      'from:apple-books',
+    ]);
+  });
+});
+
+describe('editIssue', () => {
+  it('invokes gh issue edit with the new body', async () => {
+    spawnSyncMock.mockReturnValueOnce(okResult(''));
+    await editIssue(42, 'new body');
+
+    const callArgs = spawnSyncMock.mock.calls[0];
+    expect(callArgs[1]).toEqual(['issue', 'edit', '42', '--body', 'new body']);
+  });
+});
+
+describe('createLabelIfMissing', () => {
+  it('returns true on successful create', async () => {
+    spawnSyncMock.mockReturnValueOnce(okResult(''));
+    expect(await createLabelIfMissing()).toBe(true);
+  });
+
+  it('returns false when the label already exists', async () => {
+    spawnSyncMock.mockReturnValueOnce(errResult('label "from:apple-books" already exists'));
+    expect(await createLabelIfMissing()).toBe(false);
+  });
+
+  it('throws for unexpected errors', async () => {
+    spawnSyncMock.mockReturnValueOnce(errResult('some other failure'));
+    await expect(createLabelIfMissing()).rejects.toThrow(/some other failure/);
+  });
+});

--- a/build/notes/github-target.ts
+++ b/build/notes/github-target.ts
@@ -1,0 +1,65 @@
+/**
+ * Thin wrappers around the `gh` CLI. We shell out via spawnSync (not
+ * a shell-expansion API) so arguments are passed as an array — no
+ * quoting or escaping concerns.
+ */
+
+import { spawnSync } from 'node:child_process';
+import type { IssueRecord, RenderedIssue } from './types.js';
+import { LABEL_NAME } from './types.js';
+
+interface SpawnResult {
+  status: number | null;
+  stdout: string | Buffer;
+  stderr: string | Buffer;
+  signal: NodeJS.Signals | null;
+}
+
+function runGh(args: string[]): { stdout: string; stderr: string } {
+  const r = spawnSync('gh', args, { encoding: 'utf8' }) as unknown as SpawnResult;
+  const stdout = typeof r.stdout === 'string' ? r.stdout : r.stdout.toString('utf8');
+  const stderr = typeof r.stderr === 'string' ? r.stderr : r.stderr.toString('utf8');
+  if (r.status !== 0) {
+    throw new Error(`gh ${args.join(' ')} exited ${r.status}: ${stderr.trim()}`);
+  }
+  return { stdout, stderr };
+}
+
+export async function listAutoFiledIssues(): Promise<IssueRecord[]> {
+  const { stdout } = runGh([
+    'issue', 'list',
+    '--label', LABEL_NAME,
+    '--state', 'all',
+    '--limit', '1000',
+    '--json', 'number,body,state',
+  ]);
+  return JSON.parse(stdout) as IssueRecord[];
+}
+
+export async function createIssue(rendered: RenderedIssue): Promise<number> {
+  const { stdout } = runGh([
+    'issue', 'create',
+    '--title', rendered.title,
+    '--body', rendered.body,
+    '--label', LABEL_NAME,
+  ]);
+  const m = stdout.match(/\/issues\/(\d+)/);
+  if (!m) throw new Error(`could not parse issue number from gh output: ${stdout}`);
+  return parseInt(m[1], 10);
+}
+
+export async function editIssue(number: number, body: string): Promise<void> {
+  runGh(['issue', 'edit', String(number), '--body', body]);
+}
+
+export async function createLabelIfMissing(): Promise<boolean> {
+  const r = spawnSync(
+    'gh',
+    ['label', 'create', LABEL_NAME, '--description', 'Auto-filed from Apple Books annotations', '--color', 'ededed'],
+    { encoding: 'utf8' }
+  ) as unknown as SpawnResult;
+  const stderr = typeof r.stderr === 'string' ? r.stderr : r.stderr.toString('utf8');
+  if (r.status === 0) return true;
+  if (/already exists/i.test(stderr)) return false;
+  throw new Error(`gh label create exited ${r.status}: ${stderr.trim()}`);
+}

--- a/build/notes/github-target.ts
+++ b/build/notes/github-target.ts
@@ -8,21 +8,12 @@ import { spawnSync } from 'node:child_process';
 import type { IssueRecord, RenderedIssue } from './types.js';
 import { LABEL_NAME } from './types.js';
 
-interface SpawnResult {
-  status: number | null;
-  stdout: string | Buffer;
-  stderr: string | Buffer;
-  signal: NodeJS.Signals | null;
-}
-
 function runGh(args: string[]): { stdout: string; stderr: string } {
-  const r = spawnSync('gh', args, { encoding: 'utf8' }) as unknown as SpawnResult;
-  const stdout = typeof r.stdout === 'string' ? r.stdout : r.stdout.toString('utf8');
-  const stderr = typeof r.stderr === 'string' ? r.stderr : r.stderr.toString('utf8');
+  const r = spawnSync('gh', args, { encoding: 'utf8' });
   if (r.status !== 0) {
-    throw new Error(`gh ${args.join(' ')} exited ${r.status}: ${stderr.trim()}`);
+    throw new Error(`gh ${args.join(' ')} exited ${r.status}: ${r.stderr.trim()}`);
   }
-  return { stdout, stderr };
+  return { stdout: r.stdout, stderr: r.stderr };
 }
 
 export async function listAutoFiledIssues(): Promise<IssueRecord[]> {
@@ -57,9 +48,8 @@ export async function createLabelIfMissing(): Promise<boolean> {
     'gh',
     ['label', 'create', LABEL_NAME, '--description', 'Auto-filed from Apple Books annotations', '--color', 'ededed'],
     { encoding: 'utf8' }
-  ) as unknown as SpawnResult;
-  const stderr = typeof r.stderr === 'string' ? r.stderr : r.stderr.toString('utf8');
+  );
   if (r.status === 0) return true;
-  if (/already exists/i.test(stderr)) return false;
-  throw new Error(`gh label create exited ${r.status}: ${stderr.trim()}`);
+  if (/already exists/i.test(r.stderr)) return false;
+  throw new Error(`gh label create exited ${r.status}: ${r.stderr.trim()}`);
 }

--- a/build/notes/reconcile.test.ts
+++ b/build/notes/reconcile.test.ts
@@ -7,8 +7,7 @@ const ann = (overrides: Partial<Annotation> = {}): Annotation => ({
   uuid: 'UUID-A',
   selectedText: 'passage',
   note: 'note A',
-  chapterTitle: 'Ch 1',
-  locationPercent: 0.1,
+  chapter: 'ch1',
   modifiedAt: new Date('2026-05-23T14:11:00Z'),
   ...overrides,
 });

--- a/build/notes/reconcile.test.ts
+++ b/build/notes/reconcile.test.ts
@@ -61,6 +61,17 @@ describe('reconcile', () => {
     expect(actions[0].type).toBe('create');
   });
 
+  it('dedupes annotations by UUID, processing only the first occurrence', () => {
+    const a1 = ann({ uuid: 'UUID-DUP', note: 'first' });
+    const a2 = ann({ uuid: 'UUID-DUP', note: 'second (should be ignored)' });
+    const actions = reconcile([a1, a2], []);
+    expect(actions).toHaveLength(1);
+    expect(actions[0].type).toBe('create');
+    if (actions[0].type === 'create') {
+      expect(actions[0].rendered.body).toContain('first');
+    }
+  });
+
   it('returns a mix of create / update / noop in one call', () => {
     const a1 = ann({ uuid: 'A1', note: 'a1' });
     const a2 = ann({ uuid: 'A2', note: 'a2 new' });

--- a/build/notes/reconcile.test.ts
+++ b/build/notes/reconcile.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { reconcile } from './reconcile.js';
+import { render } from './render.js';
+import type { Annotation, IssueRecord } from './types.js';
+
+const ann = (overrides: Partial<Annotation> = {}): Annotation => ({
+  uuid: 'UUID-A',
+  selectedText: 'passage',
+  note: 'note A',
+  chapterTitle: 'Ch 1',
+  locationPercent: 0.1,
+  modifiedAt: new Date('2026-05-23T14:11:00Z'),
+  ...overrides,
+});
+
+const issueWith = (n: number, body: string, state: 'OPEN' | 'CLOSED' = 'OPEN'): IssueRecord => ({
+  number: n,
+  body,
+  state,
+});
+
+describe('reconcile', () => {
+  it('returns create actions for annotations with no matching issue', () => {
+    const annotations = [ann({ uuid: 'UUID-A' }), ann({ uuid: 'UUID-B', note: 'note B' })];
+    const actions = reconcile(annotations, []);
+    expect(actions).toHaveLength(2);
+    expect(actions.every((a) => a.type === 'create')).toBe(true);
+  });
+
+  it('returns noop for an annotation whose rendered body matches the existing issue', () => {
+    const a = ann({ uuid: 'UUID-A' });
+    const existing = [issueWith(42, render(a).body)];
+    const actions = reconcile([a], existing);
+    expect(actions).toEqual([{ type: 'noop', uuid: 'UUID-A', issue: 42 }]);
+  });
+
+  it('returns update for an annotation whose rendered body differs from the existing issue', () => {
+    const original = ann({ uuid: 'UUID-A', note: 'old note' });
+    const existing = [issueWith(42, render(original).body)];
+    const edited = ann({ uuid: 'UUID-A', note: 'new note' });
+    const actions = reconcile([edited], existing);
+    expect(actions).toHaveLength(1);
+    expect(actions[0].type).toBe('update');
+    if (actions[0].type === 'update') {
+      expect(actions[0].issue).toBe(42);
+      expect(actions[0].uuid).toBe('UUID-A');
+    }
+  });
+
+  it('matches issues against UUIDs found in CLOSED issues, not just OPEN ones', () => {
+    const a = ann({ uuid: 'UUID-A' });
+    const existing = [issueWith(42, render(a).body, 'CLOSED')];
+    const actions = reconcile([a], existing);
+    expect(actions[0].type).toBe('noop');
+  });
+
+  it('ignores existing issues whose body has no UUID marker', () => {
+    const a = ann({ uuid: 'UUID-A' });
+    const existing = [issueWith(42, 'a manually filed issue with no marker')];
+    const actions = reconcile([a], existing);
+    expect(actions[0].type).toBe('create');
+  });
+
+  it('returns a mix of create / update / noop in one call', () => {
+    const a1 = ann({ uuid: 'A1', note: 'a1' });
+    const a2 = ann({ uuid: 'A2', note: 'a2 new' });
+    const a3 = ann({ uuid: 'A3', note: 'a3' });
+    const a2Original = ann({ uuid: 'A2', note: 'a2 old' });
+
+    const existing = [
+      issueWith(10, render(a1).body),
+      issueWith(11, render(a2Original).body),
+      issueWith(12, 'unrelated issue'),
+    ];
+    const actions = reconcile([a1, a2, a3], existing);
+
+    const byUuid = new Map(actions.map((x) => [x.uuid, x]));
+    expect(byUuid.get('A1')?.type).toBe('noop');
+    expect(byUuid.get('A2')?.type).toBe('update');
+    expect(byUuid.get('A3')?.type).toBe('create');
+    expect(actions).toHaveLength(3);
+  });
+});

--- a/build/notes/reconcile.ts
+++ b/build/notes/reconcile.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure reconciliation: given current annotations and existing
+ * auto-filed issues, compute the action list.
+ */
+
+import type { Action, Annotation, IssueRecord } from './types.js';
+import { render } from './render.js';
+import { parseUuid } from './uuid-parse.js';
+
+export function reconcile(
+  annotations: readonly Annotation[],
+  existing: readonly IssueRecord[]
+): Action[] {
+  const byUuid = new Map<string, IssueRecord>();
+  for (const issue of existing) {
+    const uuid = parseUuid(issue.body);
+    if (uuid !== null) byUuid.set(uuid, issue);
+  }
+
+  const actions: Action[] = [];
+  for (const ann of annotations) {
+    const rendered = render(ann);
+    const found = byUuid.get(ann.uuid);
+    if (!found) {
+      actions.push({ type: 'create', uuid: ann.uuid, rendered });
+    } else if (found.body === rendered.body) {
+      actions.push({ type: 'noop', uuid: ann.uuid, issue: found.number });
+    } else {
+      actions.push({ type: 'update', uuid: ann.uuid, issue: found.number, rendered });
+    }
+  }
+  return actions;
+}

--- a/build/notes/reconcile.ts
+++ b/build/notes/reconcile.ts
@@ -11,6 +11,16 @@ export function reconcile(
   annotations: readonly Annotation[],
   existing: readonly IssueRecord[]
 ): Action[] {
+  // Defensive: if sqlite somehow returns two rows with the same UUID,
+  // process only the first occurrence (spec failure-mode table).
+  const seen = new Set<string>();
+  const uniqueAnnotations: Annotation[] = [];
+  for (const ann of annotations) {
+    if (seen.has(ann.uuid)) continue;
+    seen.add(ann.uuid);
+    uniqueAnnotations.push(ann);
+  }
+
   const byUuid = new Map<string, IssueRecord>();
   for (const issue of existing) {
     const uuid = parseUuid(issue.body);
@@ -18,7 +28,7 @@ export function reconcile(
   }
 
   const actions: Action[] = [];
-  for (const ann of annotations) {
+  for (const ann of uniqueAnnotations) {
     const rendered = render(ann);
     const found = byUuid.get(ann.uuid);
     if (!found) {

--- a/build/notes/render.test.ts
+++ b/build/notes/render.test.ts
@@ -7,8 +7,7 @@ const sample: Annotation = {
   uuid: '4F3A-AB12-B891',
   selectedText: 'A library is a building; a life is a way of living.',
   note: 'fix this metaphor about libraries',
-  chapterTitle: 'Chapter 1: Introduction',
-  locationPercent: 0.12,
+  chapter: '01-introduction',
   modifiedAt: new Date('2026-05-23T14:11:00Z'),
 };
 
@@ -64,15 +63,15 @@ describe('render', () => {
     const out = render(sample);
     expect(out.title).toBe('fix this metaphor about libraries');
     expect(out.body).toContain('> A library is a building; a life is a way of living.');
-    expect(out.body).toContain('— Chapter 1: Introduction (12%)');
+    expect(out.body).toContain('— 01-introduction');
     expect(out.body).toContain('fix this metaphor about libraries');
     expect(out.body).toContain('<!-- apple-books-uuid: 4F3A-AB12-B891 -->');
     expect(out.body).toContain('<!-- apple-books-modified: 2026-05-23T14:11:00.000Z -->');
   });
 
-  it('handles a null chapter title gracefully', () => {
-    const out = render({ ...sample, chapterTitle: null });
-    expect(out.body).toContain('— Uncategorized (12%)');
+  it('handles a null chapter gracefully', () => {
+    const out = render({ ...sample, chapter: null });
+    expect(out.body).toContain('— unknown');
   });
 
   it('quotes each line of a multi-line passage', () => {
@@ -87,10 +86,5 @@ describe('render', () => {
     expect(out.body.length).toBeLessThanOrEqual(GITHUB_BODY_MAX);
     expect(out.body).toContain('_[truncated]_');
     expect(out.body).toContain('<!-- apple-books-uuid: 4F3A-AB12-B891 -->');
-  });
-
-  it('renders location as an integer percentage', () => {
-    const out = render({ ...sample, locationPercent: 0.0735 });
-    expect(out.body).toContain('(7%)');
   });
 });

--- a/build/notes/render.test.ts
+++ b/build/notes/render.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { render, nsdateToDate, deriveTitle } from './render.js';
+import type { Annotation } from './types.js';
+import { GITHUB_BODY_MAX } from './types.js';
+
+const sample: Annotation = {
+  uuid: '4F3A-AB12-B891',
+  selectedText: 'A library is a building; a life is a way of living.',
+  note: 'fix this metaphor about libraries',
+  chapterTitle: 'Chapter 1: Introduction',
+  locationPercent: 0.12,
+  modifiedAt: new Date('2026-05-23T14:11:00Z'),
+};
+
+describe('nsdateToDate', () => {
+  it('converts Core Data NSDate seconds to a JS Date', () => {
+    expect(nsdateToDate(0).toISOString()).toBe('2001-01-01T00:00:00.000Z');
+  });
+
+  it('converts a real-world NSDate to the expected year', () => {
+    const d = nsdateToDate(800_000_000);
+    expect(d.getUTCFullYear()).toBe(2026);
+  });
+
+  it('round-trips a known modification date', () => {
+    expect(nsdateToDate(801238260).toISOString()).toBe('2026-05-23T14:11:00.000Z');
+  });
+});
+
+describe('deriveTitle', () => {
+  it('takes the first non-empty line', () => {
+    expect(deriveTitle('first line\nsecond line')).toBe('first line');
+  });
+
+  it('skips leading blank lines', () => {
+    expect(deriveTitle('\n\nactual content')).toBe('actual content');
+  });
+
+  it('truncates to 80 chars with an ellipsis', () => {
+    const long = 'a'.repeat(120);
+    const result = deriveTitle(long);
+    expect(result.length).toBe(80);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('strips leading markdown punctuation', () => {
+    expect(deriveTitle('## Heading')).toBe('Heading');
+    expect(deriveTitle('- list item')).toBe('list item');
+    expect(deriveTitle('> quoted')).toBe('quoted');
+  });
+
+  it('collapses runs of whitespace', () => {
+    expect(deriveTitle('hello   world\t\tagain')).toBe('hello world again');
+  });
+
+  it('returns a sensible default for empty input', () => {
+    expect(deriveTitle('')).toBe('(empty note)');
+    expect(deriveTitle('\n\n  \n')).toBe('(empty note)');
+  });
+});
+
+describe('render', () => {
+  it('produces the expected title and body for a typical annotation', () => {
+    const out = render(sample);
+    expect(out.title).toBe('fix this metaphor about libraries');
+    expect(out.body).toContain('> A library is a building; a life is a way of living.');
+    expect(out.body).toContain('— Chapter 1: Introduction (12%)');
+    expect(out.body).toContain('fix this metaphor about libraries');
+    expect(out.body).toContain('<!-- apple-books-uuid: 4F3A-AB12-B891 -->');
+    expect(out.body).toContain('<!-- apple-books-modified: 2026-05-23T14:11:00.000Z -->');
+  });
+
+  it('handles a null chapter title gracefully', () => {
+    const out = render({ ...sample, chapterTitle: null });
+    expect(out.body).toContain('— Uncategorized (12%)');
+  });
+
+  it('quotes each line of a multi-line passage', () => {
+    const out = render({ ...sample, selectedText: 'line one\nline two\nline three' });
+    expect(out.body).toContain('> line one');
+    expect(out.body).toContain('> line two');
+    expect(out.body).toContain('> line three');
+  });
+
+  it('truncates an over-long body, preserving the UUID footer', () => {
+    const out = render({ ...sample, note: 'x'.repeat(GITHUB_BODY_MAX + 1000) });
+    expect(out.body.length).toBeLessThanOrEqual(GITHUB_BODY_MAX);
+    expect(out.body).toContain('_[truncated]_');
+    expect(out.body).toContain('<!-- apple-books-uuid: 4F3A-AB12-B891 -->');
+  });
+
+  it('renders location as an integer percentage', () => {
+    const out = render({ ...sample, locationPercent: 0.0735 });
+    expect(out.body).toContain('(7%)');
+  });
+});

--- a/build/notes/render.ts
+++ b/build/notes/render.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure transformation: Apple Books annotation → GitHub issue body.
+ */
+
+import type { Annotation, RenderedIssue } from './types.js';
+import { GITHUB_BODY_MAX, NSDATE_EPOCH_OFFSET } from './types.js';
+
+const TRUNCATED_SUFFIX = '\n\n_[truncated]_\n';
+
+export function nsdateToDate(nsdateSeconds: number): Date {
+  return new Date((nsdateSeconds + NSDATE_EPOCH_OFFSET) * 1000);
+}
+
+export function deriveTitle(note: string): string {
+  const firstNonEmpty = note
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+
+  if (!firstNonEmpty) return '(empty note)';
+
+  const stripped = firstNonEmpty.replace(/^(#+|[-*+]|>)\s+/, '').trim();
+  const collapsed = stripped.replace(/\s+/g, ' ');
+
+  if (collapsed.length <= 80) return collapsed;
+  return collapsed.slice(0, 79) + '…';
+}
+
+function quoteLines(text: string): string {
+  return text
+    .split('\n')
+    .map((l) => `> ${l}`)
+    .join('\n');
+}
+
+function locationLabel(percent: number): string {
+  return `${Math.round(percent * 100)}%`;
+}
+
+export function render(ann: Annotation): RenderedIssue {
+  const title = deriveTitle(ann.note);
+  const chapter = ann.chapterTitle ?? 'Uncategorized';
+
+  const body =
+    quoteLines(ann.selectedText) +
+    `\n>\n> — ${chapter} (${locationLabel(ann.locationPercent)})\n\n` +
+    ann.note +
+    `\n\n<!-- apple-books-uuid: ${ann.uuid} -->\n` +
+    `<!-- apple-books-modified: ${ann.modifiedAt.toISOString()} -->\n`;
+
+  if (body.length <= GITHUB_BODY_MAX) {
+    return { title, body };
+  }
+
+  const footer =
+    `\n\n<!-- apple-books-uuid: ${ann.uuid} -->\n` +
+    `<!-- apple-books-modified: ${ann.modifiedAt.toISOString()} -->\n`;
+  const budget = GITHUB_BODY_MAX - TRUNCATED_SUFFIX.length - footer.length;
+  const truncated = body.slice(0, budget) + TRUNCATED_SUFFIX + footer;
+  return { title, body: truncated };
+}

--- a/build/notes/render.ts
+++ b/build/notes/render.ts
@@ -33,17 +33,13 @@ function quoteLines(text: string): string {
     .join('\n');
 }
 
-function locationLabel(percent: number): string {
-  return `${Math.round(percent * 100)}%`;
-}
-
 export function render(ann: Annotation): RenderedIssue {
   const title = deriveTitle(ann.note);
-  const chapter = ann.chapterTitle ?? 'Uncategorized';
+  const chapter = ann.chapter ?? 'unknown';
 
   const body =
     quoteLines(ann.selectedText) +
-    `\n>\n> — ${chapter} (${locationLabel(ann.locationPercent)})\n\n` +
+    `\n>\n> — ${chapter}\n\n` +
     ann.note +
     `\n\n<!-- apple-books-uuid: ${ann.uuid} -->\n` +
     `<!-- apple-books-modified: ${ann.modifiedAt.toISOString()} -->\n`;

--- a/build/notes/sqlite-source.test.ts
+++ b/build/notes/sqlite-source.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import { findAssetId, listAnnotations } from './sqlite-source.js';
+import { BOOK_TITLE } from './types.js';
+
+const fixtureSql = readFileSync(
+  join(import.meta.dirname, '__fixtures__', 'aeannotation.sql'),
+  'utf8'
+);
+
+let libraryDb: Database.Database;
+let annotationDb: Database.Database;
+
+beforeEach(() => {
+  libraryDb = new Database(':memory:');
+  annotationDb = new Database(':memory:');
+  libraryDb.exec(fixtureSql);
+  annotationDb.exec(fixtureSql);
+  libraryDb.exec('DROP TABLE ZAEANNOTATION');
+  annotationDb.exec('DROP TABLE ZBKLIBRARYASSET');
+});
+
+describe('findAssetId', () => {
+  it('returns the ASSETID for a book title that exists', () => {
+    expect(findAssetId(libraryDb, BOOK_TITLE)).toBe('ASSET-MAJORDOMO');
+  });
+
+  it('returns null for a title that does not exist', () => {
+    expect(findAssetId(libraryDb, 'No Such Book')).toBeNull();
+  });
+});
+
+describe('listAnnotations', () => {
+  it('returns only annotations with a non-null note', () => {
+    const rows = listAnnotations(annotationDb, 'ASSET-MAJORDOMO');
+    const uuids = rows.map((r) => r.uuid).sort();
+    expect(uuids).toEqual(['UUID-A', 'UUID-C']);
+  });
+
+  it('filters out soft-deleted annotations', () => {
+    const rows = listAnnotations(annotationDb, 'ASSET-MAJORDOMO');
+    expect(rows.find((r) => r.uuid === 'UUID-D')).toBeUndefined();
+  });
+
+  it('filters by asset_id (no annotations from other books)', () => {
+    const rows = listAnnotations(annotationDb, 'ASSET-OTHER');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].uuid).toBe('UUID-OTHER');
+  });
+
+  it('decodes the NSDate column into a JS Date', () => {
+    const rows = listAnnotations(annotationDb, 'ASSET-MAJORDOMO');
+    const a = rows.find((r) => r.uuid === 'UUID-A');
+    expect(a).toBeDefined();
+    expect(a!.modifiedAt.toISOString()).toBe('2026-05-23T14:11:00.000Z');
+  });
+
+  it('decodes location string to a number', () => {
+    const rows = listAnnotations(annotationDb, 'ASSET-MAJORDOMO');
+    const a = rows.find((r) => r.uuid === 'UUID-A');
+    expect(a!.locationPercent).toBeCloseTo(0.12);
+  });
+
+  it('returns an empty array for an unknown asset_id', () => {
+    expect(listAnnotations(annotationDb, 'ASSET-MISSING')).toEqual([]);
+  });
+});

--- a/build/notes/sqlite-source.test.ts
+++ b/build/notes/sqlite-source.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 import { findAssetId, listAnnotations } from './sqlite-source.js';
 import { BOOK_TITLE } from './types.js';
 
 const fixtureSql = readFileSync(
-  join(import.meta.dirname, '__fixtures__', 'aeannotation.sql'),
+  fileURLToPath(new URL('./__fixtures__/aeannotation.sql', import.meta.url)),
   'utf8'
 );
 

--- a/build/notes/sqlite-source.test.ts
+++ b/build/notes/sqlite-source.test.ts
@@ -31,6 +31,12 @@ describe('findAssetId', () => {
   it('returns null for a title that does not exist', () => {
     expect(findAssetId(libraryDb, 'No Such Book')).toBeNull();
   });
+
+  it('returns the most-recently-added asset when multiple share the title', () => {
+    // Seed an additional row with a higher Z_PK and the same title
+    libraryDb.exec("INSERT INTO ZBKLIBRARYASSET VALUES (99, 'ASSET-NEWER', 'Majordomo');");
+    expect(findAssetId(libraryDb, BOOK_TITLE)).toBe('ASSET-NEWER');
+  });
 });
 
 describe('listAnnotations', () => {
@@ -43,6 +49,11 @@ describe('listAnnotations', () => {
   it('filters out soft-deleted annotations', () => {
     const rows = listAnnotations(annotationDb, 'ASSET-MAJORDOMO');
     expect(rows.find((r) => r.uuid === 'UUID-D')).toBeUndefined();
+  });
+
+  it('filters out annotations with empty/whitespace-only notes', () => {
+    const rows = listAnnotations(annotationDb, 'ASSET-MAJORDOMO');
+    expect(rows.find((r) => r.uuid === 'UUID-E')).toBeUndefined();
   });
 
   it('filters by asset_id (no annotations from other books)', () => {

--- a/build/notes/sqlite-source.test.ts
+++ b/build/notes/sqlite-source.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
-import { findAssetId, listAnnotations } from './sqlite-source.js';
+import { findAssetId, listAnnotations, parseChapter } from './sqlite-source.js';
 import { BOOK_TITLE } from './types.js';
 
 const fixtureSql = readFileSync(
@@ -58,13 +58,32 @@ describe('listAnnotations', () => {
     expect(a!.modifiedAt.toISOString()).toBe('2026-05-23T14:11:00.000Z');
   });
 
-  it('decodes location string to a number', () => {
+  it('parses chapter slug from CFI', () => {
     const rows = listAnnotations(annotationDb, 'ASSET-MAJORDOMO');
     const a = rows.find((r) => r.uuid === 'UUID-A');
-    expect(a!.locationPercent).toBeCloseTo(0.12);
+    expect(a!.chapter).toBe('00-epigraph');
   });
 
   it('returns an empty array for an unknown asset_id', () => {
     expect(listAnnotations(annotationDb, 'ASSET-MISSING')).toEqual([]);
+  });
+});
+
+describe('parseChapter', () => {
+  it('extracts the bracketed id from a typical CFI', () => {
+    expect(parseChapter('epubcfi(/6/4[00-epigraph]!/4/2/6/2/1,:3,:55)')).toBe('00-epigraph');
+  });
+
+  it('returns null when the CFI has no bracketed id', () => {
+    expect(parseChapter('epubcfi(/6/4!/4/2)')).toBeNull();
+  });
+
+  it('returns null on null/empty input', () => {
+    expect(parseChapter(null)).toBeNull();
+    expect(parseChapter('')).toBeNull();
+  });
+
+  it('returns the first bracket if multiple are present', () => {
+    expect(parseChapter('[first]/...[second]')).toBe('first');
   });
 });

--- a/build/notes/sqlite-source.ts
+++ b/build/notes/sqlite-source.ts
@@ -68,11 +68,24 @@ export function findAssetId(libraryDb: Database.Database, title: string): string
   return row?.ZASSETID ?? null;
 }
 
+/**
+ * Extract the chapter identifier from an EPUB CFI.
+ * CFIs look like `epubcfi(/6/4[00-epigraph]!/4/2/6/2/1,:3,:55)` — the
+ * bracketed part inside the spine reference is the spine item's idref,
+ * which in this book's build matches the source-tree chapter directory.
+ * Returns the slug (e.g. "00-epigraph") or null if not found.
+ */
+export function parseChapter(cfi: string | null): string | null {
+  if (!cfi) return null;
+  const m = cfi.match(/\[([^\]]+)\]/);
+  return m ? m[1] : null;
+}
+
 interface AnnotationRow {
   ZANNOTATIONUUID: string;
+  ZANNOTATIONREPRESENTATIVETEXT: string | null;
   ZANNOTATIONSELECTEDTEXT: string;
   ZANNOTATIONNOTE: string;
-  ZFUTUREPROOFING5: string | null;
   ZANNOTATIONLOCATION: string | null;
   ZANNOTATIONMODIFICATIONDATE: number;
 }
@@ -82,9 +95,9 @@ export function listAnnotations(annotationDb: Database.Database, assetId: string
     .prepare<[string], AnnotationRow>(
       `SELECT
          ZANNOTATIONUUID,
+         ZANNOTATIONREPRESENTATIVETEXT,
          ZANNOTATIONSELECTEDTEXT,
          ZANNOTATIONNOTE,
-         ZFUTUREPROOFING5,
          ZANNOTATIONLOCATION,
          ZANNOTATIONMODIFICATIONDATE
        FROM ZAEANNOTATION
@@ -97,10 +110,11 @@ export function listAnnotations(annotationDb: Database.Database, assetId: string
 
   return rows.map((r) => ({
     uuid: r.ZANNOTATIONUUID,
-    selectedText: r.ZANNOTATIONSELECTEDTEXT,
+    // Prefer the representative (full natural unit); fall back to the
+    // user's literal selection if Apple didn't populate the representative.
+    selectedText: r.ZANNOTATIONREPRESENTATIVETEXT ?? r.ZANNOTATIONSELECTEDTEXT,
     note: r.ZANNOTATIONNOTE,
-    chapterTitle: r.ZFUTUREPROOFING5,
-    locationPercent: r.ZANNOTATIONLOCATION ? parseFloat(r.ZANNOTATIONLOCATION) : 0,
+    chapter: parseChapter(r.ZANNOTATIONLOCATION),
     modifiedAt: nsdateToDate(r.ZANNOTATIONMODIFICATIONDATE),
   }));
 }

--- a/build/notes/sqlite-source.ts
+++ b/build/notes/sqlite-source.ts
@@ -6,7 +6,7 @@
  *   ~/Library/Containers/com.apple.iBooksX/Data/Documents/AEAnnotation/AEAnnotation_*.sqlite
  */
 
-import { glob } from 'node:fs/promises';
+import { readdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
@@ -16,14 +16,34 @@ import { nsdateToDate } from './render.js';
 const BOOKS_CONTAINER = 'Library/Containers/com.apple.iBooksX/Data/Documents';
 
 export async function findAnnotationDbPath(home: string = homedir()): Promise<string | null> {
-  const pattern = join(home, BOOKS_CONTAINER, 'AEAnnotation', 'AEAnnotation_*.sqlite');
-  for await (const match of glob(pattern)) return match;
+  const dir = join(home, BOOKS_CONTAINER, 'AEAnnotation');
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return null;
+  }
+  for (const f of entries) {
+    if (f.startsWith('AEAnnotation_') && f.endsWith('.sqlite')) {
+      return join(dir, f);
+    }
+  }
   return null;
 }
 
 export async function findLibraryDbPath(home: string = homedir()): Promise<string | null> {
-  const pattern = join(home, BOOKS_CONTAINER, 'BKLibrary', 'BKLibrary-*.sqlite');
-  for await (const match of glob(pattern)) return match;
+  const dir = join(home, BOOKS_CONTAINER, 'BKLibrary');
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return null;
+  }
+  for (const f of entries) {
+    if (f.startsWith('BKLibrary-') && f.endsWith('.sqlite')) {
+      return join(dir, f);
+    }
+  }
   return null;
 }
 

--- a/build/notes/sqlite-source.ts
+++ b/build/notes/sqlite-source.ts
@@ -1,0 +1,76 @@
+/**
+ * Read-only access to Apple Books's sqlite databases.
+ *
+ * Real paths (caller resolves via glob):
+ *   ~/Library/Containers/com.apple.iBooksX/Data/Documents/BKLibrary/BKLibrary-*.sqlite
+ *   ~/Library/Containers/com.apple.iBooksX/Data/Documents/AEAnnotation/AEAnnotation_*.sqlite
+ */
+
+import { glob } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import type { Annotation } from './types.js';
+import { nsdateToDate } from './render.js';
+
+const BOOKS_CONTAINER = 'Library/Containers/com.apple.iBooksX/Data/Documents';
+
+export async function findAnnotationDbPath(home: string = homedir()): Promise<string | null> {
+  const pattern = join(home, BOOKS_CONTAINER, 'AEAnnotation', 'AEAnnotation_*.sqlite');
+  for await (const match of glob(pattern)) return match;
+  return null;
+}
+
+export async function findLibraryDbPath(home: string = homedir()): Promise<string | null> {
+  const pattern = join(home, BOOKS_CONTAINER, 'BKLibrary', 'BKLibrary-*.sqlite');
+  for await (const match of glob(pattern)) return match;
+  return null;
+}
+
+export function openReadonly(path: string): Database.Database {
+  return new Database(path, { readonly: true, fileMustExist: true });
+}
+
+export function findAssetId(libraryDb: Database.Database, title: string): string | null {
+  const row = libraryDb
+    .prepare<[string], { ZASSETID: string }>('SELECT ZASSETID FROM ZBKLIBRARYASSET WHERE ZTITLE = ?')
+    .get(title);
+  return row?.ZASSETID ?? null;
+}
+
+interface AnnotationRow {
+  ZANNOTATIONUUID: string;
+  ZANNOTATIONSELECTEDTEXT: string;
+  ZANNOTATIONNOTE: string;
+  ZFUTUREPROOFING5: string | null;
+  ZANNOTATIONLOCATION: string | null;
+  ZANNOTATIONMODIFICATIONDATE: number;
+}
+
+export function listAnnotations(annotationDb: Database.Database, assetId: string): Annotation[] {
+  const rows = annotationDb
+    .prepare<[string], AnnotationRow>(
+      `SELECT
+         ZANNOTATIONUUID,
+         ZANNOTATIONSELECTEDTEXT,
+         ZANNOTATIONNOTE,
+         ZFUTUREPROOFING5,
+         ZANNOTATIONLOCATION,
+         ZANNOTATIONMODIFICATIONDATE
+       FROM ZAEANNOTATION
+       WHERE ZANNOTATIONASSETID = ?
+         AND ZANNOTATIONNOTE IS NOT NULL
+         AND (ZANNOTATIONDELETED IS NULL OR ZANNOTATIONDELETED = 0)
+       ORDER BY ZANNOTATIONLOCATION`
+    )
+    .all(assetId);
+
+  return rows.map((r) => ({
+    uuid: r.ZANNOTATIONUUID,
+    selectedText: r.ZANNOTATIONSELECTEDTEXT,
+    note: r.ZANNOTATIONNOTE,
+    chapterTitle: r.ZFUTUREPROOFING5,
+    locationPercent: r.ZANNOTATIONLOCATION ? parseFloat(r.ZANNOTATIONLOCATION) : 0,
+    modifiedAt: nsdateToDate(r.ZANNOTATIONMODIFICATIONDATE),
+  }));
+}

--- a/build/notes/sqlite-source.ts
+++ b/build/notes/sqlite-source.ts
@@ -63,7 +63,9 @@ export async function openReadonly(path: string): Promise<Database.Database> {
 
 export function findAssetId(libraryDb: Database.Database, title: string): string | null {
   const row = libraryDb
-    .prepare<[string], { ZASSETID: string }>('SELECT ZASSETID FROM ZBKLIBRARYASSET WHERE ZTITLE = ?')
+    .prepare<[string], { ZASSETID: string }>(
+      'SELECT ZASSETID FROM ZBKLIBRARYASSET WHERE ZTITLE = ? ORDER BY Z_PK DESC LIMIT 1'
+    )
     .get(title);
   return row?.ZASSETID ?? null;
 }
@@ -103,6 +105,7 @@ export function listAnnotations(annotationDb: Database.Database, assetId: string
        FROM ZAEANNOTATION
        WHERE ZANNOTATIONASSETID = ?
          AND ZANNOTATIONNOTE IS NOT NULL
+         AND length(trim(ZANNOTATIONNOTE)) > 0
          AND (ZANNOTATIONDELETED IS NULL OR ZANNOTATIONDELETED = 0)
        ORDER BY ZANNOTATIONLOCATION`
     )

--- a/build/notes/sqlite-source.ts
+++ b/build/notes/sqlite-source.ts
@@ -47,8 +47,18 @@ export async function findLibraryDbPath(home: string = homedir()): Promise<strin
   return null;
 }
 
-export function openReadonly(path: string): Database.Database {
-  return new Database(path, { readonly: true, fileMustExist: true });
+export async function openReadonly(path: string): Promise<Database.Database> {
+  try {
+    return new Database(path, { readonly: true, fileMustExist: true });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/SQLITE_BUSY|database is locked/i.test(msg)) {
+      // Single retry after 500ms — matches spec failure-mode table.
+      await new Promise((r) => setTimeout(r, 500));
+      return new Database(path, { readonly: true, fileMustExist: true });
+    }
+    throw e;
+  }
 }
 
 export function findAssetId(libraryDb: Database.Database, title: string): string | null {

--- a/build/notes/state.test.ts
+++ b/build/notes/state.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readState, writeState, emptyState, statePath } from './state.js';
+import type { SyncState } from './types.js';
+
+let tmpDir: string;
+let path: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'majordomo-state-'));
+  path = join(tmpDir, 'state.json');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('emptyState', () => {
+  it('produces a valid initial SyncState', () => {
+    const s = emptyState();
+    expect(s.schemaVersion).toBe(1);
+    expect(s.majordomoAssetId).toBeNull();
+    expect(s.runs).toEqual({ total: 0, created: 0, updated: 0, noop: 0 });
+    expect(s.lastSqliteMtime).toBe('1970-01-01T00:00:00.000Z');
+  });
+});
+
+describe('readState', () => {
+  it('returns emptyState when the file does not exist', async () => {
+    const s = await readState(path);
+    expect(s).toEqual(emptyState());
+  });
+
+  it('returns emptyState when the file is unparseable JSON', async () => {
+    writeFileSync(path, '{ this is not json');
+    const s = await readState(path);
+    expect(s).toEqual(emptyState());
+  });
+
+  it('returns emptyState when schemaVersion is missing or unknown', async () => {
+    writeFileSync(path, JSON.stringify({ schemaVersion: 99, foo: 'bar' }));
+    const s = await readState(path);
+    expect(s).toEqual(emptyState());
+  });
+
+  it('reads and parses a valid v1 state file', async () => {
+    const written: SyncState = {
+      schemaVersion: 1,
+      lastSqliteMtime: '2026-05-23T18:00:00.000Z',
+      lastSuccessfulSync: '2026-05-23T18:00:01.000Z',
+      majordomoAssetId: 'ASSET-XYZ',
+      runs: { total: 5, created: 2, updated: 1, noop: 2 },
+    };
+    writeFileSync(path, JSON.stringify(written));
+    expect(await readState(path)).toEqual(written);
+  });
+});
+
+describe('writeState', () => {
+  it('persists a state object as readable JSON', async () => {
+    const s = emptyState();
+    s.lastSqliteMtime = '2026-05-23T18:00:00.000Z';
+    s.runs.total = 1;
+    await writeState(path, s);
+    const back = await readState(path);
+    expect(back).toEqual(s);
+  });
+
+  it('creates parent directories if missing', async () => {
+    const nested = join(tmpDir, 'a', 'b', 'c', 'state.json');
+    await writeState(nested, emptyState());
+    expect(await readState(nested)).toEqual(emptyState());
+  });
+});
+
+describe('statePath', () => {
+  it('returns the macOS Application Support path under the given home', () => {
+    const p = statePath('/Users/dwk');
+    expect(p).toBe('/Users/dwk/Library/Application Support/majordomo/notes-sync-state.json');
+  });
+});

--- a/build/notes/state.ts
+++ b/build/notes/state.ts
@@ -1,0 +1,43 @@
+/**
+ * Read / write / migrate the sync state file.
+ * Location: ~/Library/Application Support/majordomo/notes-sync-state.json
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import type { SyncState } from './types.js';
+
+export function statePath(home: string): string {
+  return join(home, 'Library', 'Application Support', 'majordomo', 'notes-sync-state.json');
+}
+
+export function emptyState(): SyncState {
+  return {
+    schemaVersion: 1,
+    lastSqliteMtime: '1970-01-01T00:00:00.000Z',
+    lastSuccessfulSync: '1970-01-01T00:00:00.000Z',
+    majordomoAssetId: null,
+    runs: { total: 0, created: 0, updated: 0, noop: 0 },
+  };
+}
+
+export async function readState(path: string): Promise<SyncState> {
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch {
+    return emptyState();
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed?.schemaVersion === 1) return parsed as SyncState;
+    return emptyState();
+  } catch {
+    return emptyState();
+  }
+}
+
+export async function writeState(path: string, state: SyncState): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(state, null, 2) + '\n', 'utf8');
+}

--- a/build/notes/types.ts
+++ b/build/notes/types.ts
@@ -5,14 +5,21 @@
 export interface Annotation {
   /** ZANNOTATIONUUID — stable across edits, primary dedup key. */
   uuid: string;
-  /** ZSELECTEDTEXT — the passage highlighted in Apple Books. */
+  /**
+   * Apple's expanded natural-unit (typically a sentence) around the user's
+   * finger-selection. Sourced from ZANNOTATIONREPRESENTATIVETEXT rather than
+   * ZANNOTATIONSELECTEDTEXT because the literal selection is often truncated
+   * mid-word and gives less context.
+   */
   selectedText: string;
   /** ZANNOTATIONNOTE — the user's typed note. Non-empty by filter. */
   note: string;
-  /** ZFUTUREPROOFING5 — chapter title captured at annotation time. */
-  chapterTitle: string | null;
-  /** ZLOCATIONRANGESTART — 0.0 to 1.0 position in the book. */
-  locationPercent: number;
+  /**
+   * Chapter slug parsed from the CFI bracket in ZANNOTATIONLOCATION
+   * (e.g. "00-epigraph" from `epubcfi(/6/4[00-epigraph]!/...)`).
+   * Null if the CFI is missing or doesn't contain a bracketed ID.
+   */
+  chapter: string | null;
   /** ZANNOTATIONMODIFICATIONDATE — already converted from NSDate. */
   modifiedAt: Date;
 }
@@ -48,7 +55,12 @@ export interface SyncState {
 
 /** Constants shared across modules. */
 export const LABEL_NAME = 'from:apple-books';
-export const BOOK_TITLE = 'A Majordomo for Everyone';
+/**
+ * The ePub's `dc:title` as set by the build pipeline (see BOOK_META in
+ * build/types.ts). This is the value Apple Books stores in ZTITLE on
+ * ZBKLIBRARYASSET — NOT the GitHub repo name.
+ */
+export const BOOK_TITLE = 'Majordomo';
 export const GITHUB_BODY_MAX = 65536;
 /** Seconds between Unix epoch and Core Data NSDate epoch (2001-01-01 UTC). */
 export const NSDATE_EPOCH_OFFSET = 978307200;

--- a/build/notes/types.ts
+++ b/build/notes/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared types for the Apple Books → GitHub Issues sync feature.
+ */
+
+export interface Annotation {
+  /** ZANNOTATIONUUID — stable across edits, primary dedup key. */
+  uuid: string;
+  /** ZSELECTEDTEXT — the passage highlighted in Apple Books. */
+  selectedText: string;
+  /** ZANNOTATIONNOTE — the user's typed note. Non-empty by filter. */
+  note: string;
+  /** ZFUTUREPROOFING5 — chapter title captured at annotation time. */
+  chapterTitle: string | null;
+  /** ZLOCATIONRANGESTART — 0.0 to 1.0 position in the book. */
+  locationPercent: number;
+  /** ZANNOTATIONMODIFICATIONDATE — already converted from NSDate. */
+  modifiedAt: Date;
+}
+
+export interface IssueRecord {
+  number: number;
+  body: string;
+  state: 'OPEN' | 'CLOSED';
+}
+
+export interface RenderedIssue {
+  title: string;
+  body: string;
+}
+
+export type Action =
+  | { type: 'create'; uuid: string; rendered: RenderedIssue }
+  | { type: 'update'; uuid: string; issue: number; rendered: RenderedIssue }
+  | { type: 'noop'; uuid: string; issue: number };
+
+export interface SyncState {
+  schemaVersion: 1;
+  lastSqliteMtime: string;
+  lastSuccessfulSync: string;
+  majordomoAssetId: string | null;
+  runs: {
+    total: number;
+    created: number;
+    updated: number;
+    noop: number;
+  };
+}
+
+/** Constants shared across modules. */
+export const LABEL_NAME = 'from:apple-books';
+export const BOOK_TITLE = 'A Majordomo for Everyone';
+export const GITHUB_BODY_MAX = 65536;
+/** Seconds between Unix epoch and Core Data NSDate epoch (2001-01-01 UTC). */
+export const NSDATE_EPOCH_OFFSET = 978307200;

--- a/build/notes/uuid-parse.test.ts
+++ b/build/notes/uuid-parse.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { parseUuid } from './uuid-parse.js';
+
+describe('parseUuid', () => {
+  it('extracts the UUID from a well-formed comment', () => {
+    const body = '> quoted passage\n\nmy note\n\n<!-- apple-books-uuid: 4F3A-AB12-B891 -->\n';
+    expect(parseUuid(body)).toBe('4F3A-AB12-B891');
+  });
+
+  it('returns null when no comment is present', () => {
+    expect(parseUuid('plain body, no marker')).toBeNull();
+  });
+
+  it('returns null on malformed comment (missing prefix)', () => {
+    expect(parseUuid('<!-- some-other-uuid: ABC123 -->')).toBeNull();
+  });
+
+  it('tolerates surrounding whitespace inside the comment', () => {
+    expect(parseUuid('<!--  apple-books-uuid:   ABC-123  -->')).toBe('ABC-123');
+  });
+
+  it('returns the first UUID if the body contains two (defensive)', () => {
+    const body = '<!-- apple-books-uuid: FIRST -->\n<!-- apple-books-uuid: SECOND -->';
+    expect(parseUuid(body)).toBe('FIRST');
+  });
+
+  it('handles real-world Apple Books UUID format (long hex with dashes)', () => {
+    const body = '<!-- apple-books-uuid: 4F3A2B1C-9D8E-7F6A-5B4C-3D2E1F0A9B8C -->';
+    expect(parseUuid(body)).toBe('4F3A2B1C-9D8E-7F6A-5B4C-3D2E1F0A9B8C');
+  });
+});

--- a/build/notes/uuid-parse.ts
+++ b/build/notes/uuid-parse.ts
@@ -1,0 +1,10 @@
+/**
+ * Extract the Apple Books UUID from a GitHub Issue body.
+ */
+
+const UUID_RE = /<!--\s*apple-books-uuid:\s*([^\s][^\s-]*(?:-[^\s-]+)*)\s*-->/;
+
+export function parseUuid(body: string): string | null {
+  const m = body.match(UUID_RE);
+  return m ? m[1] : null;
+}

--- a/build/scripts/install-notes-sync.ts
+++ b/build/scripts/install-notes-sync.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * One-shot installer for the Apple Books notes sync LaunchAgent.
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { createLabelIfMissing } from '../notes/github-target.js';
+import { findAnnotationDbPath } from '../notes/sqlite-source.js';
+
+const LABEL_PLIST = 'io.dwk.majordomo.notes-sync';
+const PLIST_NAME = `${LABEL_PLIST}.plist`;
+
+function die(msg: string, code = 1): never {
+  console.error(`[install-notes-sync] ${msg}`);
+  process.exit(code);
+}
+
+function checkTool(tool: string, args: string[] = ['--version']): void {
+  const r = spawnSync(tool, args, { encoding: 'utf8' });
+  if (r.status !== 0) die(`required tool not working: \`${tool} ${args.join(' ')}\` exited ${r.status}`);
+}
+
+function repoRoot(): string {
+  const r = spawnSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' });
+  if (r.status !== 0) die('not inside a git repository');
+  return r.stdout.trim();
+}
+
+function repoRemote(repo: string): string {
+  const r = spawnSync('git', ['-C', repo, 'remote', 'get-url', 'origin'], { encoding: 'utf8' });
+  if (r.status !== 0) die('repo has no `origin` remote');
+  return r.stdout.trim();
+}
+
+async function main(): Promise<void> {
+  const home = homedir();
+  const repo = repoRoot();
+  const tsx = resolve(repo, 'node_modules', '.bin', 'tsx');
+  const path = '/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin';
+
+  console.log('[install-notes-sync] preflight...');
+
+  checkTool('gh');
+
+  const auth = spawnSync('gh', ['auth', 'status'], { encoding: 'utf8' });
+  if (auth.status !== 0) {
+    die(`gh CLI is not authenticated. Run: gh auth login --git-protocol https --hostname github.com`);
+  }
+
+  checkTool(tsx);
+
+  const remote = repoRemote(repo);
+  if (!/davidwkeith\/A-Majordomo-for-Everyone(\.git)?$/.test(remote)) {
+    die(`unexpected origin remote: ${remote}\n  expected: davidwkeith/A-Majordomo-for-Everyone`);
+  }
+
+  const annPath = await findAnnotationDbPath(home);
+  if (!annPath) {
+    console.log('[install-notes-sync] warning: Apple Books sqlite not found yet — open Books at least once after install.');
+  }
+
+  console.log('[install-notes-sync] creating from:apple-books label (if missing)...');
+  const created = await createLabelIfMissing();
+  console.log(`[install-notes-sync]   ${created ? 'created' : 'already exists'}`);
+
+  console.log('[install-notes-sync] writing LaunchAgent plist...');
+  const tmplPath = join(repo, 'build', 'scripts', 'notes-sync', `${PLIST_NAME}.template`);
+  const dest = join(home, 'Library', 'LaunchAgents', PLIST_NAME);
+  const tmpl = await readFile(tmplPath, 'utf8');
+  const plist = tmpl
+    .replaceAll('__HOME__', home)
+    .replaceAll('__PATH__', path)
+    .replaceAll('__TSX__', tsx)
+    .replaceAll('__REPO__', repo);
+  await mkdir(dirname(dest), { recursive: true });
+  await writeFile(dest, plist, 'utf8');
+  console.log(`[install-notes-sync]   wrote ${dest}`);
+
+  console.log('[install-notes-sync] loading via launchctl bootstrap...');
+  const uid = process.getuid?.() ?? 0;
+  const bootstrap = spawnSync('launchctl', ['bootstrap', `gui/${uid}`, dest], { encoding: 'utf8' });
+  if (bootstrap.status !== 0) {
+    if (/already loaded|Bootstrap failed/i.test(bootstrap.stderr)) {
+      console.log('[install-notes-sync]   already loaded — replacing');
+      spawnSync('launchctl', ['bootout', `gui/${uid}/${LABEL_PLIST}`], { encoding: 'utf8' });
+      const second = spawnSync('launchctl', ['bootstrap', `gui/${uid}`, dest], { encoding: 'utf8' });
+      if (second.status !== 0) die(`launchctl bootstrap failed: ${second.stderr.trim()}`);
+    } else {
+      die(`launchctl bootstrap failed: ${bootstrap.stderr.trim()}`);
+    }
+  }
+  console.log('[install-notes-sync]   loaded');
+
+  console.log('[install-notes-sync] kickstarting first run...');
+  const kick = spawnSync('launchctl', ['kickstart', '-p', `gui/${uid}/${LABEL_PLIST}`], { encoding: 'utf8' });
+  if (kick.status !== 0) die(`launchctl kickstart failed: ${kick.stderr.trim()}`);
+  console.log('[install-notes-sync]   kicked');
+
+  console.log('');
+  console.log('Done. Next steps:');
+  console.log(`  • Log:           tail -f ${home}/Library/Logs/majordomo-notes-sync.log`);
+  console.log(`  • Status:        npm run sync:notes:status`);
+  console.log(`  • Manual run:    npm run sync:notes`);
+  console.log(`  • Uninstall:     npm run sync:notes:uninstall`);
+}
+
+main().catch((e) => die(e instanceof Error ? e.message : String(e)));

--- a/build/scripts/install-notes-sync.ts
+++ b/build/scripts/install-notes-sync.ts
@@ -39,9 +39,19 @@ async function main(): Promise<void> {
   const home = homedir();
   const repo = repoRoot();
   const tsx = resolve(repo, 'node_modules', '.bin', 'tsx');
-  const path = '/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin';
+  // Prepend the install-time node's bin dir so the daemon uses the same
+  // node that built the better-sqlite3 native module. Without this, a
+  // user with multiple node versions (e.g. node@22 in their shell PATH
+  // but the default `/opt/homebrew/bin/node` being a newer release) would
+  // hit a NODE_MODULE_VERSION mismatch when launchd's PATH resolves to
+  // the wrong node.
+  const nodeDir = dirname(process.execPath);
+  const path = [nodeDir, '/usr/local/bin', '/opt/homebrew/bin', '/usr/bin', '/bin']
+    .filter((p, i, arr) => arr.indexOf(p) === i)
+    .join(':');
 
   console.log('[install-notes-sync] preflight...');
+  console.log(`[install-notes-sync]   node:  ${process.execPath} (${process.version})`);
 
   checkTool('gh');
 

--- a/build/scripts/install-notes-sync.ts
+++ b/build/scripts/install-notes-sync.ts
@@ -115,6 +115,12 @@ async function main(): Promise<void> {
   console.log(`  • Status:        npm run sync:notes:status`);
   console.log(`  • Manual run:    npm run sync:notes`);
   console.log(`  • Uninstall:     npm run sync:notes:uninstall`);
+  console.log('');
+  console.log('⚠️  If the daemon hangs on first launch, grant Full Disk Access to:');
+  console.log(`     ${process.execPath}`);
+  console.log('   (System Settings → Privacy & Security → Full Disk Access → +)');
+  console.log('   Then re-kickstart:');
+  console.log(`     launchctl kickstart -p "gui/$(id -u)/io.dwk.majordomo.notes-sync"`);
 }
 
 main().catch((e) => die(e instanceof Error ? e.message : String(e)));

--- a/build/scripts/install-notes-sync.ts
+++ b/build/scripts/install-notes-sync.ts
@@ -36,6 +36,10 @@ function repoRemote(repo: string): string {
 }
 
 async function main(): Promise<void> {
+  if (typeof process.getuid !== 'function') {
+    console.error('This script requires a POSIX environment (macOS).');
+    process.exit(1);
+  }
   const home = homedir();
   const repo = repoRoot();
   const tsx = resolve(repo, 'node_modules', '.bin', 'tsx');
@@ -90,10 +94,10 @@ async function main(): Promise<void> {
   console.log(`[install-notes-sync]   wrote ${dest}`);
 
   console.log('[install-notes-sync] loading via launchctl bootstrap...');
-  const uid = process.getuid?.() ?? 0;
+  const uid = process.getuid!();
   const bootstrap = spawnSync('launchctl', ['bootstrap', `gui/${uid}`, dest], { encoding: 'utf8' });
   if (bootstrap.status !== 0) {
-    if (/already loaded|Bootstrap failed/i.test(bootstrap.stderr)) {
+    if (/already loaded|already bootstrapped/i.test(bootstrap.stderr)) {
       console.log('[install-notes-sync]   already loaded — replacing');
       spawnSync('launchctl', ['bootout', `gui/${uid}/${LABEL_PLIST}`], { encoding: 'utf8' });
       const second = spawnSync('launchctl', ['bootstrap', `gui/${uid}`, dest], { encoding: 'utf8' });

--- a/build/scripts/notes-sync/io.dwk.majordomo.notes-sync.plist.template
+++ b/build/scripts/notes-sync/io.dwk.majordomo.notes-sync.plist.template
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.dwk.majordomo.notes-sync</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/env</string>
+        <string>-i</string>
+        <string>HOME=__HOME__</string>
+        <string>PATH=__PATH__</string>
+        <string>__TSX__</string>
+        <string>build/scripts/sync-apple-books-notes.ts</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO__</string>
+
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/majordomo-notes-sync.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/majordomo-notes-sync.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+
+    <key>Nice</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/build/scripts/sync-apple-books-notes-status.ts
+++ b/build/scripts/sync-apple-books-notes-status.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * `npm run sync:notes:status` — pretty-printed observability summary.
+ */
+
+import { stat } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { readState, statePath } from '../notes/state.js';
+import { findAnnotationDbPath } from '../notes/sqlite-source.js';
+import { LABEL_NAME } from '../notes/types.js';
+
+function fmt(iso: string): string {
+  if (iso === '1970-01-01T00:00:00.000Z') return '(never)';
+  const d = new Date(iso);
+  const now = Date.now();
+  const ago = Math.round((now - d.getTime()) / 60000);
+  return `${d.toLocaleString()} (${ago} minutes ago)`;
+}
+
+async function fileSize(path: string): Promise<string> {
+  try {
+    const s = await stat(path);
+    if (s.size > 1024 * 1024) return `${(s.size / 1024 / 1024).toFixed(1)} MB`;
+    if (s.size > 1024) return `${(s.size / 1024).toFixed(1)} KB`;
+    return `${s.size} B`;
+  } catch {
+    return '(missing)';
+  }
+}
+
+function ghCount(state: 'open' | 'closed'): number | null {
+  const r = spawnSync(
+    'gh',
+    ['issue', 'list', '--label', LABEL_NAME, '--state', state, '--limit', '1000', '--json', 'number'],
+    { encoding: 'utf8' }
+  );
+  if (r.status !== 0) return null;
+  try {
+    return (JSON.parse(r.stdout) as unknown[]).length;
+  } catch {
+    return null;
+  }
+}
+
+function launchctlLoaded(): boolean {
+  const r = spawnSync(
+    'launchctl',
+    ['print', `gui/${process.getuid?.() ?? 0}/io.dwk.majordomo.notes-sync`],
+    { encoding: 'utf8' }
+  );
+  return r.status === 0;
+}
+
+async function main(): Promise<void> {
+  const home = homedir();
+  const s = await readState(statePath(home));
+  const logPath = join(home, 'Library', 'Logs', 'majordomo-notes-sync.log');
+  const annPath = await findAnnotationDbPath(home);
+  const annMtime = annPath ? (await stat(annPath)).mtime.toISOString() : null;
+
+  console.log('Majordomo notes sync');
+  console.log(`  Last run:           ${fmt(s.lastSuccessfulSync)}`);
+  console.log(`  Apple Books mtime:  ${annMtime ? fmt(annMtime) : '(books not installed)'}`);
+  console.log(`  State file:         ${statePath(home)}`);
+  console.log(`  Log file:           ${logPath}  (${await fileSize(logPath)})`);
+  console.log(`  LaunchAgent:        ${launchctlLoaded() ? 'loaded' : 'NOT loaded'}`);
+  console.log('');
+  console.log('  Lifetime counters');
+  console.log(`    runs:     ${s.runs.total}   (created: ${s.runs.created}, updated: ${s.runs.updated}, noop: ${s.runs.noop})`);
+
+  const open = ghCount('open');
+  const closed = ghCount('closed');
+  if (open !== null && closed !== null) {
+    console.log(`    open issues with ${LABEL_NAME} label:    ${open}`);
+    console.log(`    closed issues with ${LABEL_NAME} label:  ${closed}`);
+  } else {
+    console.log(`    (could not query GitHub — is gh auth valid?)`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/build/scripts/sync-apple-books-notes.ts
+++ b/build/scripts/sync-apple-books-notes.ts
@@ -21,6 +21,7 @@ import {
   editIssue,
   listAutoFiledIssues,
 } from '../notes/github-target.js';
+import { parseUuid } from '../notes/uuid-parse.js';
 import {
   findAnnotationDbPath,
   findAssetId,
@@ -167,7 +168,8 @@ async function main(): Promise<number> {
     log('error', 'gh-list-failed', { message: msg });
     return 1;
   }
-  log('info', 'gh-list', { existing: existing.length, 'with-uuid': existing.length });
+  const withUuid = existing.filter((i) => parseUuid(i.body) !== null).length;
+  log('info', 'gh-list', { existing: existing.length, 'with-uuid': withUuid });
 
   const actions: Action[] = reconcile(annotations, existing);
   const counts = { create: 0, update: 0, noop: 0 };

--- a/build/scripts/sync-apple-books-notes.ts
+++ b/build/scripts/sync-apple-books-notes.ts
@@ -7,6 +7,7 @@
  */
 
 import { stat } from 'node:fs/promises';
+import type Database from 'better-sqlite3';
 import { homedir } from 'node:os';
 import { reconcile } from '../notes/reconcile.js';
 import {
@@ -29,6 +30,19 @@ import {
 import type { Action } from '../notes/types.js';
 import { BOOK_TITLE } from '../notes/types.js';
 
+async function maxMtime(paths: string[]): Promise<string> {
+  let max = 0;
+  for (const p of paths) {
+    try {
+      const s = await stat(p);
+      if (s.mtimeMs > max) max = s.mtimeMs;
+    } catch {
+      // file may not exist (e.g., no -shm yet); skip
+    }
+  }
+  return new Date(max).toISOString();
+}
+
 function log(severity: 'info' | 'warn' | 'error', event: string, fields: Record<string, unknown> = {}): void {
   const pairs = Object.entries(fields)
     .map(([k, v]) => `${k}=${String(v)}`)
@@ -48,8 +62,10 @@ async function main(): Promise<number> {
     return 0;
   }
 
-  const annStat = await stat(annPath);
-  const annMtimeIso = annStat.mtime.toISOString();
+  // WAL-aware mtime: Apple Books uses SQLite WAL journaling, so new
+  // iCloud-synced annotations may only touch -wal/-shm. Use the max
+  // mtime across all three files.
+  const annMtimeIso = await maxMtime([annPath, `${annPath}-wal`, `${annPath}-shm`]);
   if (annMtimeIso === state.lastSqliteMtime) {
     log('info', 'run-start', { 'mtime-changed': false, 'skip-reason': 'mtime-stable' });
     state.runs.total += 1;
@@ -66,7 +82,7 @@ async function main(): Promise<number> {
       log('warn', 'run-end', { ok: false, reason: 'library-db-missing' });
       return 0;
     }
-    const libDb = openReadonly(libPath);
+    const libDb = await openReadonly(libPath);
     try {
       assetId = findAssetId(libDb, BOOK_TITLE);
     } finally {
@@ -83,7 +99,17 @@ async function main(): Promise<number> {
     state.majordomoAssetId = assetId;
   }
 
-  const annDb = openReadonly(annPath);
+  let annDb: Database.Database;
+  try {
+    annDb = await openReadonly(annPath);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/SQLITE_BUSY|database is locked/i.test(msg)) {
+      log('warn', 'run-end', { ok: false, reason: 'sqlite-busy' });
+      return 0;
+    }
+    throw e;
+  }
   let annotations;
   try {
     annotations = listAnnotations(annDb, assetId);
@@ -131,14 +157,23 @@ async function main(): Promise<number> {
       }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
+      if (/rate limit/i.test(msg) || /dial tcp|getaddrinfo/i.test(msg)) {
+        // Transient: surface as warn, bail out of the loop (any later
+        // action is likely to hit the same condition). exitCode stays 0
+        // so the LaunchAgent doesn't escalate.
+        log('warn', 'action-transient', { type: a.type, uuid: a.uuid, message: msg });
+        break;
+      }
       log('error', 'action-failed', { type: a.type, uuid: a.uuid, message: msg });
       exitCode = 1;
     }
   }
 
   state.runs.total += 1;
-  state.lastSqliteMtime = annMtimeIso;
-  if (exitCode === 0) state.lastSuccessfulSync = new Date().toISOString();
+  if (exitCode === 0) {
+    state.lastSqliteMtime = annMtimeIso;
+    state.lastSuccessfulSync = new Date().toISOString();
+  }
   await writeState(sPath, state);
 
   log('info', 'run-end', {

--- a/build/scripts/sync-apple-books-notes.ts
+++ b/build/scripts/sync-apple-books-notes.ts
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Entry point for the Apple Books → GitHub Issues sync daemon.
+ * Invoked hourly by the LaunchAgent, and by `npm run sync:notes`.
+ *
+ * Exit 0 = success or soft-fail. Exit 1 = user needs to look at the log.
+ */
+
+import { stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { reconcile } from '../notes/reconcile.js';
+import {
+  readState,
+  statePath,
+  writeState,
+} from '../notes/state.js';
+import {
+  createIssue,
+  editIssue,
+  listAutoFiledIssues,
+} from '../notes/github-target.js';
+import {
+  findAnnotationDbPath,
+  findAssetId,
+  findLibraryDbPath,
+  listAnnotations,
+  openReadonly,
+} from '../notes/sqlite-source.js';
+import type { Action } from '../notes/types.js';
+import { BOOK_TITLE } from '../notes/types.js';
+
+function log(severity: 'info' | 'warn' | 'error', event: string, fields: Record<string, unknown> = {}): void {
+  const pairs = Object.entries(fields)
+    .map(([k, v]) => `${k}=${String(v)}`)
+    .join(' ');
+  console.log(`${new Date().toISOString()} [${severity}]  ${event}${pairs ? ' ' + pairs : ''}`);
+}
+
+async function main(): Promise<number> {
+  const t0 = Date.now();
+  const home = homedir();
+  const sPath = statePath(home);
+  const state = await readState(sPath);
+
+  const annPath = await findAnnotationDbPath(home);
+  if (!annPath) {
+    log('warn', 'run-end', { ok: false, reason: 'apple-books-not-installed' });
+    return 0;
+  }
+
+  const annStat = await stat(annPath);
+  const annMtimeIso = annStat.mtime.toISOString();
+  if (annMtimeIso === state.lastSqliteMtime) {
+    log('info', 'run-start', { 'mtime-changed': false, 'skip-reason': 'mtime-stable' });
+    state.runs.total += 1;
+    await writeState(sPath, state);
+    log('info', 'run-end', { ok: true, 'elapsed-ms': Date.now() - t0 });
+    return 0;
+  }
+  log('info', 'run-start', { 'mtime-changed': true });
+
+  let assetId = state.majordomoAssetId;
+  if (!assetId) {
+    const libPath = await findLibraryDbPath(home);
+    if (!libPath) {
+      log('warn', 'run-end', { ok: false, reason: 'library-db-missing' });
+      return 0;
+    }
+    const libDb = openReadonly(libPath);
+    try {
+      assetId = findAssetId(libDb, BOOK_TITLE);
+    } finally {
+      libDb.close();
+    }
+    if (!assetId) {
+      log('warn', 'run-end', {
+        ok: false,
+        reason: 'book-not-found',
+        hint: 'open the built ePub in Books at least once',
+      });
+      return 0;
+    }
+    state.majordomoAssetId = assetId;
+  }
+
+  const annDb = openReadonly(annPath);
+  let annotations;
+  try {
+    annotations = listAnnotations(annDb, assetId);
+  } finally {
+    annDb.close();
+  }
+  log('info', 'sqlite-query', { annotations: annotations.length, 'with-notes': annotations.length });
+
+  let existing;
+  try {
+    existing = await listAutoFiledIssues();
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/authentication/i.test(msg)) {
+      log('error', 'gh-auth-failed', { hint: 'run `gh auth refresh`' });
+      return 1;
+    }
+    if (/rate limit/i.test(msg) || /dial tcp|getaddrinfo/i.test(msg)) {
+      log('warn', 'gh-transient', { message: msg });
+      return 0;
+    }
+    log('error', 'gh-list-failed', { message: msg });
+    return 1;
+  }
+  log('info', 'gh-list', { existing: existing.length, 'with-uuid': existing.length });
+
+  const actions: Action[] = reconcile(annotations, existing);
+  const counts = { create: 0, update: 0, noop: 0 };
+  for (const a of actions) counts[a.type]++;
+  log('info', 'reconcile', counts);
+
+  let exitCode = 0;
+  for (const a of actions) {
+    try {
+      if (a.type === 'create') {
+        const n = await createIssue(a.rendered);
+        state.runs.created += 1;
+        log('info', 'issue-created', { number: n, uuid: a.uuid });
+      } else if (a.type === 'update') {
+        await editIssue(a.issue, a.rendered.body);
+        state.runs.updated += 1;
+        log('info', 'issue-updated', { number: a.issue, uuid: a.uuid });
+      } else {
+        state.runs.noop += 1;
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      log('error', 'action-failed', { type: a.type, uuid: a.uuid, message: msg });
+      exitCode = 1;
+    }
+  }
+
+  state.runs.total += 1;
+  state.lastSqliteMtime = annMtimeIso;
+  if (exitCode === 0) state.lastSuccessfulSync = new Date().toISOString();
+  await writeState(sPath, state);
+
+  log('info', 'run-end', {
+    ok: exitCode === 0,
+    'elapsed-ms': Date.now() - t0,
+  });
+  return exitCode;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((e) => {
+    log('error', 'unhandled', { message: e instanceof Error ? e.message : String(e) });
+    process.exit(1);
+  });

--- a/build/scripts/sync-apple-books-notes.ts
+++ b/build/scripts/sync-apple-books-notes.ts
@@ -6,7 +6,8 @@
  * Exit 0 = success or soft-fail. Exit 1 = user needs to look at the log.
  */
 
-import { stat } from 'node:fs/promises';
+import { access, stat } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
 import type Database from 'better-sqlite3';
 import { homedir } from 'node:os';
 import { reconcile } from '../notes/reconcile.js';
@@ -52,9 +53,41 @@ function log(severity: 'info' | 'warn' | 'error', event: string, fields: Record<
 
 async function main(): Promise<number> {
   const t0 = Date.now();
+
+  // Daemon-wide hard timeout: if anything async stalls (network,
+  // unexpected sqlite lock, etc.), bail before the LaunchAgent considers
+  // us still running and skips the next hourly fire.
+  const hardTimeout = setTimeout(() => {
+    log('error', 'hard-timeout', { 'elapsed-ms': Date.now() - t0 });
+    process.exit(1);
+  }, 60_000);
+  hardTimeout.unref();
+
   const home = homedir();
   const sPath = statePath(home);
   const state = await readState(sPath);
+
+  // FDA preflight: in launchd context the daemon may be denied access
+  // to ~/Library/Containers/com.apple.iBooksX/ even though the installer
+  // (run from the user's interactive shell) could see it. Use fs.access
+  // wrapped in a 5s timeout so a denied-or-stalled check fails fast
+  // rather than hanging the whole hourly slot.
+  const annDir = `${home}/Library/Containers/com.apple.iBooksX/Data/Documents/AEAnnotation`;
+  try {
+    await Promise.race([
+      access(annDir, fsConstants.R_OK),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('fda-timeout')), 5000)
+      ),
+    ]);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log('error', 'fda-check-failed', {
+      message: msg,
+      hint: `grant Full Disk Access to ${process.execPath}`,
+    });
+    return 1;
+  }
 
   const annPath = await findAnnotationDbPath(home);
   if (!annPath) {

--- a/build/scripts/uninstall-notes-sync.ts
+++ b/build/scripts/uninstall-notes-sync.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * One-shot uninstaller. Unloads the LaunchAgent and removes the plist.
+ * Leaves state file and GitHub label alone — data, not config.
+ */
+
+import { rm } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const LABEL = 'io.dwk.majordomo.notes-sync';
+
+async function main(): Promise<void> {
+  const home = homedir();
+  const uid = process.getuid?.() ?? 0;
+  const dest = join(home, 'Library', 'LaunchAgents', `${LABEL}.plist`);
+
+  console.log('[uninstall-notes-sync] booting out...');
+  const r = spawnSync('launchctl', ['bootout', `gui/${uid}/${LABEL}`], { encoding: 'utf8' });
+  if (r.status !== 0 && !/not loaded|no such/i.test(r.stderr)) {
+    console.log(`[uninstall-notes-sync]   note: ${r.stderr.trim()}`);
+  } else {
+    console.log('[uninstall-notes-sync]   booted out');
+  }
+
+  console.log('[uninstall-notes-sync] removing plist...');
+  try {
+    await rm(dest);
+    console.log(`[uninstall-notes-sync]   removed ${dest}`);
+  } catch {
+    console.log(`[uninstall-notes-sync]   no plist at ${dest}`);
+  }
+
+  console.log('');
+  console.log('State file and GitHub label left in place:');
+  console.log(`  ${home}/Library/Application Support/majordomo/notes-sync-state.json`);
+  console.log(`  GitHub label: from:apple-books`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/build/scripts/uninstall-notes-sync.ts
+++ b/build/scripts/uninstall-notes-sync.ts
@@ -12,8 +12,12 @@ import { join } from 'node:path';
 const LABEL = 'io.dwk.majordomo.notes-sync';
 
 async function main(): Promise<void> {
+  if (typeof process.getuid !== 'function') {
+    console.error('This script requires a POSIX environment (macOS).');
+    process.exit(1);
+  }
   const home = homedir();
-  const uid = process.getuid?.() ?? 0;
+  const uid = process.getuid!();
   const dest = join(home, 'Library', 'LaunchAgents', `${LABEL}.plist`);
 
   console.log('[uninstall-notes-sync] booting out...');

--- a/docs/superpowers/plans/2026-05-23-apple-books-notes-sync.md
+++ b/docs/superpowers/plans/2026-05-23-apple-books-notes-sync.md
@@ -1,0 +1,2222 @@
+# Apple Books Notes → GitHub Issues Sync — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a macOS LaunchAgent + TypeScript script that hourly reads Apple Books typed annotations on *A Majordomo for Everyone* from local sqlite and files each one as a deduped GitHub Issue on this repo.
+
+**Architecture:** Pure functions for transformations (`render`, `reconcile`, `uuid-parse`), thin I/O wrappers (`sqlite-source` reads via `better-sqlite3`; `github-target` shells out to `gh` CLI), a single entry point that orchestrates them, and a one-shot installer that writes a LaunchAgent plist with `launchctl bootstrap`. Idempotency is achieved by embedding the stable Apple Books `ZANNOTATIONUUID` in each issue body as an HTML comment and searching the existing-issue index by UUID on every run.
+
+**Tech Stack:** TypeScript (ES2022 / Node16 ESM), `vitest` for tests, `better-sqlite3` for read-only sqlite, `gh` CLI via `child_process` for GitHub API, `tsx` for direct TS execution (no compile step needed for the daemon). All conventions match the existing `build/` pipeline.
+
+**Spec:** [docs/superpowers/specs/2026-05-23-apple-books-notes-sync-design.md](../specs/2026-05-23-apple-books-notes-sync-design.md)
+
+---
+
+## File map
+
+| File | Created in Task | Purpose |
+|---|---|---|
+| `build/notes/types.ts` | 1 | Shared interfaces: `Annotation`, `IssueRecord`, `RenderedIssue`, `Action`, `SyncState` |
+| `build/notes/uuid-parse.ts` | 2 | Extract `<!-- apple-books-uuid: X -->` from issue body |
+| `build/notes/uuid-parse.test.ts` | 2 | Tests for `uuid-parse` |
+| `build/notes/render.ts` | 3 | Pure: `Annotation → RenderedIssue` |
+| `build/notes/render.test.ts` | 3 | Tests for `render` (NSDate conversion, title derivation, truncation) |
+| `build/notes/reconcile.ts` | 4 | Pure: `(annotations, existing) → Action[]` |
+| `build/notes/reconcile.test.ts` | 4 | Tests for `reconcile` |
+| `build/notes/state.ts` | 5 | Read/write/migrate `~/Library/Application Support/majordomo/notes-sync-state.json` |
+| `build/notes/state.test.ts` | 5 | Tests for state file handling |
+| `build/notes/sqlite-source.ts` | 6 | Read-only sqlite access: `findAssetId`, `listAnnotations` |
+| `build/notes/sqlite-source.test.ts` | 6 | Integration tests with in-memory sqlite |
+| `build/notes/__fixtures__/aeannotation.sql` | 6 | Schema + seed data for sqlite tests |
+| `build/notes/github-target.ts` | 7 | Wraps `gh` CLI: list, create, edit, label-create |
+| `build/notes/github-target.test.ts` | 7 | Tests with mocked spawn |
+| `build/scripts/sync-apple-books-notes.ts` | 8 | Daemon entry point |
+| `build/scripts/sync-apple-books-notes-status.ts` | 9 | `npm run sync:notes:status` output |
+| `build/scripts/install-notes-sync.ts` | 10 | One-shot installer |
+| `build/scripts/uninstall-notes-sync.ts` | 10 | One-shot uninstaller |
+| `build/scripts/notes-sync/io.dwk.majordomo.notes-sync.plist.template` | 10 | LaunchAgent plist with token placeholders |
+| `package.json` | 0 (deps), 11 (scripts), 12 (version) | Three modifications across the plan |
+| `CLAUDE.md` | 11 | Document sync:notes commands |
+
+---
+
+## Task 0: Add dependencies and verify clean baseline
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Verify the current branch and clean state**
+
+```bash
+git status
+git rev-parse --abbrev-ref HEAD
+```
+
+Expected: branch `claude/issue-23-apple-books-notes-sync-spec`, working tree clean.
+
+- [ ] **Step 2: Install `better-sqlite3` as a production dep**
+
+```bash
+npm install better-sqlite3@^12.5.0
+```
+
+Expected: `package.json` `dependencies` gains `better-sqlite3`.
+
+- [ ] **Step 3: Install `tsx` as a devDep**
+
+```bash
+npm install --save-dev tsx@^4.20.0
+```
+
+Expected: `package.json` `devDependencies` gains `tsx`; `node_modules/.bin/tsx` exists.
+
+- [ ] **Step 4: Verify the existing test suite still passes**
+
+```bash
+npm test
+```
+
+Expected: 55/55 pass.
+
+- [ ] **Step 5: Verify type-check still clean**
+
+```bash
+npm run build:check
+```
+
+Expected: zero `tsc` output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "Add better-sqlite3 and tsx deps for notes sync (#23)
+
+better-sqlite3 reads Apple Books sqlite directly; tsx runs the
+daemon entry-point TS file without a compile step. Both are needed
+by the upcoming Apple-Books-notes → GitHub-Issues sync feature.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 1: Shared types
+
+**Files:**
+- Create: `build/notes/types.ts`
+
+- [ ] **Step 1: Create the types module**
+
+Create `build/notes/types.ts`:
+
+```ts
+/**
+ * Shared types for the Apple Books → GitHub Issues sync feature.
+ */
+
+export interface Annotation {
+  /** ZANNOTATIONUUID — stable across edits, primary dedup key. */
+  uuid: string;
+  /** ZSELECTEDTEXT — the passage highlighted in Apple Books. */
+  selectedText: string;
+  /** ZANNOTATIONNOTE — the user's typed note. Non-empty by filter. */
+  note: string;
+  /** ZFUTUREPROOFING5 — chapter title captured at annotation time. */
+  chapterTitle: string | null;
+  /** ZLOCATIONRANGESTART — 0.0 to 1.0 position in the book. */
+  locationPercent: number;
+  /** ZANNOTATIONMODIFICATIONDATE — already converted from NSDate. */
+  modifiedAt: Date;
+}
+
+export interface IssueRecord {
+  number: number;
+  body: string;
+  state: 'OPEN' | 'CLOSED';
+}
+
+export interface RenderedIssue {
+  title: string;
+  body: string;
+}
+
+export type Action =
+  | { type: 'create'; uuid: string; rendered: RenderedIssue }
+  | { type: 'update'; uuid: string; issue: number; rendered: RenderedIssue }
+  | { type: 'noop'; uuid: string; issue: number };
+
+export interface SyncState {
+  schemaVersion: 1;
+  lastSqliteMtime: string;
+  lastSuccessfulSync: string;
+  majordomoAssetId: string | null;
+  runs: {
+    total: number;
+    created: number;
+    updated: number;
+    noop: number;
+  };
+}
+
+/** Constants shared across modules. */
+export const LABEL_NAME = 'from:apple-books';
+export const BOOK_TITLE = 'A Majordomo for Everyone';
+export const GITHUB_BODY_MAX = 65536;
+/** Seconds between Unix epoch and Core Data NSDate epoch (2001-01-01 UTC). */
+export const NSDATE_EPOCH_OFFSET = 978307200;
+```
+
+- [ ] **Step 2: Verify type-check**
+
+```bash
+npm run build:check
+```
+
+Expected: silent.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add build/notes/types.ts
+git commit -m "Add shared types for notes sync (#23)
+
+types.ts defines Annotation, IssueRecord, RenderedIssue, Action,
+SyncState, plus shared constants (label name, book title, NSDate
+offset).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: UUID parsing (pure)
+
+**Files:**
+- Create: `build/notes/uuid-parse.ts`
+- Create: `build/notes/uuid-parse.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `build/notes/uuid-parse.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { parseUuid } from './uuid-parse.js';
+
+describe('parseUuid', () => {
+  it('extracts the UUID from a well-formed comment', () => {
+    const body = '> quoted passage\n\nmy note\n\n<!-- apple-books-uuid: 4F3A-AB12-B891 -->\n';
+    expect(parseUuid(body)).toBe('4F3A-AB12-B891');
+  });
+
+  it('returns null when no comment is present', () => {
+    expect(parseUuid('plain body, no marker')).toBeNull();
+  });
+
+  it('returns null on malformed comment (missing prefix)', () => {
+    expect(parseUuid('<!-- some-other-uuid: ABC123 -->')).toBeNull();
+  });
+
+  it('tolerates surrounding whitespace inside the comment', () => {
+    expect(parseUuid('<!--  apple-books-uuid:   ABC-123  -->')).toBe('ABC-123');
+  });
+
+  it('returns the first UUID if the body contains two (defensive)', () => {
+    const body = '<!-- apple-books-uuid: FIRST -->\n<!-- apple-books-uuid: SECOND -->';
+    expect(parseUuid(body)).toBe('FIRST');
+  });
+
+  it('handles real-world Apple Books UUID format (long hex with dashes)', () => {
+    const body = '<!-- apple-books-uuid: 4F3A2B1C-9D8E-7F6A-5B4C-3D2E1F0A9B8C -->';
+    expect(parseUuid(body)).toBe('4F3A2B1C-9D8E-7F6A-5B4C-3D2E1F0A9B8C');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run build/notes/uuid-parse.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the minimal module**
+
+Create `build/notes/uuid-parse.ts`:
+
+```ts
+/**
+ * Extract the Apple Books UUID from a GitHub Issue body.
+ */
+
+const UUID_RE = /<!--\s*apple-books-uuid:\s*([^\s][^\s-]*(?:-[^\s-]+)*)\s*-->/;
+
+export function parseUuid(body: string): string | null {
+  const m = body.match(UUID_RE);
+  return m ? m[1] : null;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run build/notes/uuid-parse.test.ts
+```
+
+Expected: PASS — 6/6 tests pass.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+npm test
+```
+
+Expected: 61/61 pass (55 existing + 6 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add build/notes/uuid-parse.ts build/notes/uuid-parse.test.ts
+git commit -m "Add UUID parser for Apple Books issue dedup (#23)
+
+parseUuid extracts the <!-- apple-books-uuid: X --> marker from a
+GitHub Issue body. Used by reconcile to build the dedup index from
+existing auto-filed issues.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Render annotation → issue body (pure)
+
+**Files:**
+- Create: `build/notes/render.ts`
+- Create: `build/notes/render.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `build/notes/render.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { render, nsdateToDate, deriveTitle } from './render.js';
+import type { Annotation } from './types.js';
+import { GITHUB_BODY_MAX } from './types.js';
+
+const sample: Annotation = {
+  uuid: '4F3A-AB12-B891',
+  selectedText: 'A library is a building; a life is a way of living.',
+  note: 'fix this metaphor about libraries',
+  chapterTitle: 'Chapter 1: Introduction',
+  locationPercent: 0.12,
+  modifiedAt: new Date('2026-05-23T14:11:00Z'),
+};
+
+describe('nsdateToDate', () => {
+  it('converts Core Data NSDate seconds to a JS Date', () => {
+    expect(nsdateToDate(0).toISOString()).toBe('2001-01-01T00:00:00.000Z');
+  });
+
+  it('converts a real-world NSDate to the expected year', () => {
+    const d = nsdateToDate(800_000_000);
+    expect(d.getUTCFullYear()).toBe(2026);
+  });
+
+  it('round-trips a known modification date', () => {
+    expect(nsdateToDate(769702260).toISOString()).toBe('2026-05-23T14:11:00.000Z');
+  });
+});
+
+describe('deriveTitle', () => {
+  it('takes the first non-empty line', () => {
+    expect(deriveTitle('first line\nsecond line')).toBe('first line');
+  });
+
+  it('skips leading blank lines', () => {
+    expect(deriveTitle('\n\nactual content')).toBe('actual content');
+  });
+
+  it('truncates to 80 chars with an ellipsis', () => {
+    const long = 'a'.repeat(120);
+    const result = deriveTitle(long);
+    expect(result.length).toBe(80);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('strips leading markdown punctuation', () => {
+    expect(deriveTitle('## Heading')).toBe('Heading');
+    expect(deriveTitle('- list item')).toBe('list item');
+    expect(deriveTitle('> quoted')).toBe('quoted');
+  });
+
+  it('collapses runs of whitespace', () => {
+    expect(deriveTitle('hello   world\t\tagain')).toBe('hello world again');
+  });
+
+  it('returns a sensible default for empty input', () => {
+    expect(deriveTitle('')).toBe('(empty note)');
+    expect(deriveTitle('\n\n  \n')).toBe('(empty note)');
+  });
+});
+
+describe('render', () => {
+  it('produces the expected title and body for a typical annotation', () => {
+    const out = render(sample);
+    expect(out.title).toBe('fix this metaphor about libraries');
+    expect(out.body).toContain('> A library is a building; a life is a way of living.');
+    expect(out.body).toContain('— Chapter 1: Introduction (12%)');
+    expect(out.body).toContain('fix this metaphor about libraries');
+    expect(out.body).toContain('<!-- apple-books-uuid: 4F3A-AB12-B891 -->');
+    expect(out.body).toContain('<!-- apple-books-modified: 2026-05-23T14:11:00.000Z -->');
+  });
+
+  it('handles a null chapter title gracefully', () => {
+    const out = render({ ...sample, chapterTitle: null });
+    expect(out.body).toContain('— Uncategorized (12%)');
+  });
+
+  it('quotes each line of a multi-line passage', () => {
+    const out = render({ ...sample, selectedText: 'line one\nline two\nline three' });
+    expect(out.body).toContain('> line one');
+    expect(out.body).toContain('> line two');
+    expect(out.body).toContain('> line three');
+  });
+
+  it('truncates an over-long body, preserving the UUID footer', () => {
+    const out = render({ ...sample, note: 'x'.repeat(GITHUB_BODY_MAX + 1000) });
+    expect(out.body.length).toBeLessThanOrEqual(GITHUB_BODY_MAX);
+    expect(out.body).toContain('_[truncated]_');
+    expect(out.body).toContain('<!-- apple-books-uuid: 4F3A-AB12-B891 -->');
+  });
+
+  it('renders location as an integer percentage', () => {
+    const out = render({ ...sample, locationPercent: 0.0735 });
+    expect(out.body).toContain('(7%)');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run build/notes/render.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the render module**
+
+Create `build/notes/render.ts`:
+
+```ts
+/**
+ * Pure transformation: Apple Books annotation → GitHub issue body.
+ */
+
+import type { Annotation, RenderedIssue } from './types.js';
+import { GITHUB_BODY_MAX, NSDATE_EPOCH_OFFSET } from './types.js';
+
+const TRUNCATED_SUFFIX = '\n\n_[truncated]_\n';
+
+export function nsdateToDate(nsdateSeconds: number): Date {
+  return new Date((nsdateSeconds + NSDATE_EPOCH_OFFSET) * 1000);
+}
+
+export function deriveTitle(note: string): string {
+  const firstNonEmpty = note
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+
+  if (!firstNonEmpty) return '(empty note)';
+
+  const stripped = firstNonEmpty.replace(/^(#+|[-*+]|>)\s+/, '').trim();
+  const collapsed = stripped.replace(/\s+/g, ' ');
+
+  if (collapsed.length <= 80) return collapsed;
+  return collapsed.slice(0, 79) + '…';
+}
+
+function quoteLines(text: string): string {
+  return text
+    .split('\n')
+    .map((l) => `> ${l}`)
+    .join('\n');
+}
+
+function locationLabel(percent: number): string {
+  return `${Math.round(percent * 100)}%`;
+}
+
+export function render(ann: Annotation): RenderedIssue {
+  const title = deriveTitle(ann.note);
+  const chapter = ann.chapterTitle ?? 'Uncategorized';
+
+  const body =
+    quoteLines(ann.selectedText) +
+    `\n>\n> — ${chapter} (${locationLabel(ann.locationPercent)})\n\n` +
+    ann.note +
+    `\n\n<!-- apple-books-uuid: ${ann.uuid} -->\n` +
+    `<!-- apple-books-modified: ${ann.modifiedAt.toISOString()} -->\n`;
+
+  if (body.length <= GITHUB_BODY_MAX) {
+    return { title, body };
+  }
+
+  const footer =
+    `\n\n<!-- apple-books-uuid: ${ann.uuid} -->\n` +
+    `<!-- apple-books-modified: ${ann.modifiedAt.toISOString()} -->\n`;
+  const budget = GITHUB_BODY_MAX - TRUNCATED_SUFFIX.length - footer.length;
+  const truncated = body.slice(0, budget) + TRUNCATED_SUFFIX + footer;
+  return { title, body: truncated };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run build/notes/render.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+npm test
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add build/notes/render.ts build/notes/render.test.ts
+git commit -m "Add render for Apple Books annotation → issue body (#23)
+
+Pure transformation matching the body schema in the design spec.
+Covers NSDate→Date conversion (Core Data 2001 epoch), title
+derivation, and body-length truncation that preserves the UUID
+footer for dedup.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Reconcile actions (pure)
+
+**Files:**
+- Create: `build/notes/reconcile.ts`
+- Create: `build/notes/reconcile.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `build/notes/reconcile.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { reconcile } from './reconcile.js';
+import { render } from './render.js';
+import type { Annotation, IssueRecord } from './types.js';
+
+const ann = (overrides: Partial<Annotation> = {}): Annotation => ({
+  uuid: 'UUID-A',
+  selectedText: 'passage',
+  note: 'note A',
+  chapterTitle: 'Ch 1',
+  locationPercent: 0.1,
+  modifiedAt: new Date('2026-05-23T14:11:00Z'),
+  ...overrides,
+});
+
+const issueWith = (n: number, body: string, state: 'OPEN' | 'CLOSED' = 'OPEN'): IssueRecord => ({
+  number: n,
+  body,
+  state,
+});
+
+describe('reconcile', () => {
+  it('returns create actions for annotations with no matching issue', () => {
+    const annotations = [ann({ uuid: 'UUID-A' }), ann({ uuid: 'UUID-B', note: 'note B' })];
+    const actions = reconcile(annotations, []);
+    expect(actions).toHaveLength(2);
+    expect(actions.every((a) => a.type === 'create')).toBe(true);
+  });
+
+  it('returns noop for an annotation whose rendered body matches the existing issue', () => {
+    const a = ann({ uuid: 'UUID-A' });
+    const existing = [issueWith(42, render(a).body)];
+    const actions = reconcile([a], existing);
+    expect(actions).toEqual([{ type: 'noop', uuid: 'UUID-A', issue: 42 }]);
+  });
+
+  it('returns update for an annotation whose rendered body differs from the existing issue', () => {
+    const original = ann({ uuid: 'UUID-A', note: 'old note' });
+    const existing = [issueWith(42, render(original).body)];
+    const edited = ann({ uuid: 'UUID-A', note: 'new note' });
+    const actions = reconcile([edited], existing);
+    expect(actions).toHaveLength(1);
+    expect(actions[0].type).toBe('update');
+    if (actions[0].type === 'update') {
+      expect(actions[0].issue).toBe(42);
+      expect(actions[0].uuid).toBe('UUID-A');
+    }
+  });
+
+  it('matches issues against UUIDs found in CLOSED issues, not just OPEN ones', () => {
+    const a = ann({ uuid: 'UUID-A' });
+    const existing = [issueWith(42, render(a).body, 'CLOSED')];
+    const actions = reconcile([a], existing);
+    expect(actions[0].type).toBe('noop');
+  });
+
+  it('ignores existing issues whose body has no UUID marker', () => {
+    const a = ann({ uuid: 'UUID-A' });
+    const existing = [issueWith(42, 'a manually filed issue with no marker')];
+    const actions = reconcile([a], existing);
+    expect(actions[0].type).toBe('create');
+  });
+
+  it('returns a mix of create / update / noop in one call', () => {
+    const a1 = ann({ uuid: 'A1', note: 'a1' });
+    const a2 = ann({ uuid: 'A2', note: 'a2 new' });
+    const a3 = ann({ uuid: 'A3', note: 'a3' });
+    const a2Original = ann({ uuid: 'A2', note: 'a2 old' });
+
+    const existing = [
+      issueWith(10, render(a1).body),
+      issueWith(11, render(a2Original).body),
+      issueWith(12, 'unrelated issue'),
+    ];
+    const actions = reconcile([a1, a2, a3], existing);
+
+    const byUuid = new Map(actions.map((x) => [x.uuid, x]));
+    expect(byUuid.get('A1')?.type).toBe('noop');
+    expect(byUuid.get('A2')?.type).toBe('update');
+    expect(byUuid.get('A3')?.type).toBe('create');
+    expect(actions).toHaveLength(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run build/notes/reconcile.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement reconcile**
+
+Create `build/notes/reconcile.ts`:
+
+```ts
+/**
+ * Pure reconciliation: given current annotations and existing
+ * auto-filed issues, compute the action list.
+ */
+
+import type { Action, Annotation, IssueRecord } from './types.js';
+import { render } from './render.js';
+import { parseUuid } from './uuid-parse.js';
+
+export function reconcile(
+  annotations: readonly Annotation[],
+  existing: readonly IssueRecord[]
+): Action[] {
+  const byUuid = new Map<string, IssueRecord>();
+  for (const issue of existing) {
+    const uuid = parseUuid(issue.body);
+    if (uuid !== null) byUuid.set(uuid, issue);
+  }
+
+  const actions: Action[] = [];
+  for (const ann of annotations) {
+    const rendered = render(ann);
+    const found = byUuid.get(ann.uuid);
+    if (!found) {
+      actions.push({ type: 'create', uuid: ann.uuid, rendered });
+    } else if (found.body === rendered.body) {
+      actions.push({ type: 'noop', uuid: ann.uuid, issue: found.number });
+    } else {
+      actions.push({ type: 'update', uuid: ann.uuid, issue: found.number, rendered });
+    }
+  }
+  return actions;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run build/notes/reconcile.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+npm test
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add build/notes/reconcile.ts build/notes/reconcile.test.ts
+git commit -m "Add reconcile for sqlite ↔ GitHub action computation (#23)
+
+reconcile is the heart of the sync algorithm: given annotations
+from Apple Books and existing auto-filed issues, returns the
+create/update/noop action list. UUID-based matching makes the sync
+crash-safe and idempotent.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: State file read/write/migrate
+
+**Files:**
+- Create: `build/notes/state.ts`
+- Create: `build/notes/state.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `build/notes/state.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readState, writeState, emptyState, statePath } from './state.js';
+import type { SyncState } from './types.js';
+
+let tmpDir: string;
+let path: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'majordomo-state-'));
+  path = join(tmpDir, 'state.json');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('emptyState', () => {
+  it('produces a valid initial SyncState', () => {
+    const s = emptyState();
+    expect(s.schemaVersion).toBe(1);
+    expect(s.majordomoAssetId).toBeNull();
+    expect(s.runs).toEqual({ total: 0, created: 0, updated: 0, noop: 0 });
+    expect(s.lastSqliteMtime).toBe('1970-01-01T00:00:00.000Z');
+  });
+});
+
+describe('readState', () => {
+  it('returns emptyState when the file does not exist', async () => {
+    const s = await readState(path);
+    expect(s).toEqual(emptyState());
+  });
+
+  it('returns emptyState when the file is unparseable JSON', async () => {
+    writeFileSync(path, '{ this is not json');
+    const s = await readState(path);
+    expect(s).toEqual(emptyState());
+  });
+
+  it('returns emptyState when schemaVersion is missing or unknown', async () => {
+    writeFileSync(path, JSON.stringify({ schemaVersion: 99, foo: 'bar' }));
+    const s = await readState(path);
+    expect(s).toEqual(emptyState());
+  });
+
+  it('reads and parses a valid v1 state file', async () => {
+    const written: SyncState = {
+      schemaVersion: 1,
+      lastSqliteMtime: '2026-05-23T18:00:00.000Z',
+      lastSuccessfulSync: '2026-05-23T18:00:01.000Z',
+      majordomoAssetId: 'ASSET-XYZ',
+      runs: { total: 5, created: 2, updated: 1, noop: 2 },
+    };
+    writeFileSync(path, JSON.stringify(written));
+    expect(await readState(path)).toEqual(written);
+  });
+});
+
+describe('writeState', () => {
+  it('persists a state object as readable JSON', async () => {
+    const s = emptyState();
+    s.lastSqliteMtime = '2026-05-23T18:00:00.000Z';
+    s.runs.total = 1;
+    await writeState(path, s);
+    const back = await readState(path);
+    expect(back).toEqual(s);
+  });
+
+  it('creates parent directories if missing', async () => {
+    const nested = join(tmpDir, 'a', 'b', 'c', 'state.json');
+    await writeState(nested, emptyState());
+    expect(await readState(nested)).toEqual(emptyState());
+  });
+});
+
+describe('statePath', () => {
+  it('returns the macOS Application Support path under the given home', () => {
+    const p = statePath('/Users/dwk');
+    expect(p).toBe('/Users/dwk/Library/Application Support/majordomo/notes-sync-state.json');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run build/notes/state.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the state module**
+
+Create `build/notes/state.ts`:
+
+```ts
+/**
+ * Read / write / migrate the sync state file.
+ * Location: ~/Library/Application Support/majordomo/notes-sync-state.json
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import type { SyncState } from './types.js';
+
+export function statePath(home: string): string {
+  return join(home, 'Library', 'Application Support', 'majordomo', 'notes-sync-state.json');
+}
+
+export function emptyState(): SyncState {
+  return {
+    schemaVersion: 1,
+    lastSqliteMtime: '1970-01-01T00:00:00.000Z',
+    lastSuccessfulSync: '1970-01-01T00:00:00.000Z',
+    majordomoAssetId: null,
+    runs: { total: 0, created: 0, updated: 0, noop: 0 },
+  };
+}
+
+export async function readState(path: string): Promise<SyncState> {
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch {
+    return emptyState();
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed?.schemaVersion === 1) return parsed as SyncState;
+    return emptyState();
+  } catch {
+    return emptyState();
+  }
+}
+
+export async function writeState(path: string, state: SyncState): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(state, null, 2) + '\n', 'utf8');
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run build/notes/state.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+npm test
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add build/notes/state.ts build/notes/state.test.ts
+git commit -m "Add state file read/write/migrate for notes sync (#23)
+
+Manages ~/Library/Application Support/majordomo/notes-sync-state.json.
+Schema-version-aware: future versions fall back to emptyState rather
+than corrupt the run.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Sqlite source
+
+**Files:**
+- Create: `build/notes/__fixtures__/aeannotation.sql`
+- Create: `build/notes/sqlite-source.ts`
+- Create: `build/notes/sqlite-source.test.ts`
+
+- [ ] **Step 1: Create the fixture SQL**
+
+Create `build/notes/__fixtures__/aeannotation.sql`:
+
+```sql
+-- Schema snapshot of the columns used from Apple Books's sqlite
+-- databases. Updates here flag schema drift on real Apple updates.
+
+CREATE TABLE ZBKLIBRARYASSET (
+  Z_PK INTEGER PRIMARY KEY,
+  ZASSETID TEXT,
+  ZTITLE TEXT
+);
+
+CREATE TABLE ZAEANNOTATION (
+  Z_PK INTEGER PRIMARY KEY,
+  ZANNOTATIONUUID TEXT,
+  ZANNOTATIONASSETID TEXT,
+  ZANNOTATIONSELECTEDTEXT TEXT,
+  ZANNOTATIONNOTE TEXT,
+  ZFUTUREPROOFING5 TEXT,
+  ZANNOTATIONLOCATION TEXT,
+  ZANNOTATIONMODIFICATIONDATE REAL,
+  ZANNOTATIONDELETED INTEGER
+);
+
+INSERT INTO ZBKLIBRARYASSET VALUES (1, 'ASSET-MAJORDOMO', 'A Majordomo for Everyone');
+INSERT INTO ZBKLIBRARYASSET VALUES (2, 'ASSET-OTHER',     'Some Other Book');
+
+INSERT INTO ZAEANNOTATION VALUES (
+  101, 'UUID-A', 'ASSET-MAJORDOMO',
+  'A library is a building; a life is a way of living.',
+  'fix this metaphor about libraries',
+  'Chapter 1: Introduction',
+  '0.12',
+  769702260.0,
+  0
+);
+INSERT INTO ZAEANNOTATION VALUES (
+  102, 'UUID-B', 'ASSET-MAJORDOMO',
+  'A bare highlight with no typed note.',
+  NULL,
+  'Chapter 1: Introduction',
+  '0.13',
+  769702300.0,
+  0
+);
+INSERT INTO ZAEANNOTATION VALUES (
+  103, 'UUID-C', 'ASSET-MAJORDOMO',
+  'Another passage I marked.',
+  'rewrite the second paragraph',
+  'Chapter 2: Engage',
+  '0.45',
+  769702400.0,
+  0
+);
+INSERT INTO ZAEANNOTATION VALUES (
+  104, 'UUID-D', 'ASSET-MAJORDOMO',
+  'A passage on a deleted annotation.',
+  'will be filtered out',
+  'Chapter 2: Engage',
+  '0.46',
+  769702500.0,
+  1
+);
+INSERT INTO ZAEANNOTATION VALUES (
+  201, 'UUID-OTHER', 'ASSET-OTHER',
+  'From a different book entirely.',
+  'should not appear',
+  'Some Chapter',
+  '0.5',
+  769702600.0,
+  0
+);
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `build/notes/sqlite-source.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import { findAssetId, listAnnotations } from './sqlite-source.js';
+import { BOOK_TITLE } from './types.js';
+
+const fixtureSql = readFileSync(
+  join(import.meta.dirname, '__fixtures__', 'aeannotation.sql'),
+  'utf8'
+);
+
+let libraryDb: Database.Database;
+let annotationDb: Database.Database;
+
+beforeEach(() => {
+  libraryDb = new Database(':memory:');
+  annotationDb = new Database(':memory:');
+  libraryDb.exec(fixtureSql);
+  annotationDb.exec(fixtureSql);
+  libraryDb.exec('DROP TABLE ZAEANNOTATION');
+  annotationDb.exec('DROP TABLE ZBKLIBRARYASSET');
+});
+
+describe('findAssetId', () => {
+  it('returns the ASSETID for a book title that exists', () => {
+    expect(findAssetId(libraryDb, BOOK_TITLE)).toBe('ASSET-MAJORDOMO');
+  });
+
+  it('returns null for a title that does not exist', () => {
+    expect(findAssetId(libraryDb, 'No Such Book')).toBeNull();
+  });
+});
+
+describe('listAnnotations', () => {
+  it('returns only annotations with a non-null note', () => {
+    const rows = listAnnotations(annotationDb, 'ASSET-MAJORDOMO');
+    const uuids = rows.map((r) => r.uuid).sort();
+    expect(uuids).toEqual(['UUID-A', 'UUID-C']);
+  });
+
+  it('filters out soft-deleted annotations', () => {
+    const rows = listAnnotations(annotationDb, 'ASSET-MAJORDOMO');
+    expect(rows.find((r) => r.uuid === 'UUID-D')).toBeUndefined();
+  });
+
+  it('filters by asset_id (no annotations from other books)', () => {
+    const rows = listAnnotations(annotationDb, 'ASSET-OTHER');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].uuid).toBe('UUID-OTHER');
+  });
+
+  it('decodes the NSDate column into a JS Date', () => {
+    const rows = listAnnotations(annotationDb, 'ASSET-MAJORDOMO');
+    const a = rows.find((r) => r.uuid === 'UUID-A');
+    expect(a).toBeDefined();
+    expect(a!.modifiedAt.toISOString()).toBe('2026-05-23T14:11:00.000Z');
+  });
+
+  it('decodes location string to a number', () => {
+    const rows = listAnnotations(annotationDb, 'ASSET-MAJORDOMO');
+    const a = rows.find((r) => r.uuid === 'UUID-A');
+    expect(a!.locationPercent).toBeCloseTo(0.12);
+  });
+
+  it('returns an empty array for an unknown asset_id', () => {
+    expect(listAnnotations(annotationDb, 'ASSET-MISSING')).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+npx vitest run build/notes/sqlite-source.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement sqlite-source**
+
+Create `build/notes/sqlite-source.ts`:
+
+```ts
+/**
+ * Read-only access to Apple Books's sqlite databases.
+ *
+ * Real paths (caller resolves via glob):
+ *   ~/Library/Containers/com.apple.iBooksX/Data/Documents/BKLibrary/BKLibrary-*.sqlite
+ *   ~/Library/Containers/com.apple.iBooksX/Data/Documents/AEAnnotation/AEAnnotation_*.sqlite
+ */
+
+import { glob } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import type { Annotation } from './types.js';
+import { nsdateToDate } from './render.js';
+
+const BOOKS_CONTAINER = 'Library/Containers/com.apple.iBooksX/Data/Documents';
+
+export async function findAnnotationDbPath(home: string = homedir()): Promise<string | null> {
+  const pattern = join(home, BOOKS_CONTAINER, 'AEAnnotation', 'AEAnnotation_*.sqlite');
+  for await (const match of glob(pattern)) return match;
+  return null;
+}
+
+export async function findLibraryDbPath(home: string = homedir()): Promise<string | null> {
+  const pattern = join(home, BOOKS_CONTAINER, 'BKLibrary', 'BKLibrary-*.sqlite');
+  for await (const match of glob(pattern)) return match;
+  return null;
+}
+
+export function openReadonly(path: string): Database.Database {
+  return new Database(path, { readonly: true, fileMustExist: true });
+}
+
+export function findAssetId(libraryDb: Database.Database, title: string): string | null {
+  const row = libraryDb
+    .prepare<[string], { ZASSETID: string }>('SELECT ZASSETID FROM ZBKLIBRARYASSET WHERE ZTITLE = ?')
+    .get(title);
+  return row?.ZASSETID ?? null;
+}
+
+interface AnnotationRow {
+  ZANNOTATIONUUID: string;
+  ZANNOTATIONSELECTEDTEXT: string;
+  ZANNOTATIONNOTE: string;
+  ZFUTUREPROOFING5: string | null;
+  ZANNOTATIONLOCATION: string | null;
+  ZANNOTATIONMODIFICATIONDATE: number;
+}
+
+export function listAnnotations(annotationDb: Database.Database, assetId: string): Annotation[] {
+  const rows = annotationDb
+    .prepare<[string], AnnotationRow>(
+      `SELECT
+         ZANNOTATIONUUID,
+         ZANNOTATIONSELECTEDTEXT,
+         ZANNOTATIONNOTE,
+         ZFUTUREPROOFING5,
+         ZANNOTATIONLOCATION,
+         ZANNOTATIONMODIFICATIONDATE
+       FROM ZAEANNOTATION
+       WHERE ZANNOTATIONASSETID = ?
+         AND ZANNOTATIONNOTE IS NOT NULL
+         AND (ZANNOTATIONDELETED IS NULL OR ZANNOTATIONDELETED = 0)
+       ORDER BY ZANNOTATIONLOCATION`
+    )
+    .all(assetId);
+
+  return rows.map((r) => ({
+    uuid: r.ZANNOTATIONUUID,
+    selectedText: r.ZANNOTATIONSELECTEDTEXT,
+    note: r.ZANNOTATIONNOTE,
+    chapterTitle: r.ZFUTUREPROOFING5,
+    locationPercent: r.ZANNOTATIONLOCATION ? parseFloat(r.ZANNOTATIONLOCATION) : 0,
+    modifiedAt: nsdateToDate(r.ZANNOTATIONMODIFICATIONDATE),
+  }));
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+npx vitest run build/notes/sqlite-source.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full suite**
+
+```bash
+npm test
+```
+
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add build/notes/sqlite-source.ts build/notes/sqlite-source.test.ts build/notes/__fixtures__/aeannotation.sql
+git commit -m "Add sqlite-source for Apple Books DB access (#23)
+
+Read-only access to BKLibrary and AEAnnotation databases. The
+fixture SQL is a checked-in schema snapshot — if Apple bumps the
+schema in a future macOS update, the failing tests surface the
+drift.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: GitHub target
+
+**Files:**
+- Create: `build/notes/github-target.ts`
+- Create: `build/notes/github-target.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `build/notes/github-target.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IssueRecord } from './types.js';
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ spawnSync: spawnSyncMock }));
+
+const {
+  listAutoFiledIssues,
+  createIssue,
+  editIssue,
+  createLabelIfMissing,
+} = await import('./github-target.js');
+
+const okResult = (stdout: string) => ({ status: 0, stdout, stderr: '', signal: null });
+const errResult = (stderr: string) => ({ status: 1, stdout: '', stderr, signal: null });
+
+beforeEach(() => {
+  spawnSyncMock.mockReset();
+});
+
+describe('listAutoFiledIssues', () => {
+  it('invokes gh with the right flags and parses the JSON', async () => {
+    const sample = [
+      { number: 1, body: 'body 1', state: 'OPEN' },
+      { number: 2, body: 'body 2', state: 'CLOSED' },
+    ];
+    spawnSyncMock.mockReturnValueOnce(okResult(JSON.stringify(sample)));
+    const out = await listAutoFiledIssues();
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    const callArgs = spawnSyncMock.mock.calls[0];
+    expect(callArgs[0]).toBe('gh');
+    expect(callArgs[1]).toEqual([
+      'issue',
+      'list',
+      '--label',
+      'from:apple-books',
+      '--state',
+      'all',
+      '--limit',
+      '1000',
+      '--json',
+      'number,body,state',
+    ]);
+
+    expect(out).toEqual<IssueRecord[]>([
+      { number: 1, body: 'body 1', state: 'OPEN' },
+      { number: 2, body: 'body 2', state: 'CLOSED' },
+    ]);
+  });
+
+  it('throws when gh exits non-zero', async () => {
+    spawnSyncMock.mockReturnValueOnce(errResult('authentication required'));
+    await expect(listAutoFiledIssues()).rejects.toThrow(/authentication required/);
+  });
+});
+
+describe('createIssue', () => {
+  it('invokes gh issue create with the rendered title/body and label', async () => {
+    spawnSyncMock.mockReturnValueOnce(
+      okResult('https://github.com/owner/repo/issues/42\n')
+    );
+    const n = await createIssue({ title: 'fix metaphor', body: 'long body' });
+
+    expect(n).toBe(42);
+    const callArgs = spawnSyncMock.mock.calls[0];
+    expect(callArgs[1]).toEqual([
+      'issue',
+      'create',
+      '--title',
+      'fix metaphor',
+      '--body',
+      'long body',
+      '--label',
+      'from:apple-books',
+    ]);
+  });
+});
+
+describe('editIssue', () => {
+  it('invokes gh issue edit with the new body', async () => {
+    spawnSyncMock.mockReturnValueOnce(okResult(''));
+    await editIssue(42, 'new body');
+
+    const callArgs = spawnSyncMock.mock.calls[0];
+    expect(callArgs[1]).toEqual(['issue', 'edit', '42', '--body', 'new body']);
+  });
+});
+
+describe('createLabelIfMissing', () => {
+  it('returns true on successful create', async () => {
+    spawnSyncMock.mockReturnValueOnce(okResult(''));
+    expect(await createLabelIfMissing()).toBe(true);
+  });
+
+  it('returns false when the label already exists', async () => {
+    spawnSyncMock.mockReturnValueOnce(errResult('label "from:apple-books" already exists'));
+    expect(await createLabelIfMissing()).toBe(false);
+  });
+
+  it('throws for unexpected errors', async () => {
+    spawnSyncMock.mockReturnValueOnce(errResult('some other failure'));
+    await expect(createLabelIfMissing()).rejects.toThrow(/some other failure/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run build/notes/github-target.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement github-target**
+
+Create `build/notes/github-target.ts`:
+
+```ts
+/**
+ * Thin wrappers around the `gh` CLI. We shell out via spawnSync (not
+ * a shell-expansion API) so arguments are passed as an array — no
+ * quoting or escaping concerns.
+ */
+
+import { spawnSync } from 'node:child_process';
+import type { IssueRecord, RenderedIssue } from './types.js';
+import { LABEL_NAME } from './types.js';
+
+interface SpawnResult {
+  status: number | null;
+  stdout: string | Buffer;
+  stderr: string | Buffer;
+  signal: NodeJS.Signals | null;
+}
+
+function runGh(args: string[]): { stdout: string; stderr: string } {
+  const r = spawnSync('gh', args, { encoding: 'utf8' }) as unknown as SpawnResult;
+  const stdout = typeof r.stdout === 'string' ? r.stdout : r.stdout.toString('utf8');
+  const stderr = typeof r.stderr === 'string' ? r.stderr : r.stderr.toString('utf8');
+  if (r.status !== 0) {
+    throw new Error(`gh ${args.join(' ')} exited ${r.status}: ${stderr.trim()}`);
+  }
+  return { stdout, stderr };
+}
+
+export async function listAutoFiledIssues(): Promise<IssueRecord[]> {
+  const { stdout } = runGh([
+    'issue', 'list',
+    '--label', LABEL_NAME,
+    '--state', 'all',
+    '--limit', '1000',
+    '--json', 'number,body,state',
+  ]);
+  return JSON.parse(stdout) as IssueRecord[];
+}
+
+export async function createIssue(rendered: RenderedIssue): Promise<number> {
+  const { stdout } = runGh([
+    'issue', 'create',
+    '--title', rendered.title,
+    '--body', rendered.body,
+    '--label', LABEL_NAME,
+  ]);
+  const m = stdout.match(/\/issues\/(\d+)/);
+  if (!m) throw new Error(`could not parse issue number from gh output: ${stdout}`);
+  return parseInt(m[1], 10);
+}
+
+export async function editIssue(number: number, body: string): Promise<void> {
+  runGh(['issue', 'edit', String(number), '--body', body]);
+}
+
+export async function createLabelIfMissing(): Promise<boolean> {
+  const r = spawnSync(
+    'gh',
+    ['label', 'create', LABEL_NAME, '--description', 'Auto-filed from Apple Books annotations', '--color', 'ededed'],
+    { encoding: 'utf8' }
+  ) as unknown as SpawnResult;
+  const stderr = typeof r.stderr === 'string' ? r.stderr : r.stderr.toString('utf8');
+  if (r.status === 0) return true;
+  if (/already exists/i.test(stderr)) return false;
+  throw new Error(`gh label create exited ${r.status}: ${stderr.trim()}`);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run build/notes/github-target.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+npm test
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add build/notes/github-target.ts build/notes/github-target.test.ts
+git commit -m "Add github-target for gh CLI operations (#23)
+
+Wraps gh issue list/create/edit and gh label create with typed
+TS signatures. Uses spawnSync (array args, no shell expansion) so
+content with special characters cannot inject. Auth inherited from
+gh auth login — no PAT to manage.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Daemon entry point
+
+**Files:**
+- Create: `build/scripts/sync-apple-books-notes.ts`
+
+- [ ] **Step 1: Implement the entry point**
+
+Create `build/scripts/sync-apple-books-notes.ts`:
+
+```ts
+#!/usr/bin/env node
+/**
+ * Entry point for the Apple Books → GitHub Issues sync daemon.
+ * Invoked hourly by the LaunchAgent, and by `npm run sync:notes`.
+ *
+ * Exit 0 = success or soft-fail. Exit 1 = user needs to look at the log.
+ */
+
+import { stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { reconcile } from '../notes/reconcile.js';
+import {
+  readState,
+  statePath,
+  writeState,
+} from '../notes/state.js';
+import {
+  createIssue,
+  editIssue,
+  listAutoFiledIssues,
+} from '../notes/github-target.js';
+import {
+  findAnnotationDbPath,
+  findAssetId,
+  findLibraryDbPath,
+  listAnnotations,
+  openReadonly,
+} from '../notes/sqlite-source.js';
+import type { Action } from '../notes/types.js';
+import { BOOK_TITLE } from '../notes/types.js';
+
+function log(severity: 'info' | 'warn' | 'error', event: string, fields: Record<string, unknown> = {}): void {
+  const pairs = Object.entries(fields)
+    .map(([k, v]) => `${k}=${String(v)}`)
+    .join(' ');
+  console.log(`${new Date().toISOString()} [${severity}]  ${event}${pairs ? ' ' + pairs : ''}`);
+}
+
+async function main(): Promise<number> {
+  const t0 = Date.now();
+  const home = homedir();
+  const sPath = statePath(home);
+  const state = await readState(sPath);
+
+  const annPath = await findAnnotationDbPath(home);
+  if (!annPath) {
+    log('warn', 'run-end', { ok: false, reason: 'apple-books-not-installed' });
+    return 0;
+  }
+
+  const annStat = await stat(annPath);
+  const annMtimeIso = annStat.mtime.toISOString();
+  if (annMtimeIso === state.lastSqliteMtime) {
+    log('info', 'run-start', { 'mtime-changed': false, 'skip-reason': 'mtime-stable' });
+    state.runs.total += 1;
+    await writeState(sPath, state);
+    log('info', 'run-end', { ok: true, 'elapsed-ms': Date.now() - t0 });
+    return 0;
+  }
+  log('info', 'run-start', { 'mtime-changed': true });
+
+  let assetId = state.majordomoAssetId;
+  if (!assetId) {
+    const libPath = await findLibraryDbPath(home);
+    if (!libPath) {
+      log('warn', 'run-end', { ok: false, reason: 'library-db-missing' });
+      return 0;
+    }
+    const libDb = openReadonly(libPath);
+    try {
+      assetId = findAssetId(libDb, BOOK_TITLE);
+    } finally {
+      libDb.close();
+    }
+    if (!assetId) {
+      log('warn', 'run-end', {
+        ok: false,
+        reason: 'book-not-found',
+        hint: 'open the built ePub in Books at least once',
+      });
+      return 0;
+    }
+    state.majordomoAssetId = assetId;
+  }
+
+  const annDb = openReadonly(annPath);
+  let annotations;
+  try {
+    annotations = listAnnotations(annDb, assetId);
+  } finally {
+    annDb.close();
+  }
+  log('info', 'sqlite-query', { annotations: annotations.length, 'with-notes': annotations.length });
+
+  let existing;
+  try {
+    existing = await listAutoFiledIssues();
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/authentication/i.test(msg)) {
+      log('error', 'gh-auth-failed', { hint: 'run `gh auth refresh`' });
+      return 1;
+    }
+    if (/rate limit/i.test(msg) || /dial tcp|getaddrinfo/i.test(msg)) {
+      log('warn', 'gh-transient', { message: msg });
+      return 0;
+    }
+    log('error', 'gh-list-failed', { message: msg });
+    return 1;
+  }
+  log('info', 'gh-list', { existing: existing.length, 'with-uuid': existing.length });
+
+  const actions: Action[] = reconcile(annotations, existing);
+  const counts = { create: 0, update: 0, noop: 0 };
+  for (const a of actions) counts[a.type]++;
+  log('info', 'reconcile', counts);
+
+  let exitCode = 0;
+  for (const a of actions) {
+    try {
+      if (a.type === 'create') {
+        const n = await createIssue(a.rendered);
+        state.runs.created += 1;
+        log('info', 'issue-created', { number: n, uuid: a.uuid });
+      } else if (a.type === 'update') {
+        await editIssue(a.issue, a.rendered.body);
+        state.runs.updated += 1;
+        log('info', 'issue-updated', { number: a.issue, uuid: a.uuid });
+      } else {
+        state.runs.noop += 1;
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      log('error', 'action-failed', { type: a.type, uuid: a.uuid, message: msg });
+      exitCode = 1;
+    }
+  }
+
+  state.runs.total += 1;
+  state.lastSqliteMtime = annMtimeIso;
+  if (exitCode === 0) state.lastSuccessfulSync = new Date().toISOString();
+  await writeState(sPath, state);
+
+  log('info', 'run-end', {
+    ok: exitCode === 0,
+    'elapsed-ms': Date.now() - t0,
+  });
+  return exitCode;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((e) => {
+    log('error', 'unhandled', { message: e instanceof Error ? e.message : String(e) });
+    process.exit(1);
+  });
+```
+
+- [ ] **Step 2: Verify type-check**
+
+```bash
+npm run build:check
+```
+
+Expected: silent.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Manual smoke test — happy path**
+
+```bash
+node_modules/.bin/tsx build/scripts/sync-apple-books-notes.ts
+```
+
+Expected: `[info]` log lines ending in `run-end ok=true`. If there are typed notes in Apple Books on Majordomo, expect `issue-created` lines for each. Verify:
+
+```bash
+gh issue list --label from:apple-books
+```
+
+- [ ] **Step 5: Smoke test the mtime guard**
+
+Re-run immediately:
+
+```bash
+node_modules/.bin/tsx build/scripts/sync-apple-books-notes.ts
+```
+
+Expected: `mtime-changed=false skip-reason=mtime-stable` and `run-end ok=true`. No new issues filed.
+
+- [ ] **Step 6: Smoke test the idempotency**
+
+Delete the state file and re-run:
+
+```bash
+rm "$HOME/Library/Application Support/majordomo/notes-sync-state.json"
+node_modules/.bin/tsx build/scripts/sync-apple-books-notes.ts
+```
+
+Expected: all `noop` actions, no `issue-created`. Dedup by UUID prevents duplicates even with no state.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add build/scripts/sync-apple-books-notes.ts
+git commit -m "Add daemon entry point for Apple Books → Issues sync (#23)
+
+Wires the pure functions (reconcile, render) and I/O modules
+(sqlite-source, github-target, state) into a single hourly run.
+Exit-code semantics: 0 = soft, 1 = hard. Logs are structured
+one-line-per-event for easy grep.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Status script
+
+**Files:**
+- Create: `build/scripts/sync-apple-books-notes-status.ts`
+
+- [ ] **Step 1: Implement the status script**
+
+Create `build/scripts/sync-apple-books-notes-status.ts`:
+
+```ts
+#!/usr/bin/env node
+/**
+ * `npm run sync:notes:status` — pretty-printed observability summary.
+ */
+
+import { stat } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { readState, statePath } from '../notes/state.js';
+import { findAnnotationDbPath } from '../notes/sqlite-source.js';
+import { LABEL_NAME } from '../notes/types.js';
+
+function fmt(iso: string): string {
+  if (iso === '1970-01-01T00:00:00.000Z') return '(never)';
+  const d = new Date(iso);
+  const now = Date.now();
+  const ago = Math.round((now - d.getTime()) / 60000);
+  return `${d.toLocaleString()} (${ago} minutes ago)`;
+}
+
+async function fileSize(path: string): Promise<string> {
+  try {
+    const s = await stat(path);
+    if (s.size > 1024 * 1024) return `${(s.size / 1024 / 1024).toFixed(1)} MB`;
+    if (s.size > 1024) return `${(s.size / 1024).toFixed(1)} KB`;
+    return `${s.size} B`;
+  } catch {
+    return '(missing)';
+  }
+}
+
+function ghCount(state: 'open' | 'closed'): number | null {
+  const r = spawnSync(
+    'gh',
+    ['issue', 'list', '--label', LABEL_NAME, '--state', state, '--limit', '1000', '--json', 'number'],
+    { encoding: 'utf8' }
+  );
+  if (r.status !== 0) return null;
+  try {
+    return (JSON.parse(r.stdout) as unknown[]).length;
+  } catch {
+    return null;
+  }
+}
+
+function launchctlLoaded(): boolean {
+  const r = spawnSync(
+    'launchctl',
+    ['print', `gui/${process.getuid?.() ?? 0}/io.dwk.majordomo.notes-sync`],
+    { encoding: 'utf8' }
+  );
+  return r.status === 0;
+}
+
+async function main(): Promise<void> {
+  const home = homedir();
+  const s = await readState(statePath(home));
+  const logPath = join(home, 'Library', 'Logs', 'majordomo-notes-sync.log');
+  const annPath = await findAnnotationDbPath(home);
+  const annMtime = annPath ? (await stat(annPath)).mtime.toISOString() : null;
+
+  console.log('Majordomo notes sync');
+  console.log(`  Last run:           ${fmt(s.lastSuccessfulSync)}`);
+  console.log(`  Apple Books mtime:  ${annMtime ? fmt(annMtime) : '(books not installed)'}`);
+  console.log(`  State file:         ${statePath(home)}`);
+  console.log(`  Log file:           ${logPath}  (${await fileSize(logPath)})`);
+  console.log(`  LaunchAgent:        ${launchctlLoaded() ? 'loaded' : 'NOT loaded'}`);
+  console.log('');
+  console.log('  Lifetime counters');
+  console.log(`    runs:     ${s.runs.total}   (created: ${s.runs.created}, updated: ${s.runs.updated}, noop: ${s.runs.noop})`);
+
+  const open = ghCount('open');
+  const closed = ghCount('closed');
+  if (open !== null && closed !== null) {
+    console.log(`    open issues with ${LABEL_NAME} label:    ${open}`);
+    console.log(`    closed issues with ${LABEL_NAME} label:  ${closed}`);
+  } else {
+    console.log(`    (could not query GitHub — is gh auth valid?)`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Verify type-check**
+
+```bash
+npm run build:check
+```
+
+Expected: silent.
+
+- [ ] **Step 3: Smoke test**
+
+```bash
+node_modules/.bin/tsx build/scripts/sync-apple-books-notes-status.ts
+```
+
+Expected: pretty-printed summary.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add build/scripts/sync-apple-books-notes-status.ts
+git commit -m "Add status subcommand for notes-sync observability (#23)
+
+\`npm run sync:notes:status\` prints last-run time, Apple Books
+mtime, state/log file paths, LaunchAgent load state, lifetime
+counters, and a fresh open/closed count via gh.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Installer, uninstaller, plist template
+
+**Files:**
+- Create: `build/scripts/notes-sync/io.dwk.majordomo.notes-sync.plist.template`
+- Create: `build/scripts/install-notes-sync.ts`
+- Create: `build/scripts/uninstall-notes-sync.ts`
+
+- [ ] **Step 1: Create the plist template**
+
+Create `build/scripts/notes-sync/io.dwk.majordomo.notes-sync.plist.template`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.dwk.majordomo.notes-sync</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/env</string>
+        <string>-i</string>
+        <string>HOME=__HOME__</string>
+        <string>PATH=__PATH__</string>
+        <string>__TSX__</string>
+        <string>build/scripts/sync-apple-books-notes.ts</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO__</string>
+
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/majordomo-notes-sync.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/majordomo-notes-sync.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+
+    <key>Nice</key>
+    <integer>10</integer>
+</dict>
+</plist>
+```
+
+- [ ] **Step 2: Implement the installer**
+
+Create `build/scripts/install-notes-sync.ts`:
+
+```ts
+#!/usr/bin/env node
+/**
+ * One-shot installer for the Apple Books notes sync LaunchAgent.
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { createLabelIfMissing } from '../notes/github-target.js';
+import { findAnnotationDbPath } from '../notes/sqlite-source.js';
+
+const LABEL_PLIST = 'io.dwk.majordomo.notes-sync';
+const PLIST_NAME = `${LABEL_PLIST}.plist`;
+
+function die(msg: string, code = 1): never {
+  console.error(`[install-notes-sync] ${msg}`);
+  process.exit(code);
+}
+
+function checkTool(tool: string, args: string[] = ['--version']): void {
+  const r = spawnSync(tool, args, { encoding: 'utf8' });
+  if (r.status !== 0) die(`required tool not working: \`${tool} ${args.join(' ')}\` exited ${r.status}`);
+}
+
+function repoRoot(): string {
+  const r = spawnSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' });
+  if (r.status !== 0) die('not inside a git repository');
+  return r.stdout.trim();
+}
+
+function repoRemote(repo: string): string {
+  const r = spawnSync('git', ['-C', repo, 'remote', 'get-url', 'origin'], { encoding: 'utf8' });
+  if (r.status !== 0) die('repo has no `origin` remote');
+  return r.stdout.trim();
+}
+
+async function main(): Promise<void> {
+  const home = homedir();
+  const repo = repoRoot();
+  const tsx = resolve(repo, 'node_modules', '.bin', 'tsx');
+  const path = '/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin';
+
+  console.log('[install-notes-sync] preflight...');
+
+  checkTool('gh');
+
+  const auth = spawnSync('gh', ['auth', 'status'], { encoding: 'utf8' });
+  if (auth.status !== 0) {
+    die(`gh CLI is not authenticated. Run: gh auth login --git-protocol https --hostname github.com`);
+  }
+
+  checkTool(tsx);
+
+  const remote = repoRemote(repo);
+  if (!/davidwkeith\/A-Majordomo-for-Everyone(\.git)?$/.test(remote)) {
+    die(`unexpected origin remote: ${remote}\n  expected: davidwkeith/A-Majordomo-for-Everyone`);
+  }
+
+  const annPath = await findAnnotationDbPath(home);
+  if (!annPath) {
+    console.log('[install-notes-sync] warning: Apple Books sqlite not found yet — open Books at least once after install.');
+  }
+
+  console.log('[install-notes-sync] creating from:apple-books label (if missing)...');
+  const created = await createLabelIfMissing();
+  console.log(`[install-notes-sync]   ${created ? 'created' : 'already exists'}`);
+
+  console.log('[install-notes-sync] writing LaunchAgent plist...');
+  const tmplPath = join(repo, 'build', 'scripts', 'notes-sync', `${PLIST_NAME}.template`);
+  const dest = join(home, 'Library', 'LaunchAgents', PLIST_NAME);
+  const tmpl = await readFile(tmplPath, 'utf8');
+  const plist = tmpl
+    .replaceAll('__HOME__', home)
+    .replaceAll('__PATH__', path)
+    .replaceAll('__TSX__', tsx)
+    .replaceAll('__REPO__', repo);
+  await mkdir(dirname(dest), { recursive: true });
+  await writeFile(dest, plist, 'utf8');
+  console.log(`[install-notes-sync]   wrote ${dest}`);
+
+  console.log('[install-notes-sync] loading via launchctl bootstrap...');
+  const uid = process.getuid?.() ?? 0;
+  const bootstrap = spawnSync('launchctl', ['bootstrap', `gui/${uid}`, dest], { encoding: 'utf8' });
+  if (bootstrap.status !== 0) {
+    if (/already loaded|Bootstrap failed/i.test(bootstrap.stderr)) {
+      console.log('[install-notes-sync]   already loaded — replacing');
+      spawnSync('launchctl', ['bootout', `gui/${uid}/${LABEL_PLIST}`], { encoding: 'utf8' });
+      const second = spawnSync('launchctl', ['bootstrap', `gui/${uid}`, dest], { encoding: 'utf8' });
+      if (second.status !== 0) die(`launchctl bootstrap failed: ${second.stderr.trim()}`);
+    } else {
+      die(`launchctl bootstrap failed: ${bootstrap.stderr.trim()}`);
+    }
+  }
+  console.log('[install-notes-sync]   loaded');
+
+  console.log('[install-notes-sync] kickstarting first run...');
+  const kick = spawnSync('launchctl', ['kickstart', '-p', `gui/${uid}/${LABEL_PLIST}`], { encoding: 'utf8' });
+  if (kick.status !== 0) die(`launchctl kickstart failed: ${kick.stderr.trim()}`);
+  console.log('[install-notes-sync]   kicked');
+
+  console.log('');
+  console.log('Done. Next steps:');
+  console.log(`  • Log:           tail -f ${home}/Library/Logs/majordomo-notes-sync.log`);
+  console.log(`  • Status:        npm run sync:notes:status`);
+  console.log(`  • Manual run:    npm run sync:notes`);
+  console.log(`  • Uninstall:     npm run sync:notes:uninstall`);
+}
+
+main().catch((e) => die(e instanceof Error ? e.message : String(e)));
+```
+
+- [ ] **Step 3: Implement the uninstaller**
+
+Create `build/scripts/uninstall-notes-sync.ts`:
+
+```ts
+#!/usr/bin/env node
+/**
+ * One-shot uninstaller. Unloads the LaunchAgent and removes the plist.
+ * Leaves state file and GitHub label alone — data, not config.
+ */
+
+import { rm } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const LABEL = 'io.dwk.majordomo.notes-sync';
+
+async function main(): Promise<void> {
+  const home = homedir();
+  const uid = process.getuid?.() ?? 0;
+  const dest = join(home, 'Library', 'LaunchAgents', `${LABEL}.plist`);
+
+  console.log('[uninstall-notes-sync] booting out...');
+  const r = spawnSync('launchctl', ['bootout', `gui/${uid}/${LABEL}`], { encoding: 'utf8' });
+  if (r.status !== 0 && !/not loaded|no such/i.test(r.stderr)) {
+    console.log(`[uninstall-notes-sync]   note: ${r.stderr.trim()}`);
+  } else {
+    console.log('[uninstall-notes-sync]   booted out');
+  }
+
+  console.log('[uninstall-notes-sync] removing plist...');
+  try {
+    await rm(dest);
+    console.log(`[uninstall-notes-sync]   removed ${dest}`);
+  } catch {
+    console.log(`[uninstall-notes-sync]   no plist at ${dest}`);
+  }
+
+  console.log('');
+  console.log('State file and GitHub label left in place:');
+  console.log(`  ${home}/Library/Application Support/majordomo/notes-sync-state.json`);
+  console.log(`  GitHub label: from:apple-books`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 4: Verify type-check**
+
+```bash
+npm run build:check
+```
+
+Expected: silent.
+
+- [ ] **Step 5: Commit (installer is tested end-to-end in Task 11)**
+
+```bash
+git add build/scripts/install-notes-sync.ts build/scripts/uninstall-notes-sync.ts build/scripts/notes-sync/io.dwk.majordomo.notes-sync.plist.template
+git commit -m "Add installer/uninstaller and LaunchAgent plist template (#23)
+
+install: preflight (gh CLI, gh auth, tsx, git remote, Apple Books
+db), create the from:apple-books label, substitute tokens in the
+plist template, launchctl bootstrap + kickstart smoke run.
+
+uninstall: launchctl bootout + plist rm. Leaves state file and
+GitHub label intact (data, not config).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Wire npm scripts, document in CLAUDE.md
+
+**Files:**
+- Modify: `package.json`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add the four npm scripts**
+
+Edit `package.json` `scripts` block — add four new entries (existing entries stay):
+
+```json
+{
+  "scripts": {
+    "build": "tsc && node dist/build/index.js",
+    "build:site": "tsc && node dist/build/site/index.js",
+    "build:pdf": "tsc && node dist/build/pdf/index.js",
+    "build:all": "tsc && node dist/build/index.js && node dist/build/site/index.js",
+    "build:check": "tsc --noEmit",
+    "dev": "npm run build:site && wrangler dev",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist",
+    "sync:notes": "tsx build/scripts/sync-apple-books-notes.ts",
+    "sync:notes:status": "tsx build/scripts/sync-apple-books-notes-status.ts",
+    "sync:notes:install": "tsx build/scripts/install-notes-sync.ts",
+    "sync:notes:uninstall": "tsx build/scripts/uninstall-notes-sync.ts"
+  }
+}
+```
+
+- [ ] **Step 2: Verify the scripts resolve**
+
+```bash
+npm run sync:notes:status
+```
+
+Expected: prints the status summary (mostly "(never)" since the daemon hasn't done a real run yet).
+
+- [ ] **Step 3: Document in CLAUDE.md**
+
+Find the insertion point (after `## Build`, before `## Project Structure`):
+
+```bash
+grep -n '^## ' CLAUDE.md
+```
+
+Insert this section after `## Build`:
+
+```markdown
+## Apple Books Notes Sync
+
+Hourly sync from your Apple Books typed annotations on the built ePub to GitHub Issues on this repo (label `from:apple-books`). Each annotation becomes one deduped issue.
+
+\`\`\`bash
+npm run sync:notes:install      # one-time: install LaunchAgent + create label
+npm run sync:notes              # force a sync now (rather than wait for next hour)
+npm run sync:notes:status       # last-run, mtime, log file size, lifetime counters
+npm run sync:notes:uninstall    # remove the LaunchAgent
+\`\`\`
+
+State lives outside the repo:
+- `~/Library/Application Support/majordomo/notes-sync-state.json` (mtime cache, asset_id, counters)
+- `~/Library/Logs/majordomo-notes-sync.log` (structured one-line-per-event log)
+
+Requires `gh auth login` to have been run once. See [the design spec](docs/superpowers/specs/2026-05-23-apple-books-notes-sync-design.md) for the full architecture.
+```
+
+(When pasting, replace the escaped fence sequences with real triple backticks.)
+
+- [ ] **Step 4: Verify type-check + tests still green**
+
+```bash
+npm run build:check && npm test
+```
+
+Expected: silent / all green.
+
+- [ ] **Step 5: Run the installer end-to-end**
+
+```bash
+npm run sync:notes:install
+```
+
+Expected: preflight passes, label created (or "already exists"), plist written, launchctl bootstrap + kickstart succeed, "Done." footer prints with next-step commands.
+
+- [ ] **Step 6: Verify the LaunchAgent is loaded**
+
+```bash
+launchctl print "gui/$(id -u)/io.dwk.majordomo.notes-sync" | head -20
+```
+
+Expected: prints the plist's path, label, state=running or waiting.
+
+- [ ] **Step 7: Tail the log to see the first auto-run**
+
+```bash
+tail -20 ~/Library/Logs/majordomo-notes-sync.log
+```
+
+Expected: sequence of `[info]` log lines from the kickstarted first run, ending in `run-end`.
+
+- [ ] **Step 8: Verify uninstall + reinstall symmetry**
+
+```bash
+npm run sync:notes:uninstall
+launchctl print "gui/$(id -u)/io.dwk.majordomo.notes-sync" 2>&1 | head -3
+# expected: "Could not find service" or similar
+npm run sync:notes:install
+launchctl print "gui/$(id -u)/io.dwk.majordomo.notes-sync" | head -3
+# expected: service printed again
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add package.json CLAUDE.md
+git commit -m "Wire sync:notes npm scripts and document in CLAUDE.md (#23)
+
+Four new scripts: sync:notes (force run), sync:notes:status (pretty
+summary), sync:notes:install (one-shot installer that loads the
+LaunchAgent), sync:notes:uninstall (clean teardown).
+
+CLAUDE.md gains an Apple Books Notes Sync section with the four
+commands, state/log paths, and a pointer to the design spec.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Version bump
+
+**Files:**
+- Modify: `package.json`
+
+Per CLAUDE.md: minor bump for pipeline changes → `0.3.0 → 0.4.0`. Tag created when this merges to main, not in this commit.
+
+- [ ] **Step 1: Bump the version**
+
+Edit `package.json`:
+
+```json
+{
+  "version": "0.4.0"
+}
+```
+
+- [ ] **Step 2: Verify everything is still green**
+
+```bash
+npm run build:check && npm test
+```
+
+Expected: silent / all green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json
+git commit -m "Bump version to 0.4.0 for notes sync subsystem (#23)
+
+Per CLAUDE.md, minor bump for pipeline changes. Tag v0.4.0 when
+this branch merges to main.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final checks before opening the PR
+
+- [ ] **Step 1: `git log` looks clean**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected: ~13 commits, each on a clear unit of work, all referencing #23.
+
+- [ ] **Step 2: Full suite passes one more time**
+
+```bash
+npm run build:check && npm test
+```
+
+Expected: silent / all green.
+
+- [ ] **Step 3: `npm run sync:notes:status` shows real activity**
+
+```bash
+npm run sync:notes:status
+```
+
+Expected: `Last run` is recent, `LaunchAgent: loaded`, counters > 0 if any notes existed at sync time.
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+git push -u origin claude/issue-23-apple-books-notes-sync-spec
+gh pr create --fill --body "Implements #23 per the design at \`docs/superpowers/specs/2026-05-23-apple-books-notes-sync-design.md\`. Supersedes the April 14 design.
+
+## Highlights
+
+- Each typed Apple Books note becomes one deduped GitHub Issue (label \`from:apple-books\`)
+- Idempotent via \`<!-- apple-books-uuid: X -->\` HTML-comment dedup
+- Hourly LaunchAgent with mtime guard for cheap no-op runs
+- TypeScript reading sqlite directly via better-sqlite3; auth via existing \`gh auth login\`
+- One PR, 12 commits along leaf-to-trunk build order
+- 0.3.0 → 0.4.0 (minor bump per CLAUDE.md)
+
+## Verification
+
+- All unit + integration tests pass (\`npm test\`)
+- Manual smoke tests for install / kickstart / mtime guard / idempotency documented in the spec
+- Verified \`launchctl print\` shows the loaded service
+- End-to-end: typed a test note in Apple Books, ran the daemon, confirmed an issue appeared with correct body schema
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+Closes #23 when merged.
+
+---
+
+## Notes for the executing agent
+
+- The daemon's first real-world run requires the user to have opened the built *Majordomo* ePub in Apple Books on macOS at least once (so its asset_id appears in `BKLibrary-*.sqlite`). If `findAssetId` returns null on first install, that's the cause — not a bug.
+- `npm test` count will grow from 55 → ~85 across this plan. Note the exact number after each task and watch for regressions.
+- The integration tests in `sqlite-source.test.ts` use `:memory:` sqlite seeded from the fixture SQL. If `better-sqlite3` fails to import on CI (rare; the package ships prebuilt binaries for `ubuntu-latest`), check that the Node major version on the runner is ≥20.
+- Commit messages all end with the Co-Authored-By trailer (per the repo's session conventions).

--- a/docs/superpowers/specs/2026-04-14-apple-books-sync-design.md
+++ b/docs/superpowers/specs/2026-04-14-apple-books-sync-design.md
@@ -1,5 +1,9 @@
 # Apple Books Highlight Sync
 
+> **Superseded by [2026-05-23-apple-books-notes-sync-design.md](./2026-05-23-apple-books-notes-sync-design.md).**
+> Architecture pivoted from "commit `notes/highlights.md` to the repo" to "file each typed note as a GitHub Issue."
+> The current implementation plan is in the superseding spec.
+
 **Issue:** [#23](https://github.com/davidwkeith/A-Majordomo-for-Everyone/issues/23)
 **Date:** 2026-04-14
 

--- a/docs/superpowers/specs/2026-05-23-apple-books-notes-sync-design.md
+++ b/docs/superpowers/specs/2026-05-23-apple-books-notes-sync-design.md
@@ -1,0 +1,444 @@
+# Apple Books Notes → GitHub Issues Sync
+
+**Issue:** [#23](https://github.com/davidwkeith/A-Majordomo-for-Everyone/issues/23)
+**Date:** 2026-05-23
+**Supersedes:** [2026-04-14-apple-books-sync-design.md](./2026-04-14-apple-books-sync-design.md)
+
+## Goal
+
+Synced revision-TODO capture: every typed note made in Apple Books on the *A Majordomo for Everyone* ePub becomes (or updates) exactly one GitHub Issue on this repo, filed automatically by an hourly LaunchAgent. The GitHub Issue is the durable, triagable record; the Apple Books annotation is the ephemeral capture surface.
+
+This supersedes the April 14 design, which proposed a single `notes/highlights.md` file committed and pushed by a Python+uv script. Issues map more naturally to a revision-TODO workflow than a growing markdown file — each note becomes a discrete unit you can label, assign, close with a commit, or convert to a PR.
+
+## Decisions captured during brainstorming
+
+These framed every downstream choice:
+
+| Decision | Value | Why |
+|---|---|---|
+| Note purpose | Private revision TODOs (filed publicly on the book's public repo) | The author writes notes against the draft to feed back into editing. Public visibility imposes self-discipline on tone. |
+| What counts as a note | Highlights *with* a typed note in `ZANNOTATIONNOTE`. Bare highlights are ignored. | Bare highlights are "this passage interested me," not actionable. |
+| Destination | GitHub Issues on `davidwkeith/A-Majordomo-for-Everyone` | Public, in-context with the rest of the project's work tracking. Replaces the original "files under `notes/`" plan. |
+| Trigger | LaunchAgent, `StartInterval=3600`, `RunAtLoad=true` | Hourly cadence; resumes correctly from sleep (unlike `StartCalendarInterval`); fires once on login. |
+| Edit handling | Patch the issue body | Issue body is a function of current sqlite state; idempotent. Comments on the issue are preserved. |
+| Delete handling | Issue stays untouched | GitHub owns the issue lifecycle after creation. Apple Books is capture; GitHub is the record. |
+| Issue title format | First line of typed note (≤80 chars). Single label `from:apple-books`. | Minimum noise; one label enables `gh issue list -l from:apple-books` filtering. |
+| Language | TypeScript reading sqlite directly via `better-sqlite3` | Matches the rest of the build pipeline. No Python dependency. The `jladicos/apple-books-highlights` schema knowledge is borrowed; the implementation is ours. |
+| Operating mode | The daemon is stateless w.r.t. git. No commits, no pushes, no worktree. Only API calls. | The pivot from filesystem-sync to Issues-sync removed the entire class of "what branch is dirty / what worktree am I in" problems. |
+
+## Architecture
+
+### Data flow
+
+```
+┌──────────────────────────┐         ┌─────────────────────────────┐
+│ iPhone/iPad Apple Books  │         │  GitHub Issues              │
+│   (typed annotations)    │         │ davidwkeith/A-Majordomo-    │
+└────────────┬─────────────┘         │  for-Everyone               │
+             │ iCloud                │  label: from:apple-books    │
+             ▼                       └──────────────▲──────────────┘
+┌──────────────────────────┐                        │
+│ macOS Apple Books        │                        │ gh CLI
+│   ~/Library/Containers/  │                        │ (create/edit)
+│   …/AEAnnotation_*.sqlite│                        │
+└────────────┬─────────────┘                        │
+             │ read-only via better-sqlite3         │
+             ▼                                      │
+┌─────────────────────────────────────────────────────────────────┐
+│ sync-apple-books-notes.ts  (hourly, via LaunchAgent)            │
+│                                                                 │
+│  1. Stat AEAnnotation_*.sqlite — bail if mtime unchanged        │
+│  2. Query annotations WHERE asset_id = Majordomo                │
+│                       AND   ZANNOTATIONNOTE IS NOT NULL         │
+│  3. gh issue list -l from:apple-books --state all --json …      │
+│     → parse <!-- apple-books-uuid: X --> from each body         │
+│  4. For each annotation: create / edit / no-op                  │
+│  5. Persist last-seen mtime to state file                       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Components
+
+Each unit has one clear purpose. Pure functions are testable without I/O; I/O modules are testable by mocking the shell/spawn boundary.
+
+| Unit | Responsibility | Pure? | Depends on |
+|---|---|---|---|
+| `build/notes/types.ts` | Shared types: `Annotation`, `IssueRecord`, `Action`, `State`. | yes | — |
+| `build/notes/uuid-parse.ts` | Extract `<!-- apple-books-uuid: X -->` from a markdown body. | yes | `types.ts` |
+| `build/notes/render.ts` | `Annotation → {title, body}`. Includes NSDate→ISO conversion. | yes | `types.ts` |
+| `build/notes/reconcile.ts` | `(current[], existing[]) → Action[]` (`create` / `update` / `noop`). | yes | `types.ts`, `uuid-parse.ts` |
+| `build/notes/state.ts` | Read/write/migrate state file at `~/Library/Application Support/majordomo/notes-sync-state.json`. | no (fs I/O) | `types.ts` |
+| `build/notes/sqlite-source.ts` | Read-only `better-sqlite3` access. `findAssetId(title)`, `listAnnotations(assetId)`. | no (sqlite I/O) | `types.ts`, `better-sqlite3` |
+| `build/notes/github-target.ts` | Wraps `gh` CLI: `listAutoFiledIssues()`, `createIssue(body)`, `editIssue(n, body)`, `createLabelIfMissing()`. | no (child_process) | `types.ts` |
+| `build/scripts/sync-apple-books-notes.ts` | Entry point. Orchestrates mtime check → query → reconcile → persist. | no (top-level) | all of `build/notes/*` |
+| `build/scripts/sync-apple-books-notes-status.ts` | `npm run sync:notes:status` — print observability summary. | no | `state.ts`, `github-target.ts` |
+| `build/scripts/install-notes-sync.ts` | One-shot installer: preflight, label create, plist substitution, `launchctl bootstrap`, smoke test. | no | `child_process`, `fs` |
+| `build/scripts/uninstall-notes-sync.ts` | `launchctl bootout`, remove plist. State file and label left alone. | no | `child_process`, `fs` |
+| `build/scripts/notes-sync/io.dwk.majordomo.notes-sync.plist.template` | LaunchAgent plist with `__HOME__` / `__PATH__` / `__NPX__` / `__REPO__` tokens. | — | — |
+
+## Issue body schema
+
+The contract between Apple Books state and GitHub state:
+
+```markdown
+> [quoted passage from the book]
+>
+> — [chapter title] ([location %])
+
+[user's typed note, full text, markdown allowed]
+
+<!-- apple-books-uuid: 4F3A-…-B891 -->
+<!-- apple-books-modified: 2026-05-23T14:11:00Z -->
+```
+
+| Element | sqlite source | Purpose |
+|---|---|---|
+| Blockquote | `ZAEANNOTATION.ZSELECTEDTEXT` | The passage you marked. Rendered visually distinct. |
+| Chapter title | `ZAEANNOTATION.ZFUTUREPROOFING5` (captured at annotation time) | Where the passage came from. Frozen at capture — the chapter title at note-time, not the drift-prone current title. |
+| Location % | `ZAEANNOTATION.ZLOCATIONRANGESTART` ÷ asset max | Soft positional reference; the ePub re-paginates between builds. |
+| Body text | `ZAEANNOTATION.ZANNOTATIONNOTE` | Verbatim. Markdown is rendered by GitHub. |
+| `<!-- apple-books-uuid: … -->` | `ZAEANNOTATION.ZANNOTATIONUUID` | **Primary dedup key.** Stable across edits. |
+| `<!-- apple-books-modified: … -->` | `ZAEANNOTATION.ZANNOTATIONMODIFICATIONDATE` (Core Data NSDate, seconds since 2001-01-01 UTC) | Fast change-detection. Converted with `new Date((nsdate + 978307200) * 1000)`. |
+
+**Title derivation:** first non-empty line of `ZANNOTATIONNOTE`, strip markdown punctuation, collapse whitespace, truncate to 80 chars with `…` suffix.
+
+## Dedup mechanics
+
+```ts
+// Per run, after the mtime guard passes:
+
+const existing = await gh.issueList({
+  label: 'from:apple-books',
+  state: 'all',
+  limit: 1000,
+  fields: ['number', 'body', 'state'],
+});
+
+const byUuid = new Map<string, IssueRecord>();
+for (const issue of existing) {
+  const uuid = parseUuid(issue.body);
+  if (uuid) byUuid.set(uuid, issue);
+}
+
+for (const ann of annotations) {
+  const rendered = render(ann);
+  const found = byUuid.get(ann.uuid);
+  if (!found)                              actions.push({type: 'create', rendered});
+  else if (found.body === rendered.body)   actions.push({type: 'noop',   issue: found.number});
+  else                                     actions.push({type: 'update', issue: found.number, rendered});
+}
+```
+
+**Properties:**
+- **Idempotent.** Running the daemon five times in five seconds produces the same end state as running it once.
+- **Crash-safe.** No state machine to corrupt. Worst case: one duplicate filing if the daemon dies *exactly* between `gh issue create` and its response landing — detected on the next run, resolved with one manual `gh issue close`.
+- **Closed-issue safe.** Closed issues appear in `--state all`, so their UUIDs are in the dedup index. The daemon will *update the body* of a closed issue but not reopen it.
+
+## State file
+
+Location: `~/Library/Application Support/majordomo/notes-sync-state.json`
+
+```json
+{
+  "schemaVersion": 1,
+  "lastSqliteMtime": "2026-05-23T18:30:14.221Z",
+  "lastSuccessfulSync": "2026-05-23T18:30:14.502Z",
+  "majordomoAssetId": "9789B6F0-…-A442",
+  "runs": {
+    "total": 142,
+    "created": 23,
+    "updated": 8,
+    "noop": 111
+  }
+}
+```
+
+| Field | Purpose |
+|---|---|
+| `schemaVersion` | Forward compatibility. Unknown future version → warn, treat as first run. |
+| `lastSqliteMtime` | Mtime guard. Skip reconciliation if sqlite unchanged since this. |
+| `lastSuccessfulSync` | Observability — "when did this last work?" without trawling logs. |
+| `majordomoAssetId` | Cached lookup. First run finds it by title; subsequent runs skip the title-search. |
+| `runs.*` | Lightweight counters for "is this thing alive?" |
+
+If the file is missing or unparseable, the daemon falls back to "full reconcile" mode — dedup-by-UUID makes it impossible to file duplicates even with no state.
+
+## LaunchAgent
+
+`build/scripts/notes-sync/io.dwk.majordomo.notes-sync.plist.template`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.dwk.majordomo.notes-sync</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/env</string>
+        <string>-i</string>
+        <string>HOME=__HOME__</string>
+        <string>PATH=__PATH__</string>
+        <string>__TSX__</string>
+        <string>build/scripts/sync-apple-books-notes.ts</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>__REPO__</string>
+    <key>StartInterval</key>
+    <integer>3600</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/majordomo-notes-sync.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/majordomo-notes-sync.log</string>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>Nice</key>
+    <integer>10</integer>
+</dict>
+</plist>
+```
+
+Token substitution happens at install time. The tokens resolve to:
+
+| Token | Value at install time |
+|---|---|
+| `__HOME__` | `process.env.HOME` |
+| `__PATH__` | A minimal explicit PATH: `/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin` (covers `gh` from Homebrew on both Intel and Apple Silicon, plus system tools) |
+| `__TSX__` | `__REPO__/node_modules/.bin/tsx` (the local devDep binary, fully resolved) |
+| `__REPO__` | The absolute path of the repo at install time, captured via `git rev-parse --show-toplevel` |
+
+Plists do not expand shell variables; all paths must be fully resolved at write time.
+
+**Why LaunchAgent, not LaunchDaemon:** macOS's TCC (Transparency, Consent, and Control) treats LaunchAgents in the user GUI domain (`gui/$(id -u)`) as inheriting the user's granted permissions, including access to `~/Library/Containers/com.apple.iBooksX/`. A LaunchDaemon (`system` domain) would be sandboxed away from Apple Books's container.
+
+**Why `StartInterval` not `StartCalendarInterval`:** `StartInterval` resumes correctly from sleep; cron-style `StartCalendarInterval` skips fires that happened during sleep.
+
+**Why `/usr/bin/env -i`:** clean environment — only the vars we pass explicitly. Prevents leakage of NVM-style PATH manipulation that wouldn't be present in launchd's env anyway. Forces explicit dependency declaration.
+
+## Auth
+
+```
+One-time setup (done by the user, not the daemon):
+
+  gh auth login --git-protocol https --hostname github.com
+    → writes creds to ~/.config/gh/hosts.yml
+
+  Verify with: gh auth status
+```
+
+The daemon does no auth setup. It calls `gh` and inherits whatever auth is present. If `gh auth status` would fail, the first `gh issue list` call returns non-zero, the daemon logs an error and exits 1, and next hour's run tries again.
+
+No PAT to manage. No environment variables with secrets. No keychain calls. `gh` already solved this.
+
+## Setup script (`install-notes-sync.ts`)
+
+Invoked once: `npm run sync:notes:install`.
+
+1. **Preflight** (fail loudly, fix nothing automatically):
+   - `gh --version` exits 0
+   - `gh auth status` shows a logged-in user
+   - `node_modules/.bin/tsx --version` exits 0 (the local devDep binary)
+   - Apple Books sqlite exists at the expected path (warn if not — it doesn't exist until Books is opened at least once)
+   - The repo's remote points at `github.com/davidwkeith/A-Majordomo-for-Everyone`
+2. **Create the GitHub label** if missing:
+   ```
+   gh label create from:apple-books \
+     --description "Auto-filed from Apple Books annotations" \
+     --color "ededed" || true
+   ```
+   (`gh label create --color` takes the hex without the leading `#`.)
+3. **Write the substituted plist** to `~/Library/LaunchAgents/io.dwk.majordomo.notes-sync.plist`, replacing all `__*__` tokens.
+4. **Load**: `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/io.dwk.majordomo.notes-sync.plist`.
+5. **Smoke test**: `launchctl kickstart -p gui/$(id -u)/io.dwk.majordomo.notes-sync` to fire it once immediately.
+6. **Print next steps**: log location, uninstall command, manual run command.
+
+## Uninstaller (`uninstall-notes-sync.ts`)
+
+- `launchctl bootout gui/$(id -u)/io.dwk.majordomo.notes-sync`
+- Remove the plist
+- **Leave the state file alone** — it's data; user can rm it manually if desired.
+- **Don't touch the GitHub label** — issues filed under it stay categorized; user may have applied it manually elsewhere.
+
+## Manual invocation
+
+```json
+"scripts": {
+  "sync:notes":            "tsx build/scripts/sync-apple-books-notes.ts",
+  "sync:notes:install":    "tsx build/scripts/install-notes-sync.ts",
+  "sync:notes:uninstall":  "tsx build/scripts/uninstall-notes-sync.ts",
+  "sync:notes:status":     "tsx build/scripts/sync-apple-books-notes-status.ts"
+}
+```
+
+Same script as the daemon, same state file, same dedup. `npm run sync:notes` from any terminal forces a sync without waiting for the next hour.
+
+## Failure modes
+
+Exit code semantics: **0 means "nothing for the user to do."** **1 means "the user needs to look at this."** The LaunchAgent re-fires on schedule regardless of exit code; mtime guard + dedup-by-UUID make it safe to retry indefinitely.
+
+| Failure | Detection | Action | Severity |
+|---|---|---|---|
+| Apple Books sqlite missing | `stat` ENOENT | Log warn, exit 0 | Soft — pre-first-launch |
+| sqlite locked (`SQLITE_BUSY`) | `better-sqlite3` open throws | Retry once after 500ms; if still locked, log warn, exit 0 | Soft — transient |
+| Majordomo asset_id not found | `findAssetId('A Majordomo for Everyone')` returns null | Log warn ("have you opened the built ePub at least once?"), exit 0 | Soft — first-run guidance |
+| `gh` not on PATH | `spawn` ENOENT | Log error, exit 1 | Hard |
+| `gh` auth expired | `gh issue list` exits non-zero with `authentication required` | Log error ("run `gh auth refresh`"), exit 1 | Hard |
+| Rate-limited | `gh` exits with `API rate limit exceeded` | Log warn ("will retry next hour"), exit 0 | Soft |
+| Network down | `gh` exits with DNS or connection failure | Log warn, exit 0 | Soft |
+| State file corrupt | `JSON.parse` throws | Log warn, proceed as first run. Dedup-by-UUID prevents duplicates. | Soft — self-heals |
+| One issue fails to file | `gh issue create` non-zero for one item | Log error with UUID, continue loop, exit 1 at end | Mixed |
+| Duplicate UUID in sqlite | UUID appears twice in query result | Log warn, process first only | Defensive |
+| Body exceeds 65,536 chars (GitHub limit) | Render produces too-long body | Truncate to 65,400 chars with `\n\n_[truncated]_\n` suffix, UUID comment preserved at end | Defensive |
+
+## Observability
+
+Three layers, passive to active:
+
+**1. Log file** — `~/Library/Logs/majordomo-notes-sync.log`
+
+Structured one-line-per-event:
+
+```
+2026-05-23T18:30:14.221Z [info]  run-start mtime-changed=true
+2026-05-23T18:30:14.245Z [info]  sqlite-query annotations=23 with-notes=8
+2026-05-23T18:30:14.302Z [info]  gh-list existing=15 with-uuid=15
+2026-05-23T18:30:14.302Z [info]  reconcile create=2 update=1 noop=5
+2026-05-23T18:30:15.118Z [info]  issue-created number=87 uuid=4F3A-…-B891
+2026-05-23T18:30:15.802Z [info]  issue-created number=88 uuid=2C81-…-A019
+2026-05-23T18:30:16.504Z [info]  issue-updated number=84 uuid=9B5E-…-F210
+2026-05-23T18:30:16.602Z [info]  run-end ok elapsed-ms=2381
+```
+
+No-op run:
+
+```
+2026-05-23T19:30:00.118Z [info]  run-start mtime-changed=false skip-reason=mtime-stable
+2026-05-23T19:30:00.119Z [info]  run-end ok elapsed-ms=1
+```
+
+Greppable by event type, severity, or UUID. No rotation needed; ~150 bytes per no-op × 8760 hours/year ≈ 1.3 MB/year.
+
+**2. State file counters** — `jq .runs < ~/Library/Application\ Support/majordomo/notes-sync-state.json`.
+
+**3. `npm run sync:notes:status`** — pretty-printed summary including last run time, mtime, log size, LaunchAgent loaded state, lifetime counters, and a fresh `gh issue list` count of open/closed auto-filed issues.
+
+## Testing strategy
+
+Following existing repo convention (`vitest`, co-located `*.test.ts`):
+
+| Test file | Layer | Covers |
+|---|---|---|
+| `build/notes/uuid-parse.test.ts` | unit | Regex extraction. Cases: present, absent, malformed, multiple (take first). |
+| `build/notes/render.test.ts` | unit | Title derivation, body shape, NSDate→ISO conversion (the 2001-epoch footgun), markdown special-char handling, body-length truncation. |
+| `build/notes/reconcile.test.ts` | unit | Action computation. Cases: empty existing, all-noop, mixed create/update/noop. |
+| `build/notes/state.test.ts` | unit | Read/write/migrate. Cases: missing, empty, corrupt JSON, schema v1, future schema → fallback. |
+| `build/notes/sqlite-source.test.ts` | integration | In-memory sqlite seeded with the real Apple Books schema (fixture at `build/notes/__fixtures__/aeannotation.sql`). Asserts `findAssetId` and `listAnnotations` returns. |
+| `build/notes/github-target.test.ts` | integration | Mock `child_process.spawn`, assert correct `gh` arg construction for list/create/edit and correct parsing of `gh`'s JSON output. |
+
+**Schema-drift defense:** the fixture SQL is a checked-in snapshot of the columns we use. If Apple bumps the schema in a future macOS release, the daemon fails one test rather than silently filing zero issues forever.
+
+**Manual smoke tests** (not CI, documented in install output):
+
+1. After `npm run sync:notes:install`, `launchctl print gui/$(id -u)/io.dwk.majordomo.notes-sync` shows it loaded.
+2. Type a test note in Apple Books on iPad with a disposable string. Wait for iCloud + an hour. Confirm an issue appears.
+3. Edit the note, wait, confirm the issue body updates.
+4. `npm run sync:notes` for forced sync without waiting.
+5. `npm run sync:notes:uninstall`; confirm clean teardown.
+
+**CI:** existing `.github/workflows/build.yml` runs type-check + tests + ePub build. New tests slot in unchanged. `better-sqlite3` ships prebuilt binaries for `ubuntu-latest`.
+
+## Files created
+
+```
+build/
+├── notes/
+│   ├── render.ts
+│   ├── render.test.ts
+│   ├── reconcile.ts
+│   ├── reconcile.test.ts
+│   ├── uuid-parse.ts
+│   ├── uuid-parse.test.ts
+│   ├── state.ts
+│   ├── state.test.ts
+│   ├── sqlite-source.ts
+│   ├── sqlite-source.test.ts
+│   ├── github-target.ts
+│   ├── github-target.test.ts
+│   ├── types.ts
+│   └── __fixtures__/
+│       └── aeannotation.sql
+└── scripts/
+    ├── sync-apple-books-notes.ts
+    ├── sync-apple-books-notes-status.ts
+    ├── install-notes-sync.ts
+    ├── uninstall-notes-sync.ts
+    └── notes-sync/
+        └── io.dwk.majordomo.notes-sync.plist.template
+
+docs/
+└── superpowers/
+    └── specs/
+        └── 2026-05-23-apple-books-notes-sync-design.md  ← this file
+```
+
+## Files modified
+
+- `package.json` — add `better-sqlite3` to `dependencies`, `tsx` to `devDependencies`, four `sync:notes*` scripts.
+- `CLAUDE.md` — document `npm run sync:notes*` commands under a new "Apple Books Notes Sync" section.
+
+## Files NOT created
+
+- No `notes/` directory. The architecture pivot from filesystem to GitHub Issues eliminates it.
+- No state file or log file in the repo. User-machine data, not source.
+- No installed plist in the repo. User-machine config.
+
+## Dependencies added
+
+```json
+{
+  "dependencies": {
+    "better-sqlite3": "^12.5.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.0"
+  }
+}
+```
+
+`better-sqlite3` is synchronous, has prebuilt binaries for darwin-arm64/darwin-x64/linux-x64, and supports read-only opens. `tsx` is already implicitly used (via `npx tsx build/embed-xmp.ts` in CLAUDE.md); making it an explicit devDep speeds up daemon fires by avoiding network on each run.
+
+## Build sequence
+
+For the implementation plan, this is the natural construction order — leaves first, trunks last, with each step testable in isolation against what already exists:
+
+1. `types.ts`
+2. `uuid-parse.ts` + test
+3. `render.ts` + test
+4. `reconcile.ts` + test
+5. `state.ts` + test
+6. `sqlite-source.ts` + test (introduces the fixture SQL)
+7. `github-target.ts` + test
+8. `sync-apple-books-notes.ts` (first end-to-end manual run becomes possible here)
+9. `sync-apple-books-notes-status.ts`
+10. `install-notes-sync.ts`, `uninstall-notes-sync.ts`, plist template
+11. `package.json` + `CLAUDE.md`
+
+Steps 1–7 fit a TDD cycle cleanly. Step 8 onward is wiring — manual smoke testing against the real Apple Books library replaces unit tests at that level.
+
+## Versioning
+
+Per `CLAUDE.md`: minor bumps for pipeline changes. This is a new subsystem: `0.3.0 → 0.4.0`. Tag `v0.4.0` when this merges.
+
+## Out of scope
+
+- Two-way sync (editing a GitHub Issue does not propagate back to Apple Books).
+- Syncing highlights from other books in the user's library.
+- Syncing bare highlights (no typed note).
+- Web dashboard or alternate viewers for the synced data.
+- Auto-closing issues when the source Apple Books highlight is deleted.
+- Multi-user support (this is the author's personal workflow).
+- Cross-platform — macOS only; iOS-direct access to its own Apple Books db requires entitlements we don't have.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@djot/djot": "^0.3.2",
         "@google/genai": "^1.48.0",
+        "better-sqlite3": "^12.10.0",
         "dotenv": "^17.4.1",
         "gray-matter": "^4.0.3",
         "jszip": "^3.10.1",
@@ -18,6 +19,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
+        "tsx": "^4.22.3",
         "typescript": "^5.4.0",
         "vitest": "^4.1.2",
         "wrangler": "^4.94.0"
@@ -1778,6 +1780,20 @@
       ],
       "license": "MIT"
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -1787,12 +1803,70 @@
         "node": "*"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -1809,6 +1883,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1863,6 +1943,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1891,6 +1995,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/error-stack-parser-es": {
@@ -1975,6 +2088,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2044,6 +2166,12 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -2055,6 +2183,12 @@
       "engines": {
         "node": ">=12.20.0"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2098,6 +2232,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/google-auth-library": {
       "version": "10.6.2",
@@ -2153,6 +2293,26 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -2163,6 +2323,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/is-extendable": {
@@ -2540,6 +2706,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/miniflare": {
       "version": "4.20260521.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260521.0.tgz",
@@ -2560,6 +2738,21 @@
       "engines": {
         "node": ">=22.0.0"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2584,6 +2777,24 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-domexception": {
@@ -2634,6 +2845,15 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/p-retry": {
       "version": "4.6.2",
@@ -2717,6 +2937,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -2745,6 +2992,31 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
       }
     },
     "node_modules/readable-stream": {
@@ -2953,6 +3225,51 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3001,6 +3318,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -3012,6 +3338,48 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/tinybench": {
@@ -3064,6 +3432,521 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -3353,6 +4236,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.20.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "sharp": "^0.34.5"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.0.0",
         "tsx": "^4.22.3",
         "typescript": "^5.4.0",
@@ -1577,6 +1578,16 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/chai": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
     "dev": "npm run build:site && wrangler dev",
     "test": "vitest run",
     "test:watch": "vitest",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "sync:notes": "tsx build/scripts/sync-apple-books-notes.ts",
+    "sync:notes:status": "tsx build/scripts/sync-apple-books-notes-status.ts",
+    "sync:notes:install": "tsx build/scripts/install-notes-sync.ts",
+    "sync:notes:uninstall": "tsx build/scripts/uninstall-notes-sync.ts"
   },
   "dependencies": {
     "@djot/djot": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "sharp": "^0.34.5"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.0.0",
     "tsx": "^4.22.3",
     "typescript": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@djot/djot": "^0.3.2",
     "@google/genai": "^1.48.0",
+    "better-sqlite3": "^12.10.0",
     "dotenv": "^17.4.1",
     "gray-matter": "^4.0.3",
     "jszip": "^3.10.1",
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "tsx": "^4.22.3",
     "typescript": "^5.4.0",
     "vitest": "^4.1.2",
     "wrangler": "^4.94.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "majordomo",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "ePub and website build pipeline for Majordomo",
   "type": "module",
   "private": true,


### PR DESCRIPTION
Implements #23. Supersedes the April 14 design at [`docs/superpowers/specs/2026-04-14-apple-books-sync-design.md`](docs/superpowers/specs/2026-04-14-apple-books-sync-design.md) (which proposed a `notes/highlights.md` file); the new design at [`docs/superpowers/specs/2026-05-23-apple-books-notes-sync-design.md`](docs/superpowers/specs/2026-05-23-apple-books-notes-sync-design.md) files each typed Apple Books note as a deduped GitHub Issue.

## What this does

- Each typed Apple Books note on *A Majordomo for Everyone* becomes (or updates) one GitHub Issue labelled `from:apple-books`
- Hourly LaunchAgent installed via `npm run sync:notes:install`; WAL-aware mtime guard makes no-op runs nearly free
- Idempotent via `<!-- apple-books-uuid: X -->` HTML-comment dedup — crash-safe, survives state-file loss
- TypeScript reading sqlite directly via `better-sqlite3`; GitHub auth inherits from existing `gh auth login`
- State lives outside the repo (`~/Library/Application Support/majordomo/notes-sync-state.json`)
- No `notes/` directory; no git pushes from the daemon; only API calls

## Implementation

17 commits in leaf-to-trunk build order. Each commit lands a TDD-shaped unit followed by its tests:

| Commit | What |
|---|---|
| `0203485` | Add `better-sqlite3`, `tsx`, `@types/better-sqlite3` |
| `f3c4bc0` | `build/notes/types.ts` — shared interfaces and constants |
| `0352875` | `uuid-parse.ts` — extract `<!-- apple-books-uuid: X -->` |
| `24d311e` | `render.ts` — annotation → issue body (NSDate epoch, title derivation, truncation) |
| `2682f34` | `reconcile.ts` — pure create/update/noop action computation |
| `dc945a3` | `state.ts` — state file read/write/migrate |
| `c4fbf8e` | `sqlite-source.ts` + fixture SQL |
| `37f437e` | Fix sqlite-source type errors (`@types/better-sqlite3` + `fs/promises.glob` → `readdir`) |
| `6a5449d` | `github-target.ts` — `gh` CLI wrappers via `spawnSync` |
| `28712e3` | `sync-apple-books-notes.ts` — daemon entry point |
| `add6df0` | `sync-apple-books-notes-status.ts` — pretty status |
| `7eae916` | Installer/uninstaller + LaunchAgent plist template |
| `fade7ee` | `npm run sync:notes*` scripts + `CLAUDE.md` docs |
| `9977635` | Version bump `0.3.0` → `0.4.0` |
| `0fbfb01` | Post-review reliability fixes (6 in one commit) |

105/105 vitest tests; `npm run build:check` silent.

## Post-review fixes applied before this PR (`0fbfb01`)

The whole-feature code review surfaced 5 Important reliability issues + 1 Node 20.0 compat issue. All fixed before merge:

1. **WAL-aware mtime guard** — Apple Books uses SQLite WAL journaling; iCloud-synced annotations may only touch `.sqlite-wal` until checkpoint. Now stats `.sqlite`, `.sqlite-wal`, and `.sqlite-shm` and uses the max mtime.
2. **Mtime cursor advances only on `exit 0`** — partial failures (e.g., one issue fails to file) no longer poison the next hour's mtime guard.
3. **Per-action transient classification** — rate-limit/DNS errors during `createIssue`/`editIssue` now soft-fail (warn + break) instead of escalating to `exit 1`.
4. **`SQLITE_BUSY` single-retry** — 500ms backoff on db open; if still locked, soft-fail per the spec's failure-mode table.
5. **Defensive UUID dedupe** — `reconcile` now dedupes annotations by UUID before processing, in case sqlite somehow returns two rows with the same UUID.
6. **`fileURLToPath` instead of `import.meta.dirname`** — the latter landed in Node 20.11; `package.json` engines declares `>=20.0.0`.

## Out of scope

Per the design spec:
- Two-way sync (editing a GitHub Issue does not propagate back to Apple Books)
- Syncing other books in the user's library
- Bare highlights (no typed note)
- Auto-closing issues when the source highlight is deleted
- Multi-user, cross-platform

## Verification

- ✅ `npm test` — 105/105 pass
- ✅ `npm run build:check` — silent
- ✅ `npm run sync:notes:status` runs cleanly (smoke-tested)
- ⏳ **Manual end-to-end pending:** `npm run sync:notes:install`, type a test note on iPad in Apple Books, wait for iCloud sync to macOS, verify an issue is filed with the correct body schema. The post-review WAL fix specifically needs this to confirm Apple's WAL behavior matches expectations.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)