### PR TITLE
Re-enable PDF build and add it to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,13 @@ jobs:
 
       - run: npm test
 
-      - run: npm run build:all
+      - run: npm run build
+
+      - run: npx playwright install --with-deps chromium
+
+      - run: npm run build:pdf
+
+      - run: npm run build:site
 
       - uses: actions/setup-java@v5
         with:
@@ -36,6 +42,11 @@ jobs:
         with:
           name: epub
           path: dist/majordomo.epub
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: pdf
+          path: dist/majordomo.pdf
 
       - uses: actions/upload-artifact@v7
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.0.0",
+        "playwright": "^1.61.1",
         "tsx": "^4.22.3",
         "typescript": "^5.4.0",
         "vitest": "^4.1.2",
@@ -2935,6 +2936,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.0.0",
+    "playwright": "^1.61.1",
     "tsx": "^4.22.3",
     "typescript": "^5.4.0",
     "vitest": "^4.1.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "lib": ["ES2022", "ESNext.Array"]
   },
   "include": ["build/**/*.ts"],
-  "exclude": ["node_modules", "dist", "build/pdf"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

- Restores `playwright` as a devDependency and removes the `build/pdf` exclusion from `tsconfig.json`, undoing the deliberate parking commit 7e4b97a ("chore: disable PDF build for now") now that #146 calls for all three artifacts to be release-ready.
- CI builds in dependency order — ePub → `playwright install chromium` → PDF → site — because the site build copies `dist/majordomo.pdf` into its output when present (it was silently skipping it before).
- Uploads the PDF as a CI artifact alongside epub and site.

## Test plan

- [x] `npm run build:check` — passes with `build/pdf` included
- [x] `npm run build:pdf` — renders 526-page PDF (11.5 MB) locally
- [x] `npm run build:site` — now logs "Copied majordomo.pdf to site output"
- [x] `npm test` — 113 passing
- [ ] CI green on this PR (exercises the new workflow order)

Part of #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)