### PR TITLE
build(tts): scaffold WordBoundary offset spike script for #161

### DIFF
--- a/build/scripts/tts-spike.test.ts
+++ b/build/scripts/tts-spike.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { verifyWordBoundaries } from './tts-spike.js';
+
+describe('verifyWordBoundaries', () => {
+  it('passes when offsets line up with the source text', () => {
+    const text = 'Jeeves considered the matter.';
+    const boundaries = [
+      { text: 'Jeeves', textOffset: 0, wordLength: 6, audioOffsetTicks: 0, durationTicks: 100 },
+      { text: 'considered', textOffset: 7, wordLength: 10, audioOffsetTicks: 100, durationTicks: 100 },
+    ];
+    expect(verifyWordBoundaries(text, boundaries)).toEqual([]);
+  });
+
+  it('flags drift after a smart-typography character', () => {
+    // Simulates the failure mode this spike exists to catch: an em dash
+    // counted as more than one UTF-16 code unit upstream shifts every
+    // subsequent offset by one.
+    const text = 'a delicate situation"—the sort that wants patience.';
+    const boundaries = [
+      { text: 'situation', textOffset: 11, wordLength: 9, audioOffsetTicks: 0, durationTicks: 100 },
+      // Drifted by one: should be 22 ("the"), reported as 23.
+      { text: 'the', textOffset: 23, wordLength: 3, audioOffsetTicks: 100, durationTicks: 100 },
+    ];
+    const mismatches = verifyWordBoundaries(text, boundaries);
+    expect(mismatches).toHaveLength(1);
+    expect(mismatches[0].expected).not.toBe('the');
+  });
+
+  it('flags an offset that runs past the end of the string', () => {
+    const text = 'short';
+    const boundaries = [
+      { text: 'short', textOffset: 10, wordLength: 5, audioOffsetTicks: 0, durationTicks: 100 },
+    ];
+    const mismatches = verifyWordBoundaries(text, boundaries);
+    expect(mismatches).toHaveLength(1);
+    expect(mismatches[0].expected).toBe('');
+  });
+});

