### PR TITLE
Fix 500s on missing routes: declare ASSETS binding, hide absent download buttons

### DIFF
--- a/build/site/index.ts
+++ b/build/site/index.ts
@@ -68,9 +68,27 @@ async function buildSite(): Promise<void> {
   );
   console.log(`Optimized ${imgCount} images`);
 
+  // Copy epub and pdf if they exist (built by earlier steps in build:all),
+  // before the landing page so its download buttons reflect what shipped.
+  const available = new Set<string>();
+  for (const file of ['majordomo.epub', 'majordomo.pdf']) {
+    const src = join(ROOT, 'dist', file);
+    try {
+      await access(src);
+      await copyFile(src, join(OUTPUT_DIR, file));
+      available.add(file);
+      console.log(`Copied ${file} to site output`);
+    } catch {
+      console.log(`${file} not found — skipping`);
+    }
+  }
+
   // Landing page
   console.log('Writing pages...');
-  await writeFile(join(OUTPUT_DIR, 'index.html'), landingPage(BOOK_META));
+  await writeFile(
+    join(OUTPUT_DIR, 'index.html'),
+    landingPage(BOOK_META, available)
+  );
 
   // 404 page
   await writeFile(join(OUTPUT_DIR, '404.html'), notFoundPage(BOOK_META));
@@ -105,21 +123,6 @@ async function buildSite(): Promise<void> {
       join(dir, 'index.html'),
       chapterPage(BOOK_META, ch, prev, next, sorted)
     );
-  }
-
-  // Copy epub and pdf if they exist (built by earlier steps in build:all)
-  for (const file of [
-    'majordomo.epub',
-    'majordomo.pdf',
-  ]) {
-    const src = join(ROOT, 'dist', file);
-    try {
-      await access(src);
-      await copyFile(src, join(OUTPUT_DIR, file));
-      console.log(`Copied ${file} to site output`);
-    } catch {
-      console.log(`${file} not found — skipping`);
-    }
   }
 
   console.log(`Site written to ${OUTPUT_DIR} (${sorted.length} chapters)`);

--- a/build/site/templates.ts
+++ b/build/site/templates.ts
@@ -185,7 +185,18 @@ ${list}    </div>
   return pageShell(meta, 'Table of Contents', body, { chapters });
 }
 
-export function landingPage(meta: BookMeta): string {
+export function landingPage(
+  meta: BookMeta,
+  available: Set<string> = new Set(['majordomo.epub', 'majordomo.pdf'])
+): string {
+  const downloadCtas = [
+    available.has('majordomo.epub')
+      ? `        <a href="/majordomo.epub" class="hero-cta hero-cta-secondary" download>Download ePub</a>\n`
+      : '',
+    available.has('majordomo.pdf')
+      ? `        <a href="/majordomo.pdf" class="hero-cta hero-cta-secondary" download>Download PDF</a>\n`
+      : '',
+  ].join('');
   return `<!DOCTYPE html>
 <html lang="${meta.language}">
 <head>
@@ -205,9 +216,7 @@ export function landingPage(meta: BookMeta): string {
       <p class="hero-pitch">The billionaire class has always had access to lawyers, doctors, and financial advisors who explain things in plain language &mdash; now you have something close to that, for free, on your phone.</p>
       <div class="hero-ctas">
         <a href="/read/" class="hero-cta">Read Online</a>
-        <a href="/majordomo.epub" class="hero-cta hero-cta-secondary" download>Download ePub</a>
-        <a href="/majordomo.pdf" class="hero-cta hero-cta-secondary" download>Download PDF</a>
-        <a href="https://github.com/davidwkeith/A-Majordomo-for-Everyone" class="hero-cta hero-cta-secondary">View Source</a>
+${downloadCtas}        <a href="https://github.com/davidwkeith/A-Majordomo-for-Everyone" class="hero-cta hero-cta-secondary">View Source</a>
       </div>
     </div>
   </header>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,6 +6,7 @@ compatibility_date = "2025-04-01"
 command = "npm run build:site"
 
 [assets]
+binding = "ASSETS"
 directory = "dist/site"
 html_handling = "auto-trailing-slash"
 not_found_handling = "404-page"


### PR DESCRIPTION
## Summary

Production returns HTTP 500 for every route that isn't a static asset — including `/majordomo.pdf` (linked from the landing page) and any typo URL — instead of the 404 page.

- **Root cause:** `worker/index.js` calls `env.ASSETS.fetch(request)`, but `wrangler.toml`'s `[assets]` block never declared `binding = "ASSETS"`. Asset hits are served before the Worker runs, so pages worked; asset *misses* fell through to the Worker, where `env.ASSETS` was `undefined` and the handler threw. One line fixes it: with the binding declared, `not_found_handling = "404-page"` serves the styled `404.html`.
- **Dead PDF link:** the landing page rendered Download ePub/PDF buttons unconditionally, but the Cloudflare deploy doesn't render the PDF (no playwright there), so its button 500'd (now would 404). The artifact-copy step now runs before the landing page is written, and buttons render only for artifacts actually present. When the deploy pipeline gains the PDF, the button comes back automatically.

## Test plan

- [x] `npm run build:check`, `npm test` (113) — pass
- [x] `wrangler dev` against the built site: `/` 200, `/versions` 200, `/nope` → 404 with the 404-page body
- [x] Landing page: buttons absent when artifacts absent; ePub button present when epub built
- [ ] After merge/deploy: `curl -s -o /dev/null -w '%{http_code}' https://majordomo.dwk.io/definitely-not-a-page` → 404

Part of #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)