### PR TITLE
Add EPUBCheck validation to the build and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,13 @@ jobs:
 
       - run: npm run build:all
 
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - run: npm run check:epub
+
       - uses: actions/upload-artifact@v7
         with:
           name: epub

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,11 +27,12 @@ Semver. Draft status is `0.x.x`. Minor bumps for significant content or pipeline
 ```bash
 npm run build        # tsc + generate ePub
 npm run build:check  # type-check only
+npm run check:epub   # EPUBCheck against dist/majordomo.epub (needs Java 11+; jar auto-downloaded and cached)
 npm test             # vitest
 npm run clean        # rm dist/
 ```
 
-CI runs on every push and PR to main (`.github/workflows/build.yml`): type-check, tests, ePub build. The built ePub is uploaded as an artifact.
+CI runs on every push and PR to main (`.github/workflows/build.yml`): type-check, tests, ePub build, EPUBCheck. The built ePub is uploaded as an artifact.
 
 ## Apple Books Notes Sync
 

--- a/build/epub/templates.ts
+++ b/build/epub/templates.ts
@@ -13,7 +13,7 @@ export function contentOpf(meta: BookMeta, chapters: ProcessedChapter[], hasCove
   const chapterItems = chapters
     .map(
       (ch) =>
-        `    <item id="${ch.meta.slug}" href="text/${ch.meta.slug}.xhtml" media-type="application/xhtml+xml"/>`
+        `    <item id="ch-${ch.meta.slug}" href="text/${ch.meta.slug}.xhtml" media-type="application/xhtml+xml"/>`
     )
     .join('\n');
 
@@ -34,7 +34,7 @@ export function contentOpf(meta: BookMeta, chapters: ProcessedChapter[], hasCove
   const manifestItems = [chapterItems, imageItems].filter(Boolean).join('\n');
 
   const spineItems = chapters
-    .map((ch) => `    <itemref idref="${ch.meta.slug}"/>`)
+    .map((ch) => `    <itemref idref="ch-${ch.meta.slug}"/>`)
     .join('\n');
 
   const coverMeta = hasCover

--- a/build/filters/endnotes.ts
+++ b/build/filters/endnotes.ts
@@ -165,7 +165,7 @@ export function epubOverrides(
         const label = calloutType.toUpperCase();
         const inner = renderer.renderChildren(node);
         return (
-          `<aside class="callout callout-${escapeHtml(calloutType)}" epub:type="sidebar" role="doc-sidebar">\n` +
+          `<aside class="callout callout-${escapeHtml(calloutType)}" epub:type="sidebar" role="note">\n` +
           `<p class="callout-label">${escapeHtml(label)}</p>\n` +
           `${inner}` +
           `</aside>`
@@ -314,13 +314,16 @@ export function renderNotesSection(
         : rendered.replace(/\s+$/, '') + backlink;
 
     notes.push(
-      `<aside epub:type="endnote" role="doc-endnote" id="en-${escaped}" class="endnote">\n${rendered}</aside>`
+      `<li epub:type="endnote" id="en-${escaped}" class="endnote">\n${rendered}</li>`
     );
   }
 
+  // DPUB-ARIA 1.1 deprecates doc-endnote; the recommended structure is a
+  // doc-endnotes section containing a list, with each note as a plain li.
   return (
-    `<aside epub:type="endnotes" class="endnotes">\n` +
+    `<section epub:type="endnotes" role="doc-endnotes" class="endnotes" aria-label="Notes">\n` +
+    `<ol class="endnote-list">\n` +
     notes.join('\n') +
-    `\n</aside>`
+    `\n</ol>\n</section>`
   );
 }

--- a/build/scripts/epubcheck.ts
+++ b/build/scripts/epubcheck.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * `npm run check:epub` — run EPUBCheck against the built ePub.
+ *
+ * Downloads the official W3C EPUBCheck release on first run and caches it
+ * under node_modules/.cache/epubcheck/. Requires a Java 11+ runtime: `java`
+ * on PATH, or JAVA_HOME, or EPUBCHECK_JAVA pointing at a java binary.
+ *
+ * Usage: tsx build/scripts/epubcheck.ts [path/to/book.epub]
+ */
+
+import { mkdir, writeFile, access, rename, rm } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import JSZip from 'jszip';
+
+const EPUBCHECK_VERSION = '5.3.0';
+const DOWNLOAD_URL = `https://github.com/w3c/epubcheck/releases/download/v${EPUBCHECK_VERSION}/epubcheck-${EPUBCHECK_VERSION}.zip`;
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const cacheDir = join(repoRoot, 'node_modules', '.cache', 'epubcheck');
+const jarPath = join(cacheDir, `epubcheck-${EPUBCHECK_VERSION}`, 'epubcheck.jar');
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function findJava(): string | null {
+  const candidates = [
+    process.env.EPUBCHECK_JAVA,
+    process.env.JAVA_HOME && join(process.env.JAVA_HOME, 'bin', 'java'),
+    'java',
+  ].filter((c): c is string => Boolean(c));
+
+  for (const candidate of candidates) {
+    const r = spawnSync(candidate, ['-version'], { encoding: 'utf8' });
+    if (r.status === 0) return candidate;
+  }
+  return null;
+}
+
+async function ensureJar(): Promise<void> {
+  if (await exists(jarPath)) return;
+
+  console.log(`Downloading EPUBCheck ${EPUBCHECK_VERSION}…`);
+  const res = await fetch(DOWNLOAD_URL);
+  if (!res.ok) throw new Error(`Download failed: ${res.status} ${res.statusText} for ${DOWNLOAD_URL}`);
+  const zip = await JSZip.loadAsync(await res.arrayBuffer());
+
+  // Extract to a temp dir, then rename into place so a partial extraction
+  // never masquerades as a valid cache.
+  const tmpDir = join(cacheDir, `.tmp-${process.pid}`);
+  await rm(tmpDir, { recursive: true, force: true });
+  for (const [name, entry] of Object.entries(zip.files)) {
+    if (entry.dir) continue;
+    const dest = join(tmpDir, name);
+    await mkdir(dirname(dest), { recursive: true });
+    await writeFile(dest, await entry.async('nodebuffer'));
+  }
+  await rm(dirname(jarPath), { recursive: true, force: true });
+  await rename(join(tmpDir, `epubcheck-${EPUBCHECK_VERSION}`), dirname(jarPath));
+  await rm(tmpDir, { recursive: true, force: true });
+}
+
+async function main(): Promise<void> {
+  const epubPath = process.argv[2] ?? join(repoRoot, 'dist', 'majordomo.epub');
+  if (!(await exists(epubPath))) {
+    console.error(`No ePub at ${epubPath} — run \`npm run build\` first.`);
+    process.exit(1);
+  }
+
+  const java = findJava();
+  if (!java) {
+    console.error(
+      'EPUBCheck needs a Java 11+ runtime and none was found.\n' +
+        'Install one (e.g. `brew install --cask temurin`) or set JAVA_HOME or EPUBCHECK_JAVA.'
+    );
+    process.exit(1);
+  }
+
+  await ensureJar();
+
+  const r = spawnSync(java, ['-jar', jarPath, epubPath], { stdio: 'inherit' });
+  process.exit(r.status ?? 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:pdf": "tsc && node dist/build/pdf/index.js",
     "build:all": "tsc && node dist/build/index.js && node dist/build/site/index.js",
     "build:check": "tsc --noEmit",
+    "check:epub": "tsx build/scripts/epubcheck.ts",
     "dev": "npm run build:site && wrangler dev",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -345,6 +345,13 @@ details.gloss .gloss-def {
   border-top: 1px solid var(--border);
 }
 
+/* Notes carry their own visible [n] labels, so the list must not number them. */
+.endnote-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 .endnote {
   font-size: 0.85em;
   margin: 0.5em 0;


### PR DESCRIPTION
Closes #144

## What

- **`npm run check:epub`** — new script ([build/scripts/epubcheck.ts](build/scripts/epubcheck.ts)) that downloads the official EPUBCheck 5.3.0 release on first run, caches it under `node_modules/.cache/epubcheck/`, and runs it against `dist/majordomo.epub`. Needs any Java 11+ runtime (`java` on PATH, `JAVA_HOME`, or `EPUBCHECK_JAVA`); prints install guidance if none is found. Non-zero exit on any error or warning.
- **CI** — `actions/setup-java` (Temurin 21) + `npm run check:epub` added to `build.yml` after the ePub build, so validation regressions fail PRs.

## First-run fixes (969 errors / 287 warnings → 0 / 0)

| Problem | Fix |
|---|---|
| Manifest item ids like `00-epigraph` start with a digit — invalid XML names (90 errors across manifest + spine) | Prefix with `ch-` |
| `role="doc-sidebar"` on callout `<aside>`s — not an allowed role on `aside` per ARIA in HTML (592 errors) | `role="note"` |
| `role="doc-endnote"` on endnote `<aside>`s — deprecated in DPUB-ARIA 1.1 and invalid on `aside` (287 errors + 287 warnings) | Restructured to the recommended shape: `<section role="doc-endnotes">` containing an `<ol>` of plain `<li>` notes; list numbering suppressed in CSS since notes carry their own visible `[n]` labels |

Verified locally: full build + all 110 tests pass, EPUBCheck reports `0 fatals / 0 errors / 0 warnings / 0 infos`, and the script exits 1 on an invalid file.

Not included: Ace by DAISY (the issue's optional second a11y check) — can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)