### PR TITLE
build(audio): SMIL generation foundation for read-along Media Overlays

### DIFF
--- a/build/audio/smil.test.ts
+++ b/build/audio/smil.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { buildSmil, formatClockValue } from './smil.js';
+import type { WordFragment } from './word-fragments.js';
+import type { WordBoundaryRecord } from './smil.js';
+
+describe('formatClockValue', () => {
+  it('formats sub-second offsets', () => {
+    expect(formatClockValue(0)).toBe('0:00:00.000');
+    expect(formatClockValue(1.23)).toBe('0:00:01.230');
+  });
+
+  it('formats offsets past a minute and an hour', () => {
+    expect(formatClockValue(75.5)).toBe('0:01:15.500');
+    expect(formatClockValue(3661.004)).toBe('1:01:01.004');
+  });
+});
+
+describe('buildSmil', () => {
+  const fragments: WordFragment[] = [
+    { id: 'w1', text: 'Jeeves', charStart: 0, charEnd: 6 },
+    { id: 'w2', text: 'considered', charStart: 7, charEnd: 17 },
+  ];
+
+  const boundaries: WordBoundaryRecord[] = [
+    { text: 'Jeeves', textOffset: 0, wordLength: 6, audioOffsetTicks: 0, durationTicks: 3_000_000 },
+    { text: 'considered', textOffset: 7, wordLength: 10, audioOffsetTicks: 3_500_000, durationTicks: 5_000_000 },
+  ];
+
+  it('emits one <par> per matched boundary with clip times converted from ticks', () => {
+    const smil = buildSmil(fragments, boundaries, {
+      chapterId: 'ch03',
+      textSrc: 'ch03.xhtml',
+      audioSrc: 'ch03.mp3',
+    });
+
+    expect(smil).toContain('<seq id="seq-ch03" epub:textref="ch03.xhtml">');
+    expect(smil).toContain('<par id="par-w1">');
+    expect(smil).toContain('<text src="ch03.xhtml#w1"/>');
+    expect(smil).toContain('<audio src="ch03.mp3" clipBegin="0:00:00.000" clipEnd="0:00:00.300"/>');
+    expect(smil).toContain('<par id="par-w2">');
+    expect(smil).toContain('clipBegin="0:00:00.350" clipEnd="0:00:00.850"');
+  });
+
+  it('skips fragments with no matching WordBoundary rather than guessing timing', () => {
+    const smil = buildSmil(fragments, [boundaries[0]], {
+      chapterId: 'ch03',
+      textSrc: 'ch03.xhtml',
+      audioSrc: 'ch03.mp3',
+    });
+
+    expect(smil).toContain('par-w1');
+    expect(smil).not.toContain('par-w2');
+  });
+
+  it('produces a valid empty <seq> when there are no boundaries', () => {
+    const smil = buildSmil(fragments, [], { chapterId: 'ch03', textSrc: 'ch03.xhtml', audioSrc: 'ch03.mp3' });
+    expect(smil).toContain('<seq id="seq-ch03" epub:textref="ch03.xhtml">');
+    expect(smil).toContain('</seq>');
+    expect(smil).not.toContain('<par');
+  });
+
+  it('escapes XML-sensitive characters in ids and file names', () => {
+    const smil = buildSmil(
+      [{ id: 'w1', text: 'a', charStart: 0, charEnd: 1 }],
+      [{ text: 'a', textOffset: 0, wordLength: 1, audioOffsetTicks: 0, durationTicks: 1 }],
+      { chapterId: 'ch"1', textSrc: 'a&b.xhtml', audioSrc: 'a&b.mp3' },
+    );
+    expect(smil).toContain('seq-ch&quot;1');
+    expect(smil).toContain('a&amp;b.xhtml');
+  });
+});

