### PR TITLE
Fill the Work chapter's artwork gap; complete WB-1's icon set

### DIFF
--- a/src/content/02-field-guide/06-work/benefits-summary-annotated.art.md
+++ b/src/content/02-field-guide/06-work/benefits-summary-annotated.art.md
@@ -1,0 +1,31 @@
+---
+format: png
+size: full
+alt: >
+  An open-enrollment benefits summary with the 401(k) match, the HSA/FSA
+  choice, and the vesting schedule circled and explained in the margin.
+---
+
+Hand-drawn #2 pencil sketch of a single-page open-enrollment benefits summary, lying flat on a pure white field. Standard layout: a header block ("2026 Benefits Enrollment"), a table of plan options (health plan tiers, an HSA line and an FSA line, a retirement-match row, disability and life insurance rows), and an enrollment-deadline line at the bottom.
+
+The text and numbers are fictional and illustrative --- a placeholder employer ("Sample Co."), generic plan names ("Plan A / Plan B"), example dollar amounts and percentages that read as round demonstration values, no real employer, no real benefits vendor or insurance carrier.
+
+Key line items annotated in blue ballpoint pen:
+
+- A circle around the **401(k) employer match** row, margin note: "free money --- get the full match"
+- A circle around the **HSA** line and the **FSA** line together, margin note: "not the same account --- ask which one fits"
+- A pencil arrow pointing at the **vesting schedule** footnote, margin note: "what you lose if you leave early"
+- A circle around the **enrollment deadline**, margin note: "the default isn't chosen for you --- it's chosen for them"
+
+The annotations are in the same hand as the rest of the book --- competent block writing, slightly uneven, the kind of margin notes someone makes the first time they read the packet all the way through.
+
+**No meta-elements --- non-negotiable.** The illustration contains only the summary sheet and its pen annotations. No color swatches, palettes, legends, keys, hex codes, callout boxes outside the page, sidebar text, or any UI explaining the colors or technique. No "EXAMPLE" watermark stamped across the page.
+
+**Background: pure white, `#FFFFFF`, flat.** Not gray, not off-white, not cream, not paper texture, not a notebook page, not a desk grain. The summary is the only object; the field around it is pure white. The build removes white to create transparency, so any gray will show as a halo in the ePub.
+
+**Watch out for:**
+
+- NO real employer name or logo
+- NO real benefits vendor or insurance carrier name --- no Fidelity, Aetna, MetLife, or any other real logo
+- NO highlighter rectangles --- annotations are pen circles, an arrow, and margin notes
+- NO graph paper or ruled-paper backing --- the summary prints on plain stock

--- a/src/content/02-field-guide/06-work/index.dj
+++ b/src/content/02-field-guide/06-work/index.dj
@@ -244,6 +244,8 @@ Give me the legal answer, not the political one.
 :::
 *What to do with the Output:* If you are organizing, do not discuss it on company devices, in company channels, or during work hours until you understand your protections. Your Agent can explain the legal framework, but a labor attorney or your regional NLRB office is the authoritative source for your specific situation. Many labor attorneys offer free initial consultations for organizing questions.
 
+[union-authorization-card]{.art}
+
 ::: tip
 _"I have a collective bargaining agreement I don't fully understand. [Paste relevant section.] What does this actually mean for me day-to-day, and what rights does it give me that I'm probably not using?"_
 :::
@@ -552,6 +554,8 @@ What I need:
 5. Tell me what most people in my situation get wrong
 :::
 *What to do with the Output:* Make the enrollment decisions during enrollment, not after. The most expensive benefit mistake is not choosing the wrong plan — it is not choosing at all and defaulting into whatever the company selected for you, which is optimized for the company's cost, not your coverage. The second most expensive mistake is not contributing enough to get the full employer match. That is a 50--100% return on your money, guaranteed. No investment you will ever make beats it.
+
+[benefits-summary-annotated]{.art}
 
 ::: science
 A Financial Engines analysis found that approximately one in four employees do not contribute enough to their 401(k) to receive the full employer match — leaving an average of $1,336 per person per year in uncollected compensation.[^w10-1] Over a 30-year career at a conservative 7% return, that single decision costs approximately $126,000. The money is contractually yours. You simply have to claim it.

--- a/src/content/02-field-guide/06-work/union-authorization-card.art.md
+++ b/src/content/02-field-guide/06-work/union-authorization-card.art.md
@@ -1,0 +1,31 @@
+---
+format: png
+size: half-left
+alt: >
+  A union authorization card with the authorization statement underlined
+  and the signature and date lines circled.
+---
+
+Hand-drawn #2 pencil sketch of a union authorization card ("card check" card), a single small card lying flat on a pure white field. Standard authorization-card format: a short header line, a paragraph of authorization language, and a signature block at the bottom.
+
+The text is fictional and illustrative --- a placeholder union name ("Local 000, United Workers"), no real local number, no real international union name or logo, no real employer.
+
+Key phrases marked in ballpoint pen:
+
+- A blue underline beneath "I authorize [Union] to represent me for the purposes of collective bargaining"
+- A red circle around the **signature** line and the **date** line
+- A pencil margin note beside the signature line: "this is the only thing that makes it official"
+
+The card sits flat on the page --- a single object, no clipboard, no hand holding a pen, no desk surface, no stack of other cards, no union hall backdrop.
+
+**No meta-elements --- non-negotiable.** The illustration contains only the card and its annotations. No color swatches, palettes, legends, keys, hex codes, callout boxes outside the card, sidebar text, or any UI explaining the colors or technique.
+
+**Background: pure white, `#FFFFFF`, flat.** Not gray, not off-white, not cream, not paper texture, not a notebook page, not a desk grain. The card is the only object; the field around it is pure white. The build removes white to create transparency, so any gray will show as a halo in the ePub.
+
+**Watch out for:**
+
+- NO real union name, local number, or international affiliation --- no AFL-CIO, SEIU, Teamsters, UAW, or any other real logo or wordmark
+- NO real employer name
+- NO highlighter rectangles --- annotations are pen underlines, a circle, and a margin note
+- NO graph paper or ruled-paper backing --- the card is on plain unlined stock
+- NO photographic realism --- this is a pencil drawing of a card, not a scan of one

