### PR TITLE
Renumber Field Guide Skill IDs to close gaps

### DIFF
--- a/spec/architecture.md
+++ b/spec/architecture.md
@@ -54,7 +54,7 @@ PART TWO: THE FIELD GUIDE
 		   W- / C- / Ch- / IRL- / WB- / Cr- / Tr-
 
   Note: Drugs (formerly a separate domain with D- prefix)
-  is merged into the Health domain as H-9 through H-19,
+  is merged into the Health domain as H-9 through H-17,
   introduced by a sub-section heading. The health system
   and the substances it prescribes, regulates, and fails
   to explain are the same structural problem.

--- a/src/content/01-strategies/00-strategy-0-specify/index.dj
+++ b/src/content/01-strategies/00-strategy-0-specify/index.dj
@@ -30,7 +30,7 @@ Every strategy in this book begins here. Before your Agent can Decode, Draft, Na
 
 The insight that makes this book work: *you do not have to write the spec.* Your Agent will interview you into one. Your job is to answer its questions honestly and tell it when the spec it proposes doesn't accurately reflect your situation. That is a human skill you already have. You know your own situation. You just needed someone to ask the right questions.
 
-_In the Field Guide: every Skill begins with a Strategy 0 specification interview. Skills using the Expert Role variant include [Ho-7: Gardening & Landscaping](ref:ho-7), [Ch-9: Pet Care and Training](ref:ch-9), [Tr-2: Car Maintenance](ref:tr-2), and [H-8: Wellness and Nutrition Coach](ref:h-8)._
+_In the Field Guide: every Skill begins with a Strategy 0 specification interview. Skills using the Expert Role variant include [Ho-7: Gardening & Landscaping](ref:ho-7), [Ch-8: Pet Care and Training](ref:ch-8), [Tr-2: Car Maintenance](ref:tr-2), and [H-8: Wellness and Nutrition Coach](ref:h-8)._
 
 ### The Specification Interview Loop
 

--- a/src/content/01-strategies/06-strategy-6-diagnose/index.dj
+++ b/src/content/01-strategies/06-strategy-6-diagnose/index.dj
@@ -45,7 +45,7 @@ I actually need a professional or can handle this myself.
 :::
 
 
-_In the Field Guide: [Ho-1 (Home Maintenance)](ref:ho-1), [Ho-2 (Home Repair)](ref:ho-2), [Tr-2 (Car Maintenance)](ref:tr-2), [Ch-3 (House Plants)](ref:ch-3), [Ch-6 (Optimizing Chores)](ref:ch-6)._
+_In the Field Guide: [Ho-1 (Home Maintenance)](ref:ho-1), [Ho-2 (Home Repair)](ref:ho-2), [Tr-2 (Car Maintenance)](ref:tr-2), [Ch-3 (House Plants)](ref:ch-3), [Ch-5 (Optimizing Chores)](ref:ch-5)._
 
 ### Example 1: A Washing Machine Making a Grinding Noise
 

--- a/src/content/01-strategies/09-strategy-9-create/index.dj
+++ b/src/content/01-strategies/09-strategy-9-create/index.dj
@@ -36,7 +36,7 @@ The failure mode — "I asked it to write me a story and it was generic" — hap
 
 This strategy is about keeping both jobs clearly assigned.
 
-_In the Field Guide: [Cr-2 (Visual Design)](ref:cr-2), [Cr-3 (Editing a Movie)](ref:cr-3), [Cr-9 (Creative Writing)](ref:cr-9), [WB-5 (Building a Website)](ref:wb-5), [WB-8 (Blogging)](ref:wb-8)._
+_In the Field Guide: [Cr-2 (Visual Design)](ref:cr-2), [Cr-3 (Editing a Movie)](ref:cr-3), [Cr-8 (Creative Writing)](ref:cr-8), [WB-5 (Building a Website)](ref:wb-5), [WB-8 (Blogging)](ref:wb-8)._
 
 ---
 