--- a/build/audio/smil.ts
+++ b/build/audio/smil.ts
@@ -1,0 +1,107 @@
+/**
+ * EPUB 3 Media Overlays (SMIL) generation.
+ *
+ * Turns word-level fragment ids (from `word-fragments.ts`) and Azure Neural
+ * TTS `WordBoundary` output (see `build/scripts/tts-spike.ts` and
+ * docs/superpowers/specs/2026-07-27-azure-tts-engine-design.md) into a SMIL
+ * file that syncs each word span to its slice of the narration audio.
+ *
+ * https://www.w3.org/TR/epub-33/#sec-media-overlays
+ */
+
+import type { WordFragment } from './word-fragments.js';
+
+/** Azure `SpeechSynthesisWordBoundaryEventArgs`, in the shape this module needs. */
+export interface WordBoundaryRecord {
+  text: string;
+  /** Character offset into the narratable text handed to the synthesizer. */
+  textOffset: number;
+  wordLength: number;
+  /** 100-nanosecond ticks, per the Speech SDK's audioOffset unit. */
+  audioOffsetTicks: number;
+  /** 100-nanosecond ticks, per the Speech SDK's duration unit. */
+  durationTicks: number;
+}
+
+export interface SmilOptions {
+  /** id for the top-level <seq>, e.g. "ch03". */
+  chapterId: string;
+  /** XHTML file the fragments live in, e.g. "ch03.xhtml". */
+  textSrc: string;
+  /** Audio file the clip times reference, e.g. "ch03.mp3". */
+  audioSrc: string;
+}
+
+const TICKS_PER_SECOND = 10_000_000;
+
+/** Format seconds as a SMIL full clock value, "H:MM:SS.mmm". */
+export function formatClockValue(seconds: number): string {
+  const totalMs = Math.round(seconds * 1000);
+  const ms = totalMs % 1000;
+  const totalSeconds = Math.floor(totalMs / 1000);
+  const s = totalSeconds % 60;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const m = totalMinutes % 60;
+  const h = Math.floor(totalMinutes / 60);
+  return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}.${String(ms).padStart(3, '0')}`;
+}
+
+function escapeXmlAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Find the fragment whose character range contains a WordBoundary's range.
+ * Uses overlap rather than exact equality since Azure's own word
+ * tokenization (e.g. around hyphens or abbreviations) isn't guaranteed to
+ * match ours exactly.
+ */
+function findFragment(fragments: WordFragment[], boundary: WordBoundaryRecord): WordFragment | undefined {
+  const boundaryEnd = boundary.textOffset + boundary.wordLength;
+  return fragments.find((f) => f.charStart < boundaryEnd && f.charEnd > boundary.textOffset);
+}
+
+/**
+ * Build a SMIL document mapping each word fragment to its clip range in the
+ * narration audio. Fragments with no matching WordBoundary (e.g. a fragment
+ * the synthesizer silently dropped) are skipped, not emitted with bogus
+ * timing — a missing highlight is a smaller failure than a wrong one.
+ */
+export function buildSmil(
+  fragments: WordFragment[],
+  boundaries: WordBoundaryRecord[],
+  options: SmilOptions,
+): string {
+  const pars: string[] = [];
+
+  for (const boundary of boundaries) {
+    const fragment = findFragment(fragments, boundary);
+    if (!fragment) continue;
+
+    const clipBegin = boundary.audioOffsetTicks / TICKS_PER_SECOND;
+    const clipEnd = (boundary.audioOffsetTicks + boundary.durationTicks) / TICKS_PER_SECOND;
+
+    pars.push(
+      `      <par id="par-${escapeXmlAttr(fragment.id)}">\n` +
+        `        <text src="${escapeXmlAttr(options.textSrc)}#${escapeXmlAttr(fragment.id)}"/>\n` +
+        `        <audio src="${escapeXmlAttr(options.audioSrc)}" clipBegin="${formatClockValue(clipBegin)}" clipEnd="${formatClockValue(clipEnd)}"/>\n` +
+        `      </par>`,
+    );
+  }
+
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<smil xmlns="http://www.w3.org/ns/SMIL" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0">\n` +
+    `  <body>\n` +
+    `    <seq id="seq-${escapeXmlAttr(options.chapterId)}" epub:textref="${escapeXmlAttr(options.textSrc)}">\n` +
+    pars.join('\n') +
+    (pars.length ? '\n' : '') +
+    `    </seq>\n` +
+    `  </body>\n` +
+    `</smil>\n`
+  );
+}