--- a/src/content/02-field-guide/10-computer-and-web/hypercard-icon.art.md
+++ b/src/content/02-field-guide/10-computer-and-web/hypercard-icon.art.md
@@ -1,0 +1,25 @@
+---
+format: png
+size: margin
+alt: >
+  The original HyperCard icon — a small stack of index cards — on a Mac
+  System 7 desktop.
+---
+
+The original HyperCard icon from the late 80s / early 90s, rendered in 8-bit pixel art as it would appear at 32x32 on a Mac System 7 desktop. The icon: a small **stack of index cards**, shown at a slight three-quarter angle, three or four cards deep, each card's edge visible as a stepped offset behind the one in front. The top card is blank --- Recycled/off-white fill with a thin Charcoal outline. A faint horizontal rule line or two suggested on the top card's face --- a hint of ruled content, not readable text.
+
+**Mac System 7 framing:** The icon sits on a small white square the same width as the icon plus a one-pixel border, with a two-pixel charcoal drop shadow offset down and right --- the unmistakable System 7 desktop icon presentation. The square sits alone on a pure white background. No filename label, no surrounding desktop, no menu bar, no other icons.
+
+**Palette (from the master palette):** Recycled for the card faces, Charcoal and Black for the outlines and the stacked-card shadow lines, Warm Gray for the soft shadow beneath the stack. No more than four colors total.
+
+**True pixel grid --- non-negotiable.** This is actual 8-bit pixel art at ~32x32 enlarged with nearest-neighbor scaling, not a 3D render and not a blocky illustration. Every pixel the same size. Hard edges between colors, no anti-aliasing, no smooth curves --- the card corners are stair-stepped pixel jumps, not rounded. The viewer should be able to count individual pixels along any edge.
+
+**No meta-elements --- non-negotiable.** No "HyperCard" wordmark inside the image, no caption, no version number, no Apple logo, no color swatches, no hex codes, no UI chrome beyond the System 7 icon tile itself.
+
+**Background: pure white, `#FFFFFF`, flat.** Not gray, not off-white, not cream, not paper texture, not a notebook page, not a desktop pattern. The build removes white to create transparency, so any gray will show as a halo in the ePub.
+
+**Watch out for:**
+
+- NO hand or cursor icon overlaid on the cards --- just the stack itself
+- NO readable text on any card face --- only suggestion-of-rule-lines
+- NO modern "index card" or "sticky note" app icon style --- this is the flat early-90s System 7 look

--- a/src/content/02-field-guide/10-computer-and-web/index.dj
+++ b/src/content/02-field-guide/10-computer-and-web/index.dj
@@ -33,7 +33,7 @@ _Before the web, before the website, before the blog — there is the machine on
 
 #### WB-1: Learning Any App or Digital Skill
 
-<!-- image idea: #2 sketch of hypercard's icon -->
+[hypercard-icon]{.art}
 
 *Strategy:* Decode + Navigate
 *See also:* WB-7: Write in CommonMark, the Language of AI (a specific digital skill)


### PR DESCRIPTION
## Summary

A full audit of the book's 43 art briefs against `spec/illustration/illustration-instructions.md` and the Gen-X reader persona in `spec/editorial/voice-and-audience.md` found the existing artwork disciplined and well-curated — no removals warranted. The audit did surface one real gap: the **Work** domain chapter (9 Skills, including Unions and Benefits — both highly relevant to the DSA-adjacent reader persona) had zero artwork, and `WB-1: Learning Any App or Digital Skill` had a leftover `<!-- image idea: #2 sketch of hypercard's icon -->` scratch comment nobody had followed up on.

- **`union-authorization-card.art.md`** (W-5: Unions) — a hand-drawn union authorization card with the authorization language and signature/date lines annotated, matching the existing "functional letter you'd actually use" treatment (`debt-validation-letter`).
- **`benefits-summary-annotated.art.md`** (W-10: Understanding Your Benefits) — an annotated open-enrollment packet calling out the 401(k) match, HSA vs. FSA, and vesting schedule, matching the existing annotated-document treatment (`eob-annotated`, `closing-disclosure-annotated`).
- **`hypercard-icon.art.md`** (WB-1) — a System-7-style HyperCard stack icon, completing the vintage-computing icon set alongside `applescript-icon`, `eliza-icon`, and `mosaic-icon`; replaces the stray scratch comment.

All three follow the established brief structure (frontmatter + production brief with "No meta-elements," "Background," and "Watch out for" sections) and are wired into their chapters at the same placement pattern used by sibling art (right after "What to do with the Output" for the two functional documents; directly under the Skill heading for the icon, matching the existing `it-crowd-ipad`/`habit-tracker` pattern).

## Test plan

- [x] `npm run build:check` — passes
- [x] `npm run build` — passes; all three new refs resolve (47 art briefs found, 0 broken refs); images not yet generated so they render as the standard placeholder box
- [x] `npm test` — 110/110 passing
- [ ] `npm run build -- --generate` to produce the actual PNGs (not run in this session — image generation wasn't requested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)