### PR TITLE
Publish version history at /versions

### DIFF
--- a/build/site/index.ts
+++ b/build/site/index.ts
@@ -19,6 +19,7 @@ import {
   tocPage,
   landingPage,
   notFoundPage,
+  versionsPage,
 } from './templates.js';
 
 const OUTPUT_DIR = join(ROOT, 'dist', 'site');
@@ -73,6 +74,18 @@ async function buildSite(): Promise<void> {
 
   // 404 page
   await writeFile(join(OUTPUT_DIR, '404.html'), notFoundPage(BOOK_META));
+
+  // Version history — spec/version-history.md is the source of truth and
+  // declares itself published at majordomo.dwk.io/versions.
+  const versionHistory = await readFile(
+    join(ROOT, 'spec', 'version-history.md'),
+    'utf-8'
+  );
+  await mkdir(join(OUTPUT_DIR, 'versions'), { recursive: true });
+  await writeFile(
+    join(OUTPUT_DIR, 'versions', 'index.html'),
+    versionsPage(BOOK_META, versionHistory)
+  );
 
   // Table of contents
   await writeFile(join(OUTPUT_DIR, 'read', 'index.html'), tocPage(BOOK_META, sorted));

--- a/build/site/templates.ts
+++ b/build/site/templates.ts
@@ -239,9 +239,54 @@ export function landingPage(meta: BookMeta): string {
   </div>
   <footer class="landing-footer">
     <p>By ${escapeHtml(meta.creator)} &middot; ${escapeHtml(meta.rights)}</p>
+    <p><a href="/versions/">Version history</a></p>
   </footer>
 </body>
 </html>`;
+}
+
+/**
+ * Render spec/version-history.md as the /versions page. The file has a
+ * deliberately simple shape — headings, prose paragraphs, and one large
+ * code fence holding the changelog — so this converts exactly that subset
+ * of Markdown rather than pulling in a full parser.
+ */
+export function versionsPage(meta: BookMeta, markdown: string): string {
+  const inline = (text: string): string =>
+    escapeHtml(text)
+      .replace(/\*\*\[([^\]]+)\]\(([^)]+)\)\*\*/g, '<strong><a href="$2">$1</a></strong>')
+      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
+      .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+      .replace(/(^|\s)\*([^*]+)\*/g, '$1<em>$2</em>');
+
+  let html = '';
+  const segments = markdown.split(/^```.*$/m);
+  for (let i = 0; i < segments.length; i++) {
+    if (i % 2 === 1) {
+      html += `      <pre class="version-log">${escapeHtml(segments[i].replace(/^\n|\n$/g, ''))}</pre>\n`;
+      continue;
+    }
+    for (const block of segments[i].split(/\n{2,}/)) {
+      const text = block.trim();
+      if (!text) continue;
+      const heading = text.match(/^(#{1,6})\s+(.*)$/);
+      if (heading) {
+        const level = heading[1].length;
+        html += `      <h${level}>${inline(heading[2])}</h${level}>\n`;
+      } else {
+        html += `      <p>${inline(text.replace(/\n/g, ' '))}</p>\n`;
+      }
+    }
+  }
+
+  const body = `    <article class="versions-page">
+${html}    </article>
+    <footer class="site-footer">
+      <p><a href="/">${escapeHtml(meta.title)}</a> by ${escapeHtml(meta.creator)}</p>
+      <p>Licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a></p>
+    </footer>\n`;
+
+  return pageShell(meta, 'Version History', body, { hasSidebar: false });
 }
 
 export function notFoundPage(meta: BookMeta): string {


### PR DESCRIPTION
## Summary

- `spec/version-history.md` says the changelog "is published at majordomo.dwk.io/versions" — but the site build never generated that page, and the live URL returns an error today (any unmatched route on the deployed Worker currently returns HTTP 500 rather than the 404 page; that deployment-side behavior is worth a separate look).
- Adds a `versionsPage` template that renders the file's simple Markdown subset (headings, prose paragraphs, the one changelog code fence, inline links/bold/italic) — no new dependency, since the file's shape is deliberately constrained.
- Writes it to `dist/site/versions/index.html` (served at `/versions` via `auto-trailing-slash`) and links it from the landing-page footer.

## Test plan

- [x] `npm run build:check` — passes
- [x] `npm test` — 113 passing
- [x] `npm run build:site` — versions page renders with full changelog in `<pre>`, correct title, footer
- [ ] After merge/deploy: `curl -I https://majordomo.dwk.io/versions` returns 200

Part of #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)