--- a/build/scripts/tts-spike.ts
+++ b/build/scripts/tts-spike.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * `npm run tts:spike` — Azure Neural TTS WordBoundary offset check.
+ *
+ * Synthesizes a paragraph of text and verifies that each `WordBoundary`
+ * event's `textOffset` lines up 1:1 with the plain-text string handed to
+ * the synthesizer, with no silent drift around smart-typography characters
+ * (curly quotes, em/en dashes, ellipses) — the risk flagged in
+ * docs/superpowers/specs/2026-07-27-azure-tts-engine-design.md.
+ *
+ * Requires SPEECH_KEY / SPEECH_REGION (see .env.example). Without them this
+ * exits with a clear error rather than attempting a network call.
+ *
+ * Usage:
+ *   npm run tts:spike                    # built-in smart-typography sample
+ *   npm run tts:spike -- path/to/text.txt
+ */
+
+import 'dotenv/config';
+import { readFile, mkdir, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as sdk from 'microsoft-cognitiveservices-speech-sdk';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const outDir = join(repoRoot, 'dist', 'tts-spike');
+
+/** Narrator voice per the shortlist in the engine-design spec. */
+const DEFAULT_VOICE = process.env.TTS_SPIKE_VOICE ?? 'en-US-AndrewMultilingualNeural';
+
+/** Standard-tier pricing per the engine-design spec, for a rough cost readout. */
+const PRICE_PER_MILLION_CHARS = 16;
+
+/**
+ * Sample deliberately exercises the smart-typography substitutions Djot
+ * performs (curly quotes, em/en dash, ellipsis) plus proper nouns the spec
+ * flags as pronunciation risks.
+ */
+const SAMPLE_TEXT =
+  'Jeeves considered the matter. "It is, if I may say so, a delicate ' +
+  'situation"—the sort that wants patience, not haste. The Skill itself is ' +
+  "well-formed; it's the ePub's Djot source that needs a second look… " +
+  'three passes, minimum—maybe four.';
+
+interface WordBoundaryRecord {
+  text: string;
+  textOffset: number;
+  wordLength: number;
+  audioOffsetTicks: number;
+  durationTicks: number;
+}
+
+interface Mismatch {
+  boundary: WordBoundaryRecord;
+  expected: string;
+  actual: string;
+}
+
+/**
+ * Compare each reported word boundary against the source string it should
+ * point into. Pure function so it's testable without a network call.
+ */
+export function verifyWordBoundaries(sourceText: string, boundaries: WordBoundaryRecord[]): Mismatch[] {
+  const mismatches: Mismatch[] = [];
+  for (const boundary of boundaries) {
+    const expected = sourceText.slice(boundary.textOffset, boundary.textOffset + boundary.wordLength);
+    if (expected !== boundary.text) {
+      mismatches.push({ boundary, expected, actual: boundary.text });
+    }
+  }
+  return mismatches;
+}
+
+async function synthesize(text: string, voice: string): Promise<{ audio: ArrayBuffer; boundaries: WordBoundaryRecord[] }> {
+  const speechKey = process.env.SPEECH_KEY;
+  const speechRegion = process.env.SPEECH_REGION;
+  if (!speechKey || !speechRegion) {
+    throw new Error('Set SPEECH_KEY and SPEECH_REGION (see .env.example) to run the TTS spike.');
+  }
+
+  const speechConfig = sdk.SpeechConfig.fromSubscription(speechKey, speechRegion);
+  speechConfig.speechSynthesisVoiceName = voice;
+  speechConfig.requestWordLevelTimestamps();
+
+  const synthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
+  const boundaries: WordBoundaryRecord[] = [];
+
+  synthesizer.wordBoundary = (_sender, e) => {
+    boundaries.push({
+      text: e.text,
+      textOffset: e.textOffset,
+      wordLength: e.wordLength,
+      audioOffsetTicks: e.audioOffset,
+      durationTicks: e.duration,
+    });
+  };
+
+  const audio = await new Promise<ArrayBuffer>((resolve, reject) => {
+    synthesizer.speakTextAsync(
+      text,
+      (result) => {
+        synthesizer.close();
+        if (result.reason === sdk.ResultReason.SynthesizingAudioCompleted) {
+          resolve(result.audioData);
+        } else {
+          reject(new Error(`Synthesis failed: ${result.errorDetails ?? result.reason}`));
+        }
+      },
+      (err) => {
+        synthesizer.close();
+        reject(new Error(err));
+      },
+    );
+  });
+
+  return { audio, boundaries };
+}
+
+async function main(): Promise<void> {
+  const textPath = process.argv[2];
+  const text = textPath ? (await readFile(textPath, 'utf-8')).trim() : SAMPLE_TEXT;
+
+  console.log(`Voice: ${DEFAULT_VOICE}`);
+  console.log(`Text (${text.length} chars): ${text.slice(0, 80)}${text.length > 80 ? '…' : ''}`);
+
+  const { audio, boundaries } = await synthesize(text, DEFAULT_VOICE);
+
+  await mkdir(outDir, { recursive: true });
+  const audioPath = join(outDir, 'spike.mp3');
+  await writeFile(audioPath, Buffer.from(audio));
+
+  const mismatches = verifyWordBoundaries(text, boundaries);
+
+  console.log(`\n${boundaries.length} word boundaries captured, ${mismatches.length} mismatched.`);
+  if (mismatches.length > 0) {
+    console.log('\nMismatches (offset drift — the failure mode this spike checks for):');
+    for (const m of mismatches) {
+      console.log(`  offset ${m.boundary.textOffset}: expected ${JSON.stringify(m.expected)}, got ${JSON.stringify(m.actual)}`);
+    }
+  }
+
+  const estimatedCost = (text.length / 1_000_000) * PRICE_PER_MILLION_CHARS;
+  console.log(`\nAudio written to ${audioPath}`);
+  console.log(`Estimated cost for this run: $${estimatedCost.toFixed(4)} (standard neural tier)`);
+
+  if (mismatches.length > 0) {
+    console.error('\nFAIL: WordBoundary offsets do not align 1:1 with the source text.');
+    process.exit(1);
+  }
+  console.log('\nPASS: WordBoundary offsets align 1:1 with the source text.');
+}
+
+// Only run when invoked directly (`tsx build/scripts/tts-spike.ts`), not when
+// imported for `verifyWordBoundaries` by tests.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/docs/superpowers/specs/2026-07-27-azure-tts-engine-design.md
+++ b/docs/superpowers/specs/2026-07-27-azure-tts-engine-design.md
@@ -166,6 +166,17 @@ the string sent to Azure. That's a narrow, engine-only check and doesn't
 require the pipeline to exist first — it just needs a human with credentials
 to run it against a paragraph of already-built chapter text.
 
+`npm run tts:spike` (`build/scripts/tts-spike.ts`) is scaffolded for exactly
+this: it synthesizes a sample paragraph deliberately exercising Djot's
+smart-typography substitutions and proper nouns, captures every
+`WordBoundary` event, and verifies each one's `textOffset`/`wordLength`
+slices back to the expected word in the source string — flagging any drift
+and writing the synthesized audio to `dist/tts-spike/spike.mp3` for a
+listening check. It exits non-zero on mismatch. Pass a text file
+(`npm run tts:spike -- path/to/file.txt`) to check a real chapter excerpt
+instead of the built-in sample. Not yet run against live Azure output —
+needs `SPEECH_KEY`/`SPEECH_REGION` from the provisioned resource.
+
 ## Remaining work (not done in this pass)
 
 These require either Azure account access, human listening judgment, or the
@@ -174,7 +185,8 @@ These require either Azure account access, human listening judgment, or the
 - [ ] Provision the Azure Speech resource (paid tier, `eastus`)
 - [ ] Add `SPEECH_KEY` / `SPEECH_REGION` as GitHub Actions secrets
 - [ ] Audition the voice shortlist above and lock in three final voices
-- [ ] Confirm `WordBoundary` offset behavior against smart-typography output
+- [ ] Run `npm run tts:spike` against live Azure output and confirm `WordBoundary`
+      offsets hold (script scaffolded; needs a provisioned resource to execute)
 - [ ] Author the SSML lexicon for recurring proper nouns, once voices are locked
 - [ ] Pipeline design issue: fragment IDs, SMIL generation, incremental
       hash-based regeneration, skippability tagging (tracked separately)

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^17.4.1",
         "gray-matter": "^4.0.3",
         "jszip": "^3.10.1",
+        "microsoft-cognitiveservices-speech-sdk": "^1.51.0",
         "sharp": "^0.35.3"
       },
       "devDependencies": {
@@ -29,6 +30,46 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.11.0.tgz",
+      "integrity": "sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.14.0.tgz",
+      "integrity": "sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1047,9 +1088,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1065,9 +1103,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1085,9 +1120,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1103,9 +1135,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1123,9 +1152,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1141,9 +1167,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1161,9 +1184,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1180,9 +1200,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1198,9 +1215,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1224,9 +1238,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1248,9 +1259,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1274,9 +1282,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1298,9 +1303,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1324,9 +1326,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1349,9 +1348,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1373,9 +1369,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1589,31 +1582,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -1777,9 +1763,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1797,9 +1780,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1817,9 +1797,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1837,9 +1814,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1857,9 +1831,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1877,9 +1848,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2093,6 +2061,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/webrtc": {
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@types/webrtc/-/webrtc-0.0.37.tgz",
+      "integrity": "sha512-JGAJC/ZZDhcrrmepU4sPLQLIOIAgs5oIK+Ieq90K8fdaNMhfdfqmYatJdgif1NDQtvrSlTOGJDUYHIDunuufOg==",
+      "license": "MIT"
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -2102,6 +2076,20 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.7.tgz",
+      "integrity": "sha512-JVUD8X2tfDMWjcjLs4yVxxVrS8yR5vnh386GAXT9Qj79nBxxXSaHFQZg5FweLmT8HlPQ3kii6noUB+Z9RN7DvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2520,6 +2508,17 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/bent": {
+      "version": "7.3.12",
+      "resolved": "https://registry.npmjs.org/bent/-/bent-7.3.12.tgz",
+      "integrity": "sha512-T3yrKnVGB63zRuoco/7Ybl7BwwGZR0lceoVG5XmQyMIH9s19SV5m+a8qam4if0zQuAmOQTyPTPmsQBdAorGK3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bytesish": "^0.4.1",
+        "caseless": "~0.12.0",
+        "is-stream": "^2.0.0"
+      }
+    },
     "node_modules/better-sqlite3": {
       "version": "12.10.0",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
@@ -2624,6 +2623,12 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/bytesish": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/bytesish/-/bytesish-0.4.4.tgz",
+      "integrity": "sha512-i4uu6M4zuMUiyfZN4RU2+i9+peJh//pXhd9x1oSe1LBkZ3LEbCoygu8W0bXTukU1Jme2txKuotpCZRaC3FLxcQ==",
+      "license": "(Apache-2.0 AND MIT)"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2661,6 +2666,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -3661,7 +3672,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -3854,7 +3864,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3877,9 +3886,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -4402,6 +4411,55 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/microsoft-cognitiveservices-speech-sdk": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.51.0.tgz",
+      "integrity": "sha512-BLLovv5PegOr5Lp52h4CSgL2c/ViFAh9LoU49ILNPyb/Z0giGI7nPV3xNLcmTtHLT+kfYNRGUIA62vORLzP8TA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.9.0",
+        "@types/webrtc": "^0.0.37",
+        "agent-base": "^6.0.1",
+        "bent": "^7.3.12",
+        "https-proxy-agent": "^4.0.0",
+        "uuid": "^11.1.1",
+        "ws": "^8.21.0"
+      }
+    },
+    "node_modules/microsoft-cognitiveservices-speech-sdk/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/microsoft-cognitiveservices-speech-sdk/node_modules/https-proxy-agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "5",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/microsoft-cognitiveservices-speech-sdk/node_modules/https-proxy-agent/node_modules/agent-base": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
@@ -4563,9 +4621,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4583,9 +4638,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4603,9 +4655,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4623,9 +4672,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4643,9 +4689,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4663,9 +4706,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4683,9 +4723,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4703,9 +4740,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4723,9 +4757,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4749,9 +4780,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4775,9 +4803,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4801,9 +4826,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4827,9 +4849,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4853,9 +4872,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4879,9 +4895,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4905,9 +4918,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5617,24 +5627,23 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
-      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -6549,7 +6558,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -6687,7 +6695,6 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
       "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:check": "tsc --noEmit",
     "check:epub": "tsx build/scripts/epubcheck.ts",
     "check:a11y": "tsx build/scripts/ace.ts",
