### PR TITLE
Add fairness callouts on training data/bias, trim CEO quotes

### DIFF
--- a/spec/social-media/facebook.md
+++ b/spec/social-media/facebook.md
@@ -1,0 +1,33 @@
+# Majordomo — Book Marketing Package
+
+## Cover
+
+**Majordomo: Billionaires have staff, now you do too.**
+
+---
+
+## Facebook Launch Post
+
+Been thinking a lot about what billionaires actually buy with all that money. Not yachts. Not islands. Those are the props. What they actually buy is people — a chef who knows how they like their eggs, an assistant who handles the DMV, a house manager who remembers the filter needs changing. Staff. That's the real product of wealth. Everything else is decoration.
+
+So I wrote a book about how the rest of us can use AI as a tool to have that too.
+
+*Majordomo: Billionaires have staff, now you do too.*
+
+Link in the comments.
+
+**First comment:** https://majordomo.dwk.io
+
+---
+
+## Art Brief for Launch Image
+
+**Concept:** A single-frame visual joke that lands before the caption is read. Two side-by-side vignettes, same composition, same lighting, different century.
+
+**Left panel:** A 1920s-era wealthy household. Oil painting style or sepia photograph treatment. A well-dressed man at a writing desk in a wood-paneled study. Standing slightly behind and to his left, a butler in tails holding a silver tray with correspondence. Warm lamplight. The butler is attentive but composed — he's been doing this a long time.
+
+**Right panel:** A present-day equivalent. Same composition exactly — person at a desk, figure behind and to the left holding something on a tray. But the desk is an IKEA Linnmon in a cluttered home office, the person is in a hoodie, and the "butler" is the same butler — same tails, same posture, same silver tray — holding a MacBook instead of letters. The lighting matches the left panel's warmth. He is equally composed. He has simply arrived at a different address.
+
+**Tone:** Not a meme. Not comic-book. Treat it like a New Yorker illustration or a Chris Ware panel — quiet, well-composed, the humor in the details rather than in any exaggerated expression. No text on the image itself. The book cover can appear as a small object on the desk in the right panel if you want a subtle callout, but it shouldn't dominate.
+
+**What it's doing:** The visual argument is that staff is staff regardless of century or class. The butler hasn't changed. The only thing that's changed is who gets to have him. That's the whole thesis of the book in one image, and it lets the caption do the political work without the image having to shout.

--- a/src/content/00-introduction/03-chapter-01-what-these-tools-are/index.dj
+++ b/src/content/00-introduction/03-chapter-01-what-these-tools-are/index.dj
@@ -35,9 +35,9 @@ Data couldn't feel, but he understood meaning — seriously, thoroughly, with ev
 
 The more politically honest version: the billionaire class has always had access to humans who do what these tools do. The family lawyer on retainer who reads the lease and flags the three clauses that matter. The accountant who explains the tax situation without making it a billable hour. The doctor who picks up the phone and translates what the specialist said into what it actually means for the patient. The chief of staff who handles every piece of institutional friction before it reaches the principal. That infrastructure of expertise has always been distributed by class. These tools are the first genuinely useful crack in that wall.
 
-Do not take my word for it. Sam Altman, CEO of OpenAI: "AI has to be democratized; power cannot be too concentrated. Control of the future belongs to all people and their institutions."[^1-1] Mark Zuckerberg released Meta's AI models as open source specifically so "power isn't concentrated in the hands of a small number of companies."[^1-2] Satya Nadella at Microsoft called it "giving people more agency and making technology more accessible through the most universal interface — natural language."[^1-3] And Dario Amodei, CEO of Anthropic, described the goal with startling specificity: "a very thoughtful and informed AI whose job is to give you everything you're legally entitled to by the government in a way you can understand."[^1-4]
+Do not take my word for it. Sam Altman, CEO of OpenAI: "AI has to be democratized; power cannot be too concentrated. Control of the future belongs to all people and their institutions."[^1-1] Dario Amodei, CEO of Anthropic, put it more specifically: "a very thoughtful and informed AI whose job is to give you everything you're legally entitled to by the government in a way you can understand."[^1-4]
 
-That last one is the thesis of this book, written by the CEO of the company that makes Claude. You do not have to trust his motives — or mine, or any of theirs. Trust is not the operating principle here. Usefulness is. The tool works. Even the people who profit from it describe what it does in terms that sound like a consumer rights pamphlet. When the billionaire class starts using your language, pay attention.
+That last one is the thesis of this book, written by the CEO of the company that makes Claude. You do not have to trust his motives — or mine, or his competitors'. Trust is not the operating principle here. Usefulness is. The tool works. Even the people who profit from it describe what it does in terms that sound like a consumer rights pamphlet. When the billionaire class starts using your language, pay attention.
 
 *What they can do:*
 - Read any document you paste in and explain it in plain language
