### PR TITLE
chore(claude): trim CLAUDE.md and move Apple Books sync to a skill

### DIFF
--- a/.claude/skills/apple-books-notes-sync/SKILL.md
+++ b/.claude/skills/apple-books-notes-sync/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: apple-books-notes-sync
+description: Install, run, troubleshoot, or remove the hourly sync from Apple Books annotations on the built ePub to GitHub Issues. Use for the sync:notes scripts, the LaunchAgent, or macOS Full Disk Access errors reading the Apple Books container.
+---
+
+# Apple Books Notes Sync
+
+Hourly sync from your Apple Books typed annotations on the built ePub to GitHub Issues on this repo (label `from:apple-books`). Each annotation becomes one deduped issue.
+
+```bash
+npm run sync:notes:install      # one-time: install LaunchAgent + create label
+npm run sync:notes              # force a sync now (rather than wait for next hour)
+npm run sync:notes:status       # last-run, mtime, log file size, lifetime counters
+npm run sync:notes:uninstall    # remove the LaunchAgent
+```
+
+State lives outside the repo:
+- `~/Library/Application Support/majordomo/notes-sync-state.json` (mtime cache, asset_id, counters)
+- `~/Library/Logs/majordomo-notes-sync.log` (structured one-line-per-event log)
+
+Requires `gh auth login` to have been run once.
+
+**macOS Full Disk Access:** The LaunchAgent-spawned daemon needs Full Disk Access to read `~/Library/Containers/com.apple.iBooksX/`. Interactive shells inherit this from Terminal/iTerm/Claude Code; LaunchAgents are attributed to their own responsible code and need explicit grants. After running `sync:notes:install`, open **System Settings → Privacy & Security → Full Disk Access**, click **+**, navigate to (Cmd+Shift+G) the node binary path printed by the installer (e.g. `/opt/homebrew/Cellar/node@22/22.22.2_1/bin/node`), and toggle it on. Then kickstart the daemon: `launchctl kickstart -p "gui/$(id -u)/io.dwk.majordomo.notes-sync"`.
+
+See [the design spec](docs/superpowers/specs/2026-05-23-apple-books-notes-sync-design.md) for the full architecture.

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ dist/
 *.tgz
 .env
 .venv/