--- a/build/audio/word-fragments.test.ts
+++ b/build/audio/word-fragments.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { injectWordFragments } from './word-fragments.js';
+
+describe('injectWordFragments', () => {
+  it('wraps each word in a plain paragraph', () => {
+    const { html, fragments, narratableText } = injectWordFragments('<p>Jeeves considered the matter.</p>');
+    expect(html).toBe(
+      '<p><span id="w1">Jeeves</span> <span id="w2">considered</span> <span id="w3">the</span> <span id="w4">matter</span>.</p>',
+    );
+    expect(fragments.map((f) => f.text)).toEqual(['Jeeves', 'considered', 'the', 'matter']);
+    expect(narratableText).toBe('Jeeves considered the matter.');
+  });
+
+  it('does not tokenize inside tags or attributes', () => {
+    const { html, fragments } = injectWordFragments('<a href="ch2.xhtml#note-1">the note</a>');
+    expect(html).toBe('<a href="ch2.xhtml#note-1"><span id="w1">the</span> <span id="w2">note</span></a>');
+    expect(fragments).toHaveLength(2);
+  });
+
+  it('assigns fragment character offsets that slice back to the word in narratableText', () => {
+    const { narratableText, fragments } = injectWordFragments('<p>Jeeves considered the matter—carefully.</p>');
+    for (const f of fragments) {
+      expect(narratableText.slice(f.charStart, f.charEnd)).toBe(f.text);
+    }
+  });
+
+  it('keeps punctuation-only and whitespace-only segments unwrapped', () => {
+    const { html } = injectWordFragments('<p>"Well," he said.</p>');
+    expect(html).toBe('<p>"<span id="w1">Well</span>," <span id="w2">he</span> <span id="w3">said</span>.</p>');
+  });
+
+  it('handles words split across multiple tags without cross-tag merging', () => {
+    const { html, fragments } = injectWordFragments('<p><em>quite</em> right</p>');
+    expect(html).toBe('<p><em><span id="w1">quite</span></em> <span id="w2">right</span></p>');
+    expect(fragments).toHaveLength(2);
+  });
+
+  it('continues fragment ids from a supplied startIndex', () => {
+    const { fragments } = injectWordFragments('<p>one two</p>', 41);
+    expect(fragments.map((f) => f.id)).toEqual(['w41', 'w42']);
+  });
+
+  it('produces no fragments for text with no words', () => {
+    const { html, fragments, narratableText } = injectWordFragments('<hr/>');
+    expect(html).toBe('<hr/>');
+    expect(fragments).toEqual([]);
+    expect(narratableText).toBe('');
+  });
+});

