### PR TITLE
Verify PDF and site builds are release-ready

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
 
@@ -54,3 +56,20 @@ jobs:
         with:
           name: site
           path: dist/site/
+
+      # The Cloudflare Workers Builds container has no root access to install
+      # Chromium's system libraries, so it can't render the PDF itself. Publish
+      # it here, where Playwright already works, to a rolling release the
+      # Cloudflare build fetches instead (see build:cf in package.json).
+      - name: Publish PDF to rolling release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view pdf-latest >/dev/null 2>&1; then
+            gh release upload pdf-latest dist/majordomo.pdf --clobber
+          else
+            gh release create pdf-latest dist/majordomo.pdf \
+              --title "Latest PDF build" \
+              --notes "Automatically updated on every push to main. Not a semver release — see spec/version-history.md for the changelog."
+          fi

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:site": "tsc && node dist/build/site/index.js",
     "build:pdf": "tsc && node dist/build/pdf/index.js",
     "build:all": "tsc && node dist/build/index.js && node dist/build/site/index.js",
+    "build:cf": "npx playwright install --with-deps chromium && npm run build:pdf && npm run build:site",
     "build:check": "tsc --noEmit",
     "check:epub": "tsx build/scripts/epubcheck.ts",
     "check:a11y": "tsx build/scripts/ace.ts",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:site": "tsc && node dist/build/site/index.js",
     "build:pdf": "tsc && node dist/build/pdf/index.js",
     "build:all": "tsc && node dist/build/index.js && node dist/build/site/index.js",
-    "build:cf": "npx playwright install chromium && npm run build:pdf && npm run build:site",
+    "build:cf": "mkdir -p dist && (curl -fsSL -o dist/majordomo.pdf https://github.com/davidwkeith/A-Majordomo-for-Everyone/releases/download/pdf-latest/majordomo.pdf || echo 'PDF fetch failed — continuing without it') && npm run build:site",
     "build:check": "tsc --noEmit",
     "check:epub": "tsx build/scripts/epubcheck.ts",
     "check:a11y": "tsx build/scripts/ace.ts",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:site": "tsc && node dist/build/site/index.js",
     "build:pdf": "tsc && node dist/build/pdf/index.js",
     "build:all": "tsc && node dist/build/index.js && node dist/build/site/index.js",
-    "build:cf": "npx playwright install --with-deps chromium && npm run build:pdf && npm run build:site",
+    "build:cf": "npx playwright install chromium && npm run build:pdf && npm run build:site",
     "build:check": "tsc --noEmit",
     "check:epub": "tsx build/scripts/epubcheck.ts",
     "check:a11y": "tsx build/scripts/ace.ts",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,7 @@ main = "worker/index.js"
 compatibility_date = "2025-04-01"
 
 [build]
-command = "npm run build:site"
+command = "npm run build:cf"
 
 [assets]
 binding = "ASSETS"


### PR DESCRIPTION
## Summary

Closes #146. Verified all three release artifacts (ePub, PDF, site) build cleanly and pass validation, and fixed the gaps found in the Cloudflare deploy pipeline.

- Ran `build:check`, `test`, `build` (ePub), `build:pdf`, `build:site`, `check:epub`, and `check:a11y` locally — all pass with no errors/warnings.
- Confirmed CI (`.github/workflows/build.yml`) already runs and uploads all three artifacts (this landed in earlier merged PRs #148–151).
- Confirmed `majordomo.dwk.io/versions` is live and rendering the version-history changelog.
- Confirmed XMP (alt text + license) is embedded in both the site's `dist/site/images/*` and the PDF's intermediate `dist/.pdf-images/*` copies, not just the ePub.

## The Cloudflare PDF gap

The live deploy's landing page had no PDF download. Root cause, found by iterating against real Cloudflare build logs:

1. `wrangler.toml`'s `[build].command` only ran `npm run build:site` — no Playwright, so `dist/majordomo.pdf` never existed for the site build to pick up.
2. Pointing it at a script that runs Playwright directly doesn't work: the Workers Builds container has no passwordless sudo, so `playwright install --with-deps` hangs on a password prompt until the build times out, and `playwright install` alone downloads Chromium but it can't launch (`error while loading shared libraries: libatk-1.0.so.0`). `build/pdf/index.ts` swallows that launch failure into a `console.warn`, so the build "succeeded" while silently never producing a PDF.

Fix: don't render the PDF in Cloudflare's container at all. GitHub Actions already builds and validates it on a runner with full sudo, so CI now publishes it to a rolling `pdf-latest` GitHub Release on every push to `main`, and `build:cf` just fetches that asset before running `build:site` (falling back to skipping the PDF, matching prior behavior, if the fetch ever fails).

## Changes

- `.github/workflows/build.yml`: after the existing artifact uploads, publish `dist/majordomo.pdf` to a rolling `pdf-latest` release (push-to-main only).
- `package.json`: `build:cf` fetches that release asset instead of invoking Playwright, then runs `build:site`.
- `wrangler.toml`: `[build].command = "npm run build:cf"` so local `wrangler deploy` matches the Cloudflare pipeline.

## Remaining manual step (tracked, not part of this diff)

The repo owner needs to set the Cloudflare dashboard Build command for `a-majordomo-for-everyone-dwk-io` (Settings > Build) — the dashboard's own build command still runs `npm run build`, ignoring `wrangler.toml`; only the *deploy* command (`npx wrangler versions upload`) picks up `build:cf` today, via Wrangler's own custom-build step, which happens to be exactly what's needed here.

Note: `pdf-latest` won't exist until this PR merges and a push-to-main CI run creates it, so this PR's own preview build has no PDF yet (graceful skip, confirmed in the Workers Builds log) — production will pick it up on the next push.

## Test plan

- [x] `npm run build:check`
- [x] `npm test`
- [x] `npm run build` (ePub)
- [x] `npm run build:pdf`
- [x] `npm run build:site`
- [x] `npm run check:epub`
- [x] `npm run check:a11y`
- [x] Verified `majordomo.dwk.io/versions` loads live
- [x] Verified the Cloudflare Workers Builds preview deploy succeeds cleanly (no PDF yet, expected — see note above)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYWMmAaQFy9FccaMYmNTKs)_