-.claude/
+.claude/*
+!.claude/skills/
 .djot-preview/
 .nova/
 .wrangler/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,58 +24,7 @@ Semver. Draft status is `0.x.x`. Minor bumps for significant content or pipeline
 
 ## Build
 
-```bash
-npm run build        # tsc + generate ePub
-npm run build:check  # type-check only
-npm run check:epub   # EPUBCheck against dist/majordomo.epub (needs Java 11+; jar auto-downloaded and cached)
-npm run check:a11y   # Ace by DAISY (axe-core via headless Chrome) against dist/majordomo.epub — second accessibility opinion alongside build/validators/a11y.ts
-npm test             # vitest
-npm run clean        # rm dist/
-```
-
-CI runs on every push and PR to main (`.github/workflows/build.yml`): type-check, tests, ePub build, EPUBCheck, Ace. The built ePub is uploaded as an artifact.
-
-## Apple Books Notes Sync
-
-Hourly sync from your Apple Books typed annotations on the built ePub to GitHub Issues on this repo (label `from:apple-books`). Each annotation becomes one deduped issue.
-
-```bash
-npm run sync:notes:install      # one-time: install LaunchAgent + create label
-npm run sync:notes              # force a sync now (rather than wait for next hour)
-npm run sync:notes:status       # last-run, mtime, log file size, lifetime counters
-npm run sync:notes:uninstall    # remove the LaunchAgent
-```
-
-State lives outside the repo:
-- `~/Library/Application Support/majordomo/notes-sync-state.json` (mtime cache, asset_id, counters)
-- `~/Library/Logs/majordomo-notes-sync.log` (structured one-line-per-event log)
-
-Requires `gh auth login` to have been run once.
-
-**macOS Full Disk Access:** The LaunchAgent-spawned daemon needs Full Disk Access to read `~/Library/Containers/com.apple.iBooksX/`. Interactive shells inherit this from Terminal/iTerm/Claude Code; LaunchAgents are attributed to their own responsible code and need explicit grants. After running `sync:notes:install`, open **System Settings → Privacy & Security → Full Disk Access**, click **+**, navigate to (Cmd+Shift+G) the node binary path printed by the installer (e.g. `/opt/homebrew/Cellar/node@22/22.22.2_1/bin/node`), and toggle it on. Then kickstart the daemon: `launchctl kickstart -p "gui/$(id -u)/io.dwk.majordomo.notes-sync"`.
-
-See [the design spec](docs/superpowers/specs/2026-05-23-apple-books-notes-sync-design.md) for the full architecture.
-
-## Project Structure
-
-```
-spec/                # All editorial, visual, and structural specifications
-  editorial/         # Voice, conventions, principles, cultural references
-  illustration/      # Illustrator agent instructions and art briefs
-src/content/         # Djot chapter files (.dj) with YAML frontmatter
-  00-introduction/   # Epigraph, Foreword, "How to Use", Chapters 1-4
-  01-strategies/     # Strategy 0-9
-  02-field-guide/    # Field Guide Skills by domain (the human equivalent of LLM SKILLS.md)
-  03-general-method/ # Part Three chapters
-  04-appendices/     # Appendices A-H + final note
-src/styles/          # ePub CSS
-src/images/          # Cover + chapter illustrations
-build/               # TypeScript build pipeline
-  filters/           # Djot filters (callouts, art-briefs, conversations, endnotes)
-  epub/              # ePub 3.0 assembly (templates, jszip)
-  embed-xmp.ts       # XMP metadata embedding utility
-dist/                # Output (gitignored)
-```
+Scripts are in `package.json`. Two things they don't tell you: `npm run check:epub` needs Java 11+ (the EPUBCheck jar is auto-downloaded and cached), and `npm run check:a11y` runs Ace by DAISY as a second accessibility opinion alongside `build/validators/a11y.ts`.
 
 ## Pipeline
 


### PR DESCRIPTION
Came out of a `/doctor` pass on the Claude Code setup. Only the repo-affecting changes are here — the rest (plugin/skill cleanup, a narrowed lint hook, agent frontmatter repair) touched `~/.claude/` and isn't version-controlled.

## What changed

**Trimmed [CLAUDE.md](CLAUDE.md)** — 8,639 → 5,786 chars (~2,160 → ~1,447 est. tokens loaded into every session). Cut two sections a fresh session could reconstruct on its own:

- **Project Structure** — a directory tree `ls` already shows, and it had drifted: it omitted `docs/`, `scripts/`, and `worker/`.
- **Build commands + CI line** — all in `package.json` scripts and `.github/workflows/build.yml`, and also drifted (`rm dist/` vs the actual `rm -rf dist`; missing `build:site`, `build:pdf`, `build:all`, `build:cf`, `dev`, `test:watch`).

Kept the two facts those files *don't* state: `check:epub` needs Java 11+, and `check:a11y` is a second accessibility opinion alongside `build/validators/a11y.ts`.

**Moved Apple Books Notes Sync to a skill** — `.claude/skills/apple-books-notes-sync/SKILL.md`, verbatim. It's a one-time install workflow plus macOS Full Disk Access troubleshooting: needed rarely, but it was resident in context always. Now only its one-line description stays loaded, and the body loads on demand.

**Narrowed `.gitignore`** — `.claude/` → `.claude/*` plus `!.claude/skills/`, so the new skill is actually tracked.

## Reviewer notes

The `.gitignore` change needs the `.claude/*` form specifically. A bare `!.claude/skills/` under the original `.claude/` would have silently done nothing — git never descends into an excluded directory, so there's no path for the negation to match. Verified after the change: `.claude/skills/` is visible, while `settings.local.json` and `worktrees/` remain ignored.

Nothing in `src/content/` was touched, so no chapter `status` values change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)