--- a/build/audio/word-fragments.ts
+++ b/build/audio/word-fragments.ts
@@ -1,0 +1,77 @@
+/**
+ * Word-level fragment ids for EPUB 3 Media Overlays.
+ *
+ * Walks rendered chapter HTML, wraps each word in a stable `<span id>`, and
+ * returns the plain narratable text with matching character offsets — the
+ * same string that gets sent to the TTS engine, and the same offsets its
+ * `WordBoundary` events report against (see `build/audio/smil.ts`).
+ *
+ * Standalone and not yet wired into `build/pipeline.ts`'s default render
+ * path — see #167 for why (every one of the book's ~169k words getting a
+ * span needs its own review pass once something downstream consumes it).
+ */
+
+export interface WordFragment {
+  id: string;
+  text: string;
+  /** Character offsets into the returned narratableText, [charStart, charEnd). */
+  charStart: number;
+  charEnd: number;
+}
+
+export interface WordFragmentResult {
+  html: string;
+  narratableText: string;
+  fragments: WordFragment[];
+}
+
+/** A run of letters/numbers, allowing internal apostrophes and hyphens. */
+const WORD_PATTERN = /[\p{L}\p{N}](?:[\p{L}\p{N}'’-]*[\p{L}\p{N}])?/gu;
+
+/** Matches an HTML tag, so text-node content can be tokenized around it. */
+const TAG_PATTERN = /<[^>]+>/g;
+
+/**
+ * Wrap each word in the text nodes of `html` with `<span id="w{n}">`,
+ * leaving tags and non-word characters (whitespace, punctuation) untouched.
+ * Ids are sequential within this call, starting from `startIndex`.
+ */
+export function injectWordFragments(html: string, startIndex = 1): WordFragmentResult {
+  const fragments: WordFragment[] = [];
+  let narratableText = '';
+  let nextId = startIndex;
+  let outHtml = '';
+  let cursor = 0;
+
+  TAG_PATTERN.lastIndex = 0;
+  let tagMatch: RegExpExecArray | null;
+  const appendTextSegment = (segment: string) => {
+    let lastEnd = 0;
+    WORD_PATTERN.lastIndex = 0;
+    let wordMatch: RegExpExecArray | null;
+    while ((wordMatch = WORD_PATTERN.exec(segment))) {
+      outHtml += segment.slice(lastEnd, wordMatch.index);
+      narratableText += segment.slice(lastEnd, wordMatch.index);
+
+      const word = wordMatch[0];
+      const id = `w${nextId++}`;
+      const charStart = narratableText.length;
+      narratableText += word;
+      fragments.push({ id, text: word, charStart, charEnd: narratableText.length });
+      outHtml += `<span id="${id}">${word}</span>`;
+
+      lastEnd = wordMatch.index + word.length;
+    }
+    outHtml += segment.slice(lastEnd);
+    narratableText += segment.slice(lastEnd);
+  };
+
+  while ((tagMatch = TAG_PATTERN.exec(html))) {
+    appendTextSegment(html.slice(cursor, tagMatch.index));
+    outHtml += tagMatch[0];
+    cursor = tagMatch.index + tagMatch[0].length;
+  }
+  appendTextSegment(html.slice(cursor));
+
+  return { html: outHtml, narratableText, fragments };
+}


### PR DESCRIPTION
## Summary

Foundation for #167 (SMIL generation for the read-along audiobook — follow-up to #161, which explicitly scoped SMIL out). Two standalone, pure, unit-tested modules:

- **`build/audio/word-fragments.ts`** — `injectWordFragments()` walks rendered chapter HTML and wraps each word in a stable `<span id="w{n}">`, skipping tag/attribute content. Returns the plain narratable text alongside, with each fragment's character offsets into that string — the exact string/offset space a TTS engine's `WordBoundary` events (see #161's spike script) report against.
- **`build/audio/smil.ts`** — `buildSmil()` turns those fragments plus Azure-shaped `WordBoundary` records into valid SMIL 3.0 XML (`<par>`/`<text>`/`<audio clipBegin/clipEnd>`), matching #161's rationale for choosing Azure: `WordBoundary` gives both halves of the SMIL mapping directly, no forced alignment needed.

Design choices worth flagging:
- Fragments and `WordBoundary` records are joined by **character-range overlap**, not array index or exact offset equality — they're produced independently (fragments from HTML at render time, boundaries from Azure at synthesis time) and Azure's own word tokenization isn't guaranteed to match ours exactly (hyphenation, abbreviations, etc.).
- A fragment with no matching boundary is **skipped**, not given guessed timing — per #161's own framing, a missing highlight is a smaller failure than a wrong one.
- Word tokenization allows internal apostrophes/hyphens (`Jean-Luc`, `it's`) and cleanly treats djot's smart-typography output (em dashes, curly quotes) as separators, not word characters.

**Not wired into `build/pipeline.ts`'s default render path.** Doing that means every one of the book's ~169k words gets a `<span>` in the shipped XHTML, which deserves its own review pass (`check:epub`, `check:a11y`, output-size sanity) once there's something downstream to actually consume it — tracked as follow-up in #167, along with skippability tagging for callouts/footnotes, illustration handling, and full pipeline wiring.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 133/133 passing (13 new: word-fragment tokenization edge cases, SMIL clock-value formatting, offset-based boundary matching, XML escaping)
- [x] Smoke-tested `injectWordFragments` against a real rendered chapter (*What These Tools Actually Are*, 2099 words) — 0 offset mismatches between fragment ranges and the returned narratable text

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHEywCr58Nm3yAxSB4rtN9)_