### PR TITLE
Glossary sweep: Introduction chapters

### DIFF
--- a/src/content/00-introduction/01-a-note-before-you-start/index.dj
+++ b/src/content/00-introduction/01-a-note-before-you-start/index.dj
@@ -139,7 +139,7 @@ Your Agent will read the English document and respond in your language. It will 
 *Multilingual households:* if you are helping a family member who speaks a different language, your Agent is the translator in the room. "My mother received this letter. She speaks Tagalog. Explain it to her in Tagalog and tell me in English what she needs to do." Your Agent handles both sides of the conversation. The family member hears the explanation in their language. You hear the action items in yours.
 
 ::: fairness
-AI language quality varies. English is the most thoroughly trained language in every major model. Spanish, French, German, Chinese, Japanese, and Korean are generally strong. Other languages — particularly indigenous languages, regional dialects, and less-resourced languages — may produce less accurate or less nuanced responses. If you are working in a language other than English, verify critical details (dollar amounts, deadlines, legal terms) against the original English document. Your Agent's translation is a starting point, not a certified translation.[^n-6]
+AI language quality varies. English is the most thoroughly trained language in every major [model]{.gloss def="The trained program that produces the answers — the engine inside an AI tool."}. Spanish, French, German, Chinese, Japanese, and Korean are generally strong. Other languages — particularly indigenous languages, regional dialects, and less-resourced languages — may produce less accurate or less nuanced responses. If you are working in a language other than English, verify critical details (dollar amounts, deadlines, legal terms) against the original English document. Your Agent's translation is a starting point, not a certified translation.[^n-6]
 :::
 
 

--- a/src/content/00-introduction/03-chapter-01-what-these-tools-are/index.dj
+++ b/src/content/00-introduction/03-chapter-01-what-these-tools-are/index.dj
@@ -17,7 +17,7 @@ _(He was describing the 24th century. We will work with what we have.)_
 
 ---
 
-These tools — the ones this book calls "your Agent" — are a new category of software that does not have a good name yet. "AI assistant" is accurate but vague. "Chatbot" carries 20 years of terrible customer service baggage. "Large language model" is what the engineers who build them call them, which is useful in the same way that "internal combustion engine" is useful when you are trying to get somewhere.
+These tools — the ones this book calls "your Agent" — are a new category of software that does not have a good name yet. "AI assistant" is accurate but vague. "Chatbot" carries 20 years of terrible customer service baggage. "[Large language model]{.gloss def="A program trained on enormous amounts of text to predict what words come next — the engine behind all of these tools."}" is what the engineers who build them call them, which is useful in the same way that "internal combustion engine" is useful when you are trying to get somewhere.
 
 For this book: they are AI agents. This book says "your Agent" to mean whichever one you have open. The distinction between tools matters less than the skill of using any of them well, which is what this book teaches.
 
@@ -49,14 +49,14 @@ That last one is the thesis of this book, written by the CEO of the company that
 - Give you the starting draft that gets you past the blank page
 
 *What they cannot do:*
-- Reliably browse the internet in real time on every free tier[^1-5]
+- Reliably browse the internet in real time on every [free tier]{.gloss def="The no-cost version of a paid service, with limits on how much you can use it."}[^1-5]
 - Remember your previous conversations (you have to give context each time but context can be saved and reused)
 - Guarantee accuracy — they can be wrong, and you should verify anything with real consequences
 - Replace a licensed professional when accountability genuinely matters (see Part Three)
 - Fix the system. That part is still on us.
 
 ::: fairness
