### PR TITLE
Glossary sweep: Strategies 1-9

### DIFF
--- a/src/content/01-strategies/04-strategy-4-navigate/index.dj
+++ b/src/content/01-strategies/04-strategy-4-navigate/index.dj
@@ -143,7 +143,7 @@ runs out — the claim date still matters.
 :::
 
 ::: science
-Research on administrative burden (Herd & Moynihan, 2018) shows that complex application processes function as de facto gatekeeping — the people most in need of benefits are the least likely to complete multi-step enrollment because the cognitive cost of navigating the process compounds with the stress of the situation that created the need. Having the steps laid out before you start is not a convenience. It is the difference between completing the process and abandoning it.[^s4-1]
+Research on [administrative burden]{.gloss def="The extra time, effort, and stress a process imposes on the person navigating it, separate from whatever benefit or right is at stake."} (Herd & Moynihan, 2018) shows that complex application processes function as de facto gatekeeping — the people most in need of benefits are the least likely to complete multi-step enrollment because the cognitive cost of navigating the process compounds with the stress of the situation that created the need. Having the steps laid out before you start is not a convenience. It is the difference between completing the process and abandoning it.[^s4-1]
 :::
 
 

--- a/src/content/01-strategies/08-strategy-8-assert/index.dj
+++ b/src/content/01-strategies/08-strategy-8-assert/index.dj
@@ -20,7 +20,7 @@ _Know and exercise your rights in a situation where the other party is betting y
 
 Al knows he's being treated unfairly. He cannot translate that knowledge into action. Knowing you have rights and knowing how to exercise them are two different skills. Al has the first one.
 
-*The lesson:* The insurance company, the landlord, the employer, and the HOA all operate with a shared assumption: that you don't know what the law actually says about your situation. The billionaire class does not deal with institutions on these terms. Their lawyers know the statute. Their HR departments know the employment code. Their property managers know the tenant rights ordinance — specifically so they can operate right up to its edge. Your Agent has read the same law. The other party already knows what it says. Now you can too.
+*The lesson:* The insurance company, the landlord, the employer, and the [HOA]{.gloss def="Homeowners Association — the private organization that enforces rules and collects fees in many housing developments and condo buildings."} all operate with a shared assumption: that you don't know what the law actually says about your situation. The billionaire class does not deal with institutions on these terms. Their lawyers know the statute. Their HR departments know the employment code. Their property managers know the tenant rights ordinance — specifically so they can operate right up to its edge. Your Agent has read the same law. The other party already knows what it says. Now you can too.
 
 *My Man Jeeves:* _Mr. Bundy's observation, that the institutions he dealt with were not configured in his favour, was entirely correct, and his inability to do anything about it was not for lack of principle — he had principles in abundance — but for the rather more practical circumstance that knowing one possesses a right and knowing the form one fills out to exercise it are skills which bear only a distant relation to one another. The second skill is the one the institution is, on most days, wagering you do not have._
 
@@ -173,7 +173,7 @@ A 2013 HUD-commissioned paired-testing study sent matched pairs of white, Black,
 
 ### Example 2: Let Go With No Clear Reason
 
-The situation: you've been at the company four years. You're called into a meeting with HR and your manager, told the position is "being restructured," and handed a severance agreement and a pen. "We'd like this back by Friday" — three business days away. Nobody says why you specifically. Nobody mentions anything resembling a WARN Act notice.
+The situation: you've been at the company four years. You're called into a meeting with HR and your manager, told the position is "being restructured," and handed a severance agreement and a pen. "We'd like this back by Friday" — three business days away. Nobody says why you specifically. Nobody mentions anything resembling a [WARN Act]{.gloss def="The Worker Adjustment and Retraining Notification Act — a federal law requiring larger employers to give advance written notice before a mass layoff or plant closing."} notice.
 
 *Your opening message:*
 
@@ -387,7 +387,7 @@ claim with a dollar value attached.
 :::
 
 ::: tip
-Mid-call, you don't need to recite the FDCPA — you need to describe what just happened and ask. _"A debt collector just called my workplace again after I told them not to. Is that legal, and what should I do right now?"_ A violation logged the day it happens is worth far more, as evidence, than one reconstructed from memory weeks later.
+Mid-call, you don't need to recite the [FDCPA]{.gloss def="The Fair Debt Collection Practices Act — the federal law governing what debt collectors can and can't do when contacting you."} — you need to describe what just happened and ask. _"A debt collector just called my workplace again after I told them not to. Is that legal, and what should I do right now?"_ A violation logged the day it happens is worth far more, as evidence, than one reconstructed from memory weeks later.
 :::
 
 ::: also


### PR DESCRIPTION
## Summary

Second batch of the #142 sweep, covering Part One (Strategies 1–9), using the noteref mechanism from #153 and the selection rules established in #154.

## Audit result

Most of the Strategy chapters' technical vocabulary lives inside `::: prompt` / `::: agent` worked-example blocks, which are off-limits for `.gloss` spans (they represent text the reader types or the Agent's reply, per convention). Of the remaining prose, most jargon is already handled — either defined inline at first use (e.g., "Zeigarnik effect," "decision fatigue," "downzone") or already linked to Wikipedia (e.g., Roth/traditional IRA, PCP, health literacy, MFA, holodeck — several satisfied earlier in the book, in "A Note Before You Start").

**Strategies 1, 2, 3, 5, 6, 7, and 9 need no spans** for the same reason Strategy 0 and Chapter 2 needed none in the first batch.

**Four spans across two chapters:**

| Chapter | Terms |
|---|---|
| Strategy 4: Navigate | administrative burden |
| Strategy 8: Assert | HOA, WARN Act, FDCPA |

"Administrative burden" appears in both Strategy 4 (this PR, glossed — first encounter in reading order) and Strategy 8 (already a Wikipedia link from prior content) — both satisfy the first-mention rule independently, so no drift concern.

## Test plan

- [x] `npm run build:check` / `npm test` — 117 passing
- [x] `npm run build` — ePub builds cleanly
- [x] `npm run check:epub` — EPUBCheck 5.3.0, 0 errors/warnings
- [x] `npm run check:a11y` — Ace by DAISY, no issues found on any chapter
- [x] Built ePub inspected: noterefs and Definitions asides render correctly for all four spans

Part of #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019Cr4qLigVDNCJEMKE8Lmae)_