+    "tts:spike": "tsx build/scripts/tts-spike.ts",
     "dev": "npm run build:site && wrangler dev",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -32,6 +33,7 @@
     "dotenv": "^17.4.1",
     "gray-matter": "^4.0.3",
     "jszip": "^3.10.1",
+    "microsoft-cognitiveservices-speech-sdk": "^1.51.0",
     "sharp": "^0.35.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Continues #161. The licensing/pricing blockers and configuration decisions were already resolved in #165 (`docs/superpowers/specs/2026-07-27-azure-tts-engine-design.md`). Everything left on that spec's remaining-work list needs either an Azure account (resource provisioning, secrets) or human listening judgment (voice audition) — nothing a coding pass can complete unilaterally.

One item doesn't need credentials to *build*, only to *run*: the issue's spike ("synthesize one chapter end-to-end, capture `WordBoundary` output, confirm offsets map cleanly onto text"). This PR scaffolds that check so it's ready the moment `SPEECH_KEY`/`SPEECH_REGION` exist.

- Adds `npm run tts:spike` (`build/scripts/tts-spike.ts`): synthesizes a sample paragraph via Azure Neural TTS, captures every `WordBoundary` event, and verifies each `textOffset`/`wordLength` slices back to the correct word in the source string.
- The sample text deliberately exercises Djot's smart-typography substitutions (curly quotes, em/en dash, ellipsis) — the specific offset-drift risk called out in the spec — plus proper nouns from the cultural-references list.
- Writes synthesized audio to `dist/tts-spike/spike.mp3` for a listening check, prints a rough cost estimate, and exits non-zero on any offset mismatch.
- Accepts an optional text-file argument to check a real chapter excerpt instead of the built-in sample.
- `verifyWordBoundaries` is a pure function with unit tests covering the pass case, offset-drift detection, and an out-of-bounds offset.
- Adds `microsoft-cognitiveservices-speech-sdk` as a dependency; ran `npm audit fix` to close the two high-severity transitive advisories it pulled in.
- Updated the engine-design spec to point at the script and reflect that the spike is scaffolded but not yet run (blocked on a provisioned Azure resource).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 120/120 passing (3 new tests for `verifyWordBoundaries`)
- [x] Ran the script without `SPEECH_KEY`/`SPEECH_REGION` set — fails fast with a clear message, no stack trace
- [ ] Run against live Azure output once a Speech resource and `SPEECH_KEY`/`SPEECH_REGION` are provisioned (tracked in the spec's remaining-work list)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHEywCr58Nm3yAxSB4rtN9)_