-Nilay Patel at The Verge calls it _software brain_: the tech-industry habit of treating the world as a series of databases to be managed with structured language and code.[^1-6] It is why [DOGE](https://en.wikipedia.org/wiki/Department%5Fof%5FGovernment%5FEfficiency) failed — a country is not a database — and why the smart-home decade produced mostly things no one asked for. Software brain is what is being done _to_ you when an insurer replaces its appeals desk with a model trained to deny claims, when a landlord screens applicants through an algorithm, when a hospital bills by code instead of by visit. This book is about the other direction — the same class of tool, on your side of the table, reading the database back to you in plain language. The distinction is the whole game. Notice which one you are looking at.
+Nilay Patel at The Verge calls it _software brain_: the tech-industry habit of treating the world as a series of databases to be managed with structured language and code.[^1-6] It is why [DOGE](https://en.wikipedia.org/wiki/Department%5Fof%5FGovernment%5FEfficiency) failed — a country is not a database — and why the smart-home decade produced mostly things no one asked for. Software brain is what is being done _to_ you when an insurer replaces its appeals desk with a [model]{.gloss def="The trained program that produces the answers — the engine inside an AI tool."} trained to deny claims, when a landlord screens applicants through an [algorithm]{.gloss def="A set of rules a computer follows automatically — here, a scoring formula no human reviews."}, when a hospital bills by code instead of by visit. This book is about the other direction — the same class of tool, on your side of the table, reading the database back to you in plain language. The distinction is the whole game. Notice which one you are looking at.
 :::
 
 

--- a/src/content/00-introduction/05-chapter-03-free-tier-playbook/index.dj
+++ b/src/content/00-introduction/05-chapter-03-free-tier-playbook/index.dj
@@ -19,7 +19,7 @@ You will not need to pay for anything to use this book. Here is how to stay in t
 
 *What the free tier includes:*
 
-Each service's free tier allows a meaningful number of conversations per day. The exact limits vary and are not publicly published, but in practice they are sufficient for several extended conversations before any throttling occurs. If you hit a limit, your Agent will tell you, and the limit typically resets within a few hours.
+Each service's free tier allows a meaningful number of conversations per day. The exact limits vary and are not publicly published, but in practice they are sufficient for several extended conversations before any [throttling]{.gloss def="When a service slows or pauses your access until your free allowance resets."} occurs. If you hit a limit, your Agent will tell you, and the limit typically resets within a few hours.
 
 ::: meme
 [nohello.net](https://nohello.net) — the rule your office already knows. Do not Slack a coworker "Hi" and wait. Send the context, the question, and what you need, in one message. Same principle here, except on the free tier every round trip costs you one of a limited daily supply. Proofread before you send. Is the document attached? Did you say what you need back? One complete message is worth three that circle the question.
@@ -33,7 +33,7 @@ When you hit one service's free limit, you have three other high-quality options
 | Service | Best for | Free limit notes |
 |---|---|---|
 | [Claude](https://claude.ai) (Anthropic) | Nuanced writing, complex explanations, documents | Daily soft limit |
-| [ChatGPT](https://chatgpt.com) (OpenAI) | Broad general use, web search | Daily limit on the flagship model |
+| [ChatGPT](https://chatgpt.com) (OpenAI) | Broad general use, web search | Daily limit on the [flagship model]{.gloss def="The company's newest, most capable model — free tiers limit how much you can use it before switching you to a smaller one."} |
 | [Gemini](https://gemini.google.com) (Google) | Gmail and Google Docs integration, current events | Generous free tier |
 | [Copilot](https://copilot.microsoft.com) (Microsoft) | Windows integration, Bing search included | Generous free tier |
 

--- a/src/content/00-introduction/06-chapter-04-how-to-ask/index.dj
+++ b/src/content/00-introduction/06-chapter-04-how-to-ask/index.dj
@@ -110,7 +110,7 @@ A good follow-up question has three properties: it is open-ended (not yes-or-no)
 
 *Ask why.* But not like that. The word "why" can sound like a cross-examination. Instead: _"What's driving that recommendation?"_ or _"What would happen if I didn't do that?"_ Same question, less heat.
 
-*Ask for a comparison.* When the Agent's answer feels too generic to act on, give it a reference point: _"How is this different from a standard HMO?"_ or _"Compared to the national average, where does this number fall?"_ Comparison forces specificity the way absolute description does not.
+*Ask for a comparison.* When the Agent's answer feels too generic to act on, give it a reference point: _"How is this different from a standard [HMO]{.gloss def="Health Maintenance Organization — an insurance plan that only covers doctors inside its own network."}?"_ or _"Compared to the national average, where does this number fall?"_ Comparison forces specificity the way absolute description does not.
 
 *Ask it to check its own work.* After a detailed answer, say: _"Now review what you just gave me. What did you get wrong, oversimplify, or leave out?"_ Your Agent will often catch its own mistakes — a missed deadline, a clause it glossed over, an assumption it made about your situation. This is not a sign the first answer was bad. It is a second pass, the same way you would reread an important email before sending it.
 
@@ -142,7 +142,7 @@ This also makes it easier to catch mistakes. If the Agent gets Part 1 wrong, you
 
 ### When to Start a New Conversation
 
-Your Agent remembers everything within a single conversation but nothing between conversations by default. Long conversations drift. After enough back-and-forth, your Agent starts to lose the thread — it gives vaguer answers, forgets details you mentioned earlier, or repeats itself. This is not a defect. Every conversation has a limited working memory, and eventually you fill it up.
+Your Agent remembers everything within a single conversation but nothing between conversations by default. Long conversations drift. After enough back-and-forth, your Agent starts to lose the thread — it gives vaguer answers, forgets details you mentioned earlier, or repeats itself. This is not a defect. Every conversation has a limited [working memory]{.gloss def="Technically the context window: the fixed amount of text your Agent can consider at once — Appendix J explains how it works."}, and eventually you fill it up.
 
 ::: also
 Claude calls persistent cross-conversation memory simply "Memory" — it can be enabled in settings and will carry facts about you from session to session. Gemini calls this "Personalization." ChatGPT calls it "Memory." All three work similarly: the tool builds a profile of your situation over time so you don't have to re-explain it. This is different from Projects / Gems / Custom GPTs, which are manually configured contexts. See [Appendix G](06-appendix-g-feature-table.xhtml).


### PR DESCRIPTION
## Summary

First batch of the #142 sweep, using the noteref mechanism from #153. Nine spans across four files, selected against three rules: **first-use jargon only**, **never inside prompt/agent blocks** (they represent text the reader types), and **never where the prose already defines the term inline** (per the style guide's first-mention rule, which this book follows heavily — it's why Chapter 2 and Strategy 0 needed nothing).

| Chapter | Terms |
|---|---|
| A Note Before You Start | model |
| Ch. 1 What These Tools Are | large language model, free tier, model, algorithm |
| Ch. 3 Free Tier Playbook | throttling, flagship model |
| Ch. 4 How to Ask | HMO, working memory (bridges to "context window", pointing at Appendix J) |

"model" appears in two chapters with byte-identical definition text, per the drift concern raised on #142.

## Test plan

- [x] `npm run build:check` / `npm test` — 117 passing
- [x] Built ePub inspected: each chapter renders matching noterefs + asides + Definitions section; nesting inside `<em>`/curly quotes (HMO) and inside literal quotes (LLM) is clean
- [ ] CI EPUBCheck + Ace green

Part of #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)