@@ -57,6 +57,16 @@ That last one is the thesis of this book, written by the CEO of the company that
 
 ::: fairness
 Nilay Patel at The Verge calls it _software brain_: the tech-industry habit of treating the world as a series of databases to be managed with structured language and code.[^1-6] It is why [DOGE](https://en.wikipedia.org/wiki/Department%5Fof%5FGovernment%5FEfficiency) failed — a country is not a database — and why the smart-home decade produced mostly things no one asked for. Software brain is what is being done _to_ you when an insurer replaces its appeals desk with a model trained to deny claims, when a landlord screens applicants through an algorithm, when a hospital bills by code instead of by visit. This book is about the other direction — the same class of tool, on your side of the table, reading the database back to you in plain language. The distinction is the whole game. Notice which one you are looking at.
+:::
+
+
+::: fairness
+The text these models trained on includes books, art, code, and tutorials scraped without asking; lawsuits are pending and consent frameworks do not yet exist.[^1-9] You did not cause this and cannot personally fix it — the structural remedy is licensing and labor law, not individual abstention. Use the tool, support the artists you can, back the policy when it shows up.
+:::
+
+
+::: fairness
+AI tools produce fluent, confident-sounding text whether or not the underlying claim is true, and a 2026 MIT study found accuracy degrades further for users phrasing questions in non-standard English, asking about underrepresented conditions, or reading at lower literacy levels — the same populations historically underserved by every other expert system.[^1-10] Verify anything with real consequences against a primary source. The fluency is not the proof.
 :::
 
 ---
@@ -87,10 +97,6 @@ You are not one input among many, to be weighted and averaged with the machine's
 
 [^1-1]: Altman, S. (2025). [Personal blog post.](https://blog.samaltman.com/2279512) "AI will be the most powerful tool for expanding human capability and potential that anyone has ever seen . . . AI has to be democratized; power cannot be too concentrated. Control of the future belongs to all people and their institutions."
 
-[^1-2]: Zuckerberg, M. (2024). ["Open Source AI Is the Path Forward."](https://about.fb.com/news/2024/07/open-source-ai-is-the-path-forward/) Meta blog.
-
-[^1-3]: Nadella, S. (2023). ["Introducing Microsoft 365 Copilot."](https://blogs.microsoft.com/blog/2023/03/16/introducing-microsoft-365-copilot-your-copilot-for-work/) Microsoft Official Blog.
-
 [^1-4]: Amodei, D. (2024). ["Machines of Loving Grace."](https://www.darioamodei.com/machines-of-loving-grace) Personal essay. Full quote: "Having a very thoughtful and informed AI whose job is to give you everything you're legally entitled to by the government in a way you can understand — and who also helps you comply with often confusing government rules — would be a big deal."
 
 [^1-5]: Free-tier web access varies by tool and changes often. Gemini connects to Google's index. Copilot includes Bing search. Claude and ChatGPT both surface web search in the free tier at times and behind a paywall at others. Chapter 3: The Free Tier Playbook covers the full rotation strategy; the companion site tracks current status.
@@ -100,3 +106,7 @@ You are not one input among many, to be weighted and averaged with the machine's
 [^1-7]: Kahneman, D. (2011). [_Thinking, Fast and Slow_](https://bookshop.org/p/books/thinking-fast-and-slow-daniel-kahneman/943943). Farrar, Straus and Giroux. The dual-process model of cognition — fast, intuitive System 1 and slow, deliberate System 2 — maps remarkably well to the architecture of modern AI: a fast pattern-matching base model with an extended reasoning layer for deliberate analysis.
 
 [^1-8]: Kim, H., Yu, H., & Yi, H. (2026). ["The LLM Fallacy: Misattribution in AI-Assisted Cognitive Workflows."](https://arxiv.org/abs/2604.14807) arXiv preprint. A conceptual-framework paper; the authors name the mechanism (opacity, fluency, low-friction interaction) and identify empirical validation as future work.
+
+[^1-9]: Electronic Frontier Foundation. (2025). ["Artificial Intelligence, Copyright, and the Fight for User Rights: 2025 in Review."](https://www.eff.org/deeplinks/2025/12/artificial-intelligence-copyright-and-fight-user-rights-2025-review) Pending litigation includes _Authors Guild v. OpenAI_, _NYT v. OpenAI_, _Kadrey v. Meta_, and _Andersen v. Stability AI_.
+
+[^1-10]: Massachusetts Institute of Technology. (2026). ["Study: AI chatbots provide less accurate information for vulnerable users."](https://news.mit.edu/2026/study-ai-chatbots-provide-less-accurate-information-vulnerable-users-0219) MIT News.


### PR DESCRIPTION
## Summary
- Chapter 1 now quotes only Altman and Amodei directly on AI democratization, dropping the Zuckerberg and Nadella quotes and their footnotes
- Adds two `fairness` callouts: unconsented training-data sourcing (with EFF citation) and the MIT finding that AI accuracy degrades for underrepresented users (non-standard English, underrepresented conditions, lower literacy)
- Adds `spec/social-media/facebook.md`: launch post copy and art brief for the book's Facebook marketing

## Test plan
- [ ] `npm run build:check` (type-check)
- [ ] `npm test`
- [ ] `npm run build` and spot-check the ePub renders the new callouts and updated footnotes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)