--- a/src/content/02-field-guide/01-health/index.dj
+++ b/src/content/02-field-guide/01-health/index.dj
@@ -839,7 +839,7 @@ John Ehrlichman, Nixon's domestic policy advisor, said in a 1994 interview: _"Th
 
 ---
 
-#### H-22: Mental Health First Aid (Helping Someone in Crisis, Including Yourself)
+#### H-18: Mental Health First Aid (Helping Someone in Crisis, Including Yourself)
 
 *Strategy:* Prepare + Assert + Navigate
 *See also:* H-13: Understanding Addiction (and Finding Help That Works), Li-1: Preparing for a Difficult Conversation, Li-7: Raising Kids

--- a/src/content/02-field-guide/02-money/index.dj
+++ b/src/content/02-field-guide/02-money/index.dj
@@ -446,7 +446,7 @@ To make the Financial Coach persistent across sessions, save the Expert Role as 
 #### M-7: Understanding Your Taxes
 
 *Strategy:* Decode + Prepare
-*See also:* M-1: Banking and Savings (for account types that affect taxes), W-8: Freelancing (1099 vs. W-2 and self-employment tax)
+*See also:* M-1: Banking and Savings (for account types that affect taxes), W-7: Freelancing (1099 vs. W-2 and self-employment tax)
 *My Man Jeeves:* _One observes that the United States is among the very few nations that requires its citizens to calculate what they owe, despite the government already possessing the relevant figures. The Internal Revenue Service knows what one earned — the W-2 and 1099 forms were filed months prior. It knows what one paid in mortgage interest, what one contributed to retirement, what one earned from a savings account. It could, if permitted, simply present the bill. That it does not is the result of a lobbying effort by the tax preparation industry — Intuit, H&R Block, and their associates — which has spent hundreds of millions of dollars ensuring that the process remains sufficiently opaque to require their services. The complexity is the product. One's Agent, however, has read the tax code in the manner the preparers have, and charges rather less for the privilege of explaining it._
 *The Spec:*
 

--- a/src/content/02-field-guide/03-legal/index.dj
+++ b/src/content/02-field-guide/03-legal/index.dj
@@ -148,7 +148,7 @@ The tone of a demand letter matters more than the legal language. Ask your Agent
 
 
 ::: science
