### PR TITLE
Wire tap-to-define glossary into Appendix I

### DIFF
--- a/src/content/04-appendices/08-appendix-i-spec-literacy/index.dj
+++ b/src/content/04-appendices/08-appendix-i-spec-literacy/index.dj
@@ -114,11 +114,11 @@ This is a standalone unit. It fits inside English Language Arts, Social Studies,
 
 This unit maps to existing standards without requiring new ones:
 
-- *[Common Core ELA](https://www.thecorestandards.org/ELA-Literacy/W/8/) (W.8.4, W.8.5):* Clear, coherent writing appropriate to task and audience; developing and strengthening writing through planning, revising, and editing.
-- *Common Core ELA (SL.8.1):* Collaborative discussions with diverse partners, building on others' ideas and expressing their own clearly.
-- *[Common Core ELA](https://www.thecorestandards.org/ELA-Literacy/RI/8/) (RI.8.4, RI.8.6):* Determining meaning of words and phrases in a text; determining author's point of view or purpose.
-- *[ISTE Student Standards](https://iste.org/standards/students) (1.1, 1.5, 1.6):* Empowered learner, computational thinker, creative communicator.
-- *CASEL SEL competencies:* Self-awareness (identifying what you need), social awareness (audience and context), responsible decision-making.
+- *[Common Core ELA](https://www.thecorestandards.org/ELA-Literacy/W/8/):* [(W.8.4, W.8.5)]{.gloss def="W = the Writing domain. The numbers are grade 8, standard items 4 and 5."} Clear, coherent writing appropriate to task and audience; developing and strengthening writing through planning, revising, and editing.
+- *Common Core ELA:* [(SL.8.1)]{.gloss def="SL = the Speaking & Listening domain. The number is grade 8, standard item 1."} Collaborative discussions with diverse partners, building on others' ideas and expressing their own clearly.
+- *[Common Core ELA](https://www.thecorestandards.org/ELA-Literacy/RI/8/):* [(RI.8.4, RI.8.6)]{.gloss def="RI = the Reading: Informational Text domain. The numbers are grade 8, standard items 4 and 6."} Determining meaning of words and phrases in a text; determining author's point of view or purpose.
+- *[ISTE Student Standards](https://iste.org/standards/students):* [(1.1, 1.5, 1.6)]{.gloss def="International Society for Technology in Education standards: 1.1 Empowered Learner, 1.5 Computational Thinker, 1.6 Creative Communicator."} Empowered learner, computational thinker, creative communicator.
+- [CASEL]{.gloss def="Collaborative for Academic, Social, and Emotional Learning — the organization that defines the SEL competency framework referenced here."} *SEL competencies:* Self-awareness (identifying what you need), social awareness (audience and context), responsible decision-making.
 
 No new standard is required. Specification literacy is what these standards describe when they are taken seriously rather than assessed by multiple choice.
 


### PR DESCRIPTION
## Summary

Follow-up to #132, which added the `[Term]{.gloss def="..."}` tap-to-define span (a native `<details>`/`<summary>` disclosure, no JS) and wired it into Appendix G. This applies it to a second appendix.

- Appendix I's "Alignment to Standards" list cites Common Core domain codes (`W.8.4`, `SL.8.1`, `RI.8.4`/`RI.8.6`), ISTE item numbers (`1.1`, `1.5`, `1.6`), and the CASEL acronym — exactly the kind of jargon that gate-keeps understanding for the appendix's actual audience (the "Note to Teachers" / "Note to Parents" sections), but would clutter the prose if spelled out inline every time.
- Each code cluster and the CASEL acronym is now a `.gloss` span, e.g. `(W.8.4, W.8.5)` → tap to reveal "W = the Writing domain. The numbers are grade 8, standard items 4 and 5."
- Constraint from #132 still applies: `<details>` can't nest inside `<strong>` or `<a>` (phrasing content only). The original markdown wrapped the whole label + code in bold (`*[Common Core ELA](url) (W.8.4, W.8.5):*`), so each bullet was restructured to close the bold/link on the label only, then place the `.gloss` span as a sibling — still a direct child of the `<li>`, which is a valid flow-content container.

## Test plan

- [x] `npm run build:check` — type-checks clean
- [x] `npm test` — 113/113 pass (no code changes this time, just content)
- [x] `npm run build` — full ePub build succeeds; extracted `08-appendix-i-spec-literacy.xhtml` and confirmed each `<details class="gloss">` renders as a sibling of `<strong>`/`<a>` inside its `<li>`, never nested inside them, and the file is well-formed XML


---
_Generated by [Claude Code](https://claude.ai/code/session_01WYPkDMhjG7yWNYE8nUaSkB)_