-When the other side is a business, a demand letter alone is rarely the strongest move. Filing a regulatory complaint at the same time creates a second pressure point the company cannot ignore. The [CFPB](https://www.consumerfinance.gov/complaint/) reports that companies provide timely responses to roughly 97% of the consumer complaints it forwards, on a statutory clock. State attorneys general run their own consumer divisions, and several --- Massachusetts, California, New York --- are notably active. See L-11 for the full escalation ladder. The demand letter still goes certified mail. The complaint goes online the same day.[^l3-1]
+When the other side is a business, a demand letter alone is rarely the strongest move. Filing a regulatory complaint at the same time creates a second pressure point the company cannot ignore. The [CFPB](https://www.consumerfinance.gov/complaint/) reports that companies provide timely responses to roughly 97% of the consumer complaints it forwards, on a statutory clock. State attorneys general run their own consumer divisions, and several --- Massachusetts, California, New York --- are notably active. See L-10 for the full escalation ladder. The demand letter still goes certified mail. The complaint goes online the same day.[^l3-1]
 :::
 
 
@@ -522,7 +522,7 @@ The paperwork is not the hard part. Asking someone to be your healthcare proxy i
 
 ---
 
-#### L-10: Navigating a Background Check
+#### L-9: Navigating a Background Check
 
 *Strategy:* Decode + Assert
 *See also:* W-1: Getting a Job (where background checks gatekeep employment), Ho-6: Getting a Home (where they gatekeep housing --- rental applications)
@@ -595,7 +595,7 @@ Tenant screening is a separate industry running in parallel to employment backgr
 
 ---
 
-#### L-11: Filing a Consumer Complaint
+#### L-10: Filing a Consumer Complaint
 
 *Strategy:* Assert + Navigate
 *See also:* IRL-2: Customer Service (the conversation --- try this first), L-3: Writing a Demand Letter (the written escalation --- try this second)

--- a/src/content/02-field-guide/04-home/index.dj
+++ b/src/content/02-field-guide/04-home/index.dj
@@ -460,7 +460,7 @@ Disaster impact is not distributed equally. Eric Klinenberg's _Heat Wave_ (2002)
 #### Ho-9: Decluttering and Organizing
 
 *Strategy:* Diagnose + Navigate
-*See also:* Ch-6: Optimizing Manual Chores (for maintaining systems once you build them), Ho-1: Maintaining Your Home (decluttering is maintenance, not renovation)
+*See also:* Ch-5: Optimizing Manual Chores (for maintaining systems once you build them), Ho-1: Maintaining Your Home (decluttering is maintenance, not renovation)
 *My Man Jeeves:* _One hesitates to suggest that the billion-dollar decluttering industry has a financial incentive to make the problem feel spiritual rather than logistical, but one does observe that the rhetoric of "sparking joy" has been rather more profitable for its inventor than for the average person standing in a 400-square-foot apartment wondering where the winter coats are meant to reside. The difficulty is not an excess of sentiment. The difficulty is an insufficiency of space, compounded by an absence of systems. An Agent can assess the space one actually has, propose storage arrangements that function within its constraints, and maintain the one-in-one-out discipline that prevents the problem from recurring --- all without requiring that one hold each object and interrogate one's feelings about it._
 *The Spec:*
 

--- a/src/content/02-field-guide/05-life/index.dj
+++ b/src/content/02-field-guide/05-life/index.dj
@@ -218,7 +218,7 @@ Checking current information requires web search, which is free in Gemini, ChatG
 #### Li-6: Finding Restaurants
 
 *Strategy:* Research + Decide
-*See also:* Li-5: Planning Trips (for restaurants while traveling), Ch-5: Cooking and Culinary Skills (for eating in)
+*See also:* Li-5: Planning Trips (for restaurants while traveling), Ch-4: Cooking and Culinary Skills (for eating in)
 *My Man Jeeves:* _It would appear that the prevailing restaurant recommendation algorithms optimize for establishments that pay for placement or generate engagement, rather than for the most suitable meal in one's vicinity at one's price point for one's actual preferences. Your Agent maintains no paid placements. It will also, one feels compelled to note, refrain from passing judgment should one desire chicken fingers at an establishment with tablecloths._
 *The Spec:*
 

--- a/src/content/02-field-guide/06-work/index.dj
+++ b/src/content/02-field-guide/06-work/index.dj
@@ -17,7 +17,7 @@ George Jetson worked a few hours a day, a few days a week, pushing a single butt
 
 ---
 
-#### W-9: Navigating a Performance Review
+#### W-8: Navigating a Performance Review
 
 *Strategy:* Prepare + Assert
 *See also:* W-3: Working with Human Resources (when the review triggers an HR process), W-2: Leaving a Job (if the review is the writing on the wall), Li-1: Preparing for a Difficult Conversation (same preparation framework)
@@ -85,7 +85,7 @@ If you are placed on a Performance Improvement Plan, read it as what it usually 
 ---
 
 
-#### W-10: Dealing with Workplace Conflict
+#### W-9: Dealing with Workplace Conflict
 
 *Strategy:* Prepare + Navigate
 *See also:* W-3: Working with Human Resources (when the conflict reaches the threshold for HR involvement), Li-1: Preparing for a Difficult Conversation (the underlying skill), W-6: Workplace Safety (when conflict becomes harassment or threats). Russ Harris, [_The Happiness Trap_](https://www.amazon.com/Happiness-Trap-Stop-Struggling-Start/dp/1590305841) (accepting the discomfort of having the conversation instead of avoiding it)
@@ -357,7 +357,7 @@ Workers' comp claim denials follow the same pattern as health insurance denials 
 ---
 
 
-#### W-11: Understanding Your Benefits
+#### W-10: Understanding Your Benefits
 
 *Strategy:* Decode + Decide
 *See also:* M-5: Retirement and Investing (the 401k match is free money — literally), M-8: Insurance (the full picture beyond employer-provided), H-6: Medicare and Medicaid (for comparison if you are approaching 65 or qualifying by income)
@@ -557,7 +557,7 @@ Remote-work isolation is real. Surgeon General Vivek Murthy's 2023 advisory on t
 ---
 
 
-#### W-8: Freelancing and Self-Employment
+#### W-7: Freelancing and Self-Employment
 
 *Strategy:* Navigate + Prepare
 *See also:* M-7: Taxes (1099 complexity is a different animal), L-1: Negotiating a Contract (every engagement needs one), M-8: Insurance (no employer, no group rate)

--- a/src/content/02-field-guide/08-chores/index.dj
+++ b/src/content/02-field-guide/08-chores/index.dj
@@ -15,7 +15,7 @@ _The domestic labor that keeps a household running — shopping, cooking, cleani
 #### Ch-1: Shopping Your Values
 
 *Strategy:* Research + Decide
-*See also:* Ch-5: Cooking and Culinary Skills (for what to do with what you bought), Ho-3: Right-to-Repair (for durable goods), H-8: Wellness and Nutrition Coach (for dietary needs)
+*See also:* Ch-4: Cooking and Culinary Skills (for what to do with what you bought), Ho-3: Right-to-Repair (for durable goods), H-8: Wellness and Nutrition Coach (for dietary needs)
 *My Man Jeeves:* _One might observe that every purchase constitutes a small policy decision, conducted under time pressure with information that is, at best, inadequate. The distinction between "free range" and "cage-free" eggs, for instance, is a regulatory matter that costs the consumer $2 per dozen and approximately an hour of research to verify --- a ratio that would give any reasonable person pause. The difference between a $40 toaster that expires in two years and a $90 toaster that endures for fifteen is, regrettably, invisible at point of sale and conspicuous only in retrospect. In well-staffed households, procurement is handled by persons who source by quality, ethics, durability, and price in whatever combination the household prefers. The remainder of the population is furnished with a label, a search engine optimized for advertising revenue, and eleven minutes before the shop closes. It may be worth noting that one's Agent is capable of evaluating all four dimensions simultaneously, unencumbered by sponsored results._
 *The Spec:*
 
@@ -155,7 +155,7 @@ To make this Expert Role persistent across sessions, save it as a *Project* (Cla
 
 ---
 
-#### Ch-5: Cooking and Culinary Skills
+#### Ch-4: Cooking and Culinary Skills
 
 *Strategy:* Research + Diagnose (Expert Role)
 *See also:* Ch-1: Shopping Your Values (for sourcing ingredients), H-8: Wellness and Nutrition Coach (for dietary guidance)
@@ -191,11 +191,11 @@ To make this Expert Role persistent across sessions, save it as a *Project* (Cla
 :::
 
 
-<!-- EDITORIAL: Expand Ch-5 with additional Expert Role specs: substituting ingredients, knife skills, processing a whole chicken to save money, meal planning for budget and health. -->
+<!-- EDITORIAL: Expand Ch-4 with additional Expert Role specs: substituting ingredients, knife skills, processing a whole chicken to save money, meal planning for budget and health. -->
 
 ---
 
-#### Ch-6: Optimizing Manual Chores
+#### Ch-5: Optimizing Manual Chores
 
 *Strategy:* Diagnose + Navigate (Expert Role)
 *See also:* Ho-1: Maintaining Your Home (for home systems maintenance), H-8: Wellness and Nutrition Coach (when physical limitations affect chore capacity). Oliver Burkeman, [_Four Thousand Weeks_](https://www.amazon.com/Four-Thousand-Weeks-Management-Mortals/dp/0374159122) (accepting finite capacity instead of optimizing your way to burnout)
@@ -250,10 +250,10 @@ The unequal distribution of domestic labor is one of the most documented finding
 
 ---
 
-#### Ch-7: Meal Planning and Grocery Shopping
+#### Ch-6: Meal Planning and Grocery Shopping
 
 *Strategy:* Research + Prepare
-*See also:* Ch-5: Cooking and Culinary Skills (for what to do once you're in the kitchen), Ch-1: Shopping Your Values (for sourcing and certification), Li-9: Household Budget (for the financial side), H-8: Wellness and Nutrition Coach (for dietary needs)
+*See also:* Ch-4: Cooking and Culinary Skills (for what to do once you're in the kitchen), Ch-1: Shopping Your Values (for sourcing and certification), Li-9: Household Budget (for the financial side), H-8: Wellness and Nutrition Coach (for dietary needs)
 *My Man Jeeves:* _One observes that the average household disposes of roughly 30% of the food it purchases --- a figure that would prompt an inquiry at any reasonably managed institution. The difficulty is not, in the main, one of appetite or intention. It is a planning problem conducted under conditions that would defeat most logistics professionals: variable schedules, unpredictable preferences, perishable inventory with no standardized shelf life, and a weekly budget that must account for nutrition, taste, household politics, and whatever happens to be on sale. The household that employs a cook also employs a person who plans meals before writing the shopping list, not after. This is the sequence that matters. One's Agent is capable of working backward from what one wishes to eat, through what one already has, to what one actually needs to buy --- a reversal that reliably reduces both the bill and the bin._
 *The Spec:*
 
@@ -301,10 +301,10 @@ Grocery budgets are not equal, and "healthy eating on a budget" advice that assu
 
 ---
 
-#### Ch-8: Cleaning and Laundry
+#### Ch-7: Cleaning and Laundry
 
 *Strategy:* Research + Navigate (Expert Role)
-*See also:* Ch-6: Optimizing Manual Chores (for scheduling and systems), Ho-1: Maintaining Your Home (cleaning is maintenance)
+*See also:* Ch-5: Optimizing Manual Chores (for scheduling and systems), Ho-1: Maintaining Your Home (cleaning is maintenance)
 *My Man Jeeves:* _It is perhaps worth observing that garment care labels employ a system of hieroglyphics that the International Organization for Standardization published in 1971 and has not, in any meaningful sense, explained to the public since. The triangle means bleach. The circle means dry clean. The number of dots inside the iron means something one has either memorized or has not --- and the consequence of guessing incorrectly is a $60 sweater reduced to a size suitable for a medium-sized cat. Similarly, the cleaning product aisle offers approximately 40 specialized solutions for surfaces that require, in practice, about four. The household that employs staff finds these matters handled by persons who know that wool felts in hot water, that bleach and ammonia must never meet, and that the "stainless" in stainless steel is aspirational. One's Agent possesses this same knowledge and is available at the moment the red wine hits the white shirt, which is to say, the moment it is actually needed._
 *The Spec:*
 
@@ -349,7 +349,7 @@ Bleach and ammonia together produce chloramine gas. This is not a cleaning hack.
 
 ---
 
-#### Ch-9: Pet Care and Training
+#### Ch-8: Pet Care and Training
 
 *Strategy:* Research + Navigate (Expert Role)
 *See also:* H-8: Wellness and Nutrition Coach (same Expert Role pattern for a different species), Ch-1: Shopping Your Values (pet food and products), Li-1: Difficult Conversations (for end-of-life decisions with your vet)
@@ -427,10 +427,10 @@ To make this Expert Role persistent across sessions, save it as a *Project* (Cla
 
 ---
 
-#### Ch-10: Seasonal Maintenance
+#### Ch-9: Seasonal Maintenance
 
 *Strategy:* Prepare + Navigate
-*See also:* Ho-1: Maintaining Your Home (for ongoing maintenance), Ho-2: Home Repair and DIY (for when maintenance reveals a repair), Ch-6: Optimizing Manual Chores (for scheduling the recurring tasks)
+*See also:* Ho-1: Maintaining Your Home (for ongoing maintenance), Ho-2: Home Repair and DIY (for when maintenance reveals a repair), Ch-5: Optimizing Manual Chores (for scheduling the recurring tasks)
 *My Man Jeeves:* _A house, if one may observe, operates on a calendar that its occupants rarely consult. The gutters require attention in autumn. The HVAC filters require replacement quarterly. The water heater requires flushing annually --- a task that a vanishingly small fraction of homeowners perform, the remainder discovering the consequence when the unit fails, which it does, on average, at the ten-year mark, on a Saturday, when plumbers charge emergency rates. The difficulty is not that these tasks are complex. Most require thirty minutes and no specialized skill. The difficulty is that no one tells you they need doing until the consequence arrives, at which point the cost of the repair is several multiples of the cost of the prevention. In a properly maintained household, one finds a seasonal checklist and a person who follows it. One's Agent can produce the checklist. The person, regrettably, must be supplied independently._
 *The Spec:*
 
@@ -479,7 +479,7 @@ Renters: most of this checklist is your landlord's responsibility, and they may 
 
 ---
 
-#### Ch-11: Managing Subscriptions and Recurring Costs
+#### Ch-10: Managing Subscriptions and Recurring Costs
 
 *Strategy:* Decode + Assert
 *See also:* M-1: Understanding Your Bank Account (for spotting charges), M-2: Understanding Your Credit Card Statement (for the audit trail), IRL-2: Customer Service Calls (for the cancellation call)

--- a/src/content/02-field-guide/11-creative/index.dj
+++ b/src/content/02-field-guide/11-creative/index.dj
@@ -189,10 +189,10 @@ For editing advice and step-by-step software guidance, any major AI tool works w
 
 ---
 
-#### Cr-5: Making Music
+#### Cr-4: Making Music
 
 *Strategy:* Create + Navigate
-*See also:* Cr-11: Learning an Instrument (the performance side), Cr-6: Podcasting and Audio Production (audio skills transfer), WB-1: Learning Any App or Digital Skill
+*See also:* Cr-10: Learning an Instrument (the performance side), Cr-5: Podcasting and Audio Production (audio skills transfer), WB-1: Learning Any App or Digital Skill
 *My Man Jeeves:* _One observes that a recording studio charges $50 to $500 an hour, that a music production course at a community college runs $800 to $2,000 per semester, and that the instruments alone — even before one considers microphones, cables, and the various boxes that make sounds louder or different — represent an investment that has historically excluded anyone who could not first afford the investment. The difficulty, if one may say so, is not musical. [GarageBand](https://en.wikipedia.org/wiki/GarageBand) ships free with every Apple device. [BandLab](https://en.wikipedia.org/wiki/BandLab_Technologies) runs in a browser and costs nothing. Between them, one has access to more instruments, effects, and recording capability than the Beatles had at Abbey Road in 1967. What one does not have — and what no free tool provides — is the craft knowledge: why a chord progression feels finished, why a rhythm track feels alive or mechanical, why a melody stays in someone's head or doesn't. Those of considerable means retain a producer. The reader now has an Agent conversant with music theory, arrangement, and the specific capabilities of whichever free tool sits open on their screen._
 *The Spec:*
 
@@ -253,10 +253,10 @@ GarageBand ships free on every Apple device. [BandLab](https://www.bandlab.com/)
 
 ---
 
-#### Cr-6: Podcasting and Audio Production
+#### Cr-5: Podcasting and Audio Production
 
 *Strategy:* Create + Navigate
-*See also:* Cr-5: Making Music (audio skills transfer), WB-5: Build a Website, Own Your Corner of the Internet, Cr-3: Editing a Movie (same storytelling principles)
+*See also:* Cr-4: Making Music (audio skills transfer), WB-5: Build a Website, Own Your Corner of the Internet, Cr-3: Editing a Movie (same storytelling principles)
 *My Man Jeeves:* _It may be worth observing that podcasting is the most democratic broadcast medium to emerge in some time. The equipment required is a telephone and a quiet room. The cost of distribution is zero — [RSS](https://en.wikipedia.org/wiki/RSS) is an open standard that no company owns and no company can revoke. A radio license costs hundreds of thousands of dollars and requires federal permission. A YouTube channel requires a camera, lighting, and the willingness to be looked at. A podcast requires a voice, a topic, and the ability to press record. The difficulty, if one may venture it, is not the recording. It is everything that separates a recording from a show: structure, pacing, the edit that removes the forty-five seconds of throat-clearing at the top, the audio quality that lets the listener forget they are listening to audio at all. Those of substantial means hire a producer. The reader has an Agent who is conversant with the entire production chain, from microphone placement to RSS feed configuration, and who has never once suggested that the reader needs a $400 microphone to begin._
 *The Spec:*
 
@@ -309,7 +309,7 @@ Podcast discoverability algorithms favor shows that publish consistently on a sc
 
 ---
 
-#### Cr-7: Drawing and Illustration
+#### Cr-6: Drawing and Illustration
 
 *Strategy:* Create + Diagnose
 *See also:* Cr-2: Learning Visual Design (principles overlap), Cr-1: Taking Better Photos (same compositional eye)
@@ -369,7 +369,7 @@ AI image generators can produce illustrations, but that is not what this Skill i
 
 ---
 
-#### Cr-8: Crafts and Maker Projects
+#### Cr-7: Crafts and Maker Projects
 
 *Strategy:* Create + Research
 *See also:* Ho-2: Home Repair and DIY (tool skills transfer), Ho-3: Right to Repair (same philosophy of ownership), Ch-1: Shopping Your Values (materials sourcing)
@@ -433,7 +433,7 @@ Makerspaces are not evenly distributed. They cluster in cities, near universitie
 
 ---
 
-#### Cr-9: Creative Writing
+#### Cr-8: Creative Writing
 
 *Strategy:* Create + Draft
 *See also:* WB-8: Blogging and Journaling (a regular writing practice), Li-2: Writing a Eulogy (specific application of craft under pressure)
@@ -499,7 +499,7 @@ Write in plain text. A `.txt` or `.md` file will outlast every proprietary forma
 
 ---
 
-#### Cr-10: Graphic Design for Real Life
+#### Cr-9: Graphic Design for Real Life
 
 *Strategy:* Create + Draft
 *See also:* Cr-2: Learning Visual Design (the principles behind the practice), WB-5: Build a Website, Own Your Corner of the Internet, W-1: Getting a Job (resume design)
@@ -555,10 +555,10 @@ Resume design deserves a specific note: applicant tracking systems (ATS) — the
 
 ---
 
-#### Cr-11: Learning an Instrument
+#### Cr-10: Learning an Instrument
 
 *Strategy:* Create + Research (Expert Role)
-*See also:* Cr-5: Making Music (the production side), Li-12: Developing a Habit (the practice discipline)
+*See also:* Cr-4: Making Music (the production side), Li-12: Developing a Habit (the practice discipline)
 *My Man Jeeves:* _A matter of some delicacy arises when one considers the learning of a musical instrument as an adult. Private music lessons run $30 to $80 per session, weekly, for a duration that competent instructors describe as "indefinite" — a term that, in financial contexts, one would regard with some suspicion. Group classes at community music schools cost $150 to $400 per term and proceed at the pace of the least prepared student. The instruments themselves range from $50 for a serviceable ukulele to figures one prefers not to contemplate for a piano. The greater difficulty, however, is not financial. It is that learning an instrument as an adult is slow, physically uncomfortable, and acutely humbling in a way that few other skills replicate. One's fingers do not cooperate. The sounds one produces bear no resemblance to the sounds one intended. Progress is measured in weeks, not hours. Those who persevere acquire a skill that research identifies as uniquely beneficial to cognitive health, emotional regulation, and the particular satisfaction of making a sound that is, at last, the sound one meant to make. One's Agent cannot hold the instrument. It can, however, design the practice routine, explain the theory, diagnose the plateau, and maintain the patient, unhurried encouragement that a $60-per-hour instructor provides in rather more limited supply._
 *The Spec:*
 

--- a/src/content/02-field-guide/99-transportation/index.dj
+++ b/src/content/02-field-guide/99-transportation/index.dj
@@ -246,10 +246,10 @@ Road trip preparation is class-coded. Wealthier families have newer cars, AAA me
 
 ---
 
-#### Tr-7: Understanding Rideshare and Delivery Gig Work
+#### Tr-6: Understanding Rideshare and Delivery Gig Work
 
 *Strategy:* Research + Decode
-*See also:* W-8: Gig Work and Self-Employment, M-7: Taxes
+*See also:* W-7: Gig Work and Self-Employment, M-7: Taxes
 *My Man Jeeves:* _The rideshare arrangement presents a matter of some interest from both sides of the transaction. The passenger perceives a taxi that has been made more convenient; the driver perceives a job that has been made less stable. The company, one might note, has structured the arrangement so that neither party is in full possession of how the pricing works. Surge pricing is presented to the passenger as supply and demand. To the driver, the surge multiplier and the fare the passenger pays are not, as it happens, the same number. One's Agent can decode both sides of this equation --- which is rather the point._
 *The Spec:*
 
@@ -293,7 +293,7 @@ _"I spent $[amount] on rideshares last month. Based on my typical trips, would a
 
 ---
 
-#### Tr-8: Navigating International Travel
+#### Tr-7: Navigating International Travel
 
 *Strategy:* Prepare + Navigate
 *See also:* Tr-4: Air Travel, IRL-3: First-Time Situations, Li-5: Planning Trips
@@ -346,7 +346,7 @@ Ask your Agent to compare Global Entry, TSA PreCheck, and CLEAR. Global Entry ($
 
 ---
 
-#### Tr-9: Accessible Transportation
+#### Tr-8: Accessible Transportation
 
 *Strategy:* Assert + Navigate
 *See also:* Tr-3: Public Transit, Cycling, and Walkability, C-7: Disability Rights
@@ -399,7 +399,7 @@ U.S. airlines mishandled 11,527 wheelchairs and scooters in 2023 --- roughly 31 
 
 ---
 
-#### Tr-10: Electric Vehicles and the Transition
+#### Tr-9: Electric Vehicles and the Transition
 
 *Strategy:* Research + Decide
 *See also:* Tr-1: Car Ownership, M-10: Big Financial Decisions
@@ -453,7 +453,7 @@ The EV transition has a class problem. Federal tax credits require enough tax li
 
 ---
 
-#### Tr-11: Boating, RVs, and Niche Vehicles
+#### Tr-10: Boating, RVs, and Niche Vehicles
 
 *Strategy:* Research + Navigate
 *See also:* Tr-1: Car Ownership, M-8: Insurance


### PR DESCRIPTION
Closes the numbering gaps in the Field Guide Skill IDs (holes left by earlier removals/renumberings: Ch-4, Cr-4, H-18–21, L-9, Tr-6, W-7). Each domain's higher IDs shift down so every domain is contiguous:

| Domain | Before | After |
|-|-|-|
| Chores | Ch-5…Ch-11 | Ch-4…Ch-10 |
| Creative | Cr-5…Cr-11 | Cr-4…Cr-10 |
| Health | H-22 | H-18 |
| Legal | L-10, L-11 | L-9, L-10 |
| Transportation | Tr-7…Tr-11 | Tr-6…Tr-10 |
| Work | W-8…W-11 | W-7…W-10 |

H-6b (Medicaid, deliberately paired with H-6 Medicare) is unchanged. Headings, prose cross-references, and `ref:` tags were all updated together — the build resolves all 131 ref targets with zero warnings, and all 110 tests pass.

Also corrects `spec/architecture.md`: the Drugs sub-section merged into Health spans H-9 through H-17, not H-19.

https://claude.ai/code/session_01VmUUUMRUfMJnu1vRmdcuVA

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmUUUMRUfMJnu1vRmdcuVA)_