### PR TITLE
build(audio): wire word-fragment ids into the ePub build

### DIFF
--- a/build/audio/word-fragments.test.ts
+++ b/build/audio/word-fragments.test.ts
@@ -46,4 +46,29 @@ describe('injectWordFragments', () => {
     expect(fragments).toEqual([]);
     expect(narratableText).toBe('');
   });
+
+  it('does not split an HTML entity into a word span, and decodes it in narratableText', () => {
+    // Reproduces the epubcheck failure this pattern guards against: djot's
+    // HTML renderer escapes literal "&" as "&amp;", and naive word-matching
+    // tokenizes "amp" out of it, splitting the entity into `&<span>amp</span>;`
+    // — a bare `&` that's not well-formed XML.
+    const { html, fragments, narratableText } = injectWordFragments('<p>Marks &amp; Spencer</p>');
+    expect(html).toBe('<p><span id="w1">Marks</span> &amp; <span id="w2">Spencer</span></p>');
+    expect(fragments.map((f) => f.text)).toEqual(['Marks', 'Spencer']);
+    expect(narratableText).toBe('Marks & Spencer');
+  });
+
+  it('decodes numeric character references and preserves them verbatim in the HTML', () => {
+    const { html, narratableText } = injectWordFragments('<p>5 &#38; 10, &#x26;more</p>');
+    expect(html).toContain('&#38;');
+    expect(html).toContain('&#x26;');
+    expect(narratableText).toContain('5 & 10, &more');
+  });
+
+  it('keeps every fragment offset valid even when the segment contains entities', () => {
+    const { narratableText, fragments } = injectWordFragments('<p>Marks &amp; Spencer &lt;the store&gt;</p>');
+    for (const f of fragments) {
+      expect(narratableText.slice(f.charStart, f.charEnd)).toBe(f.text);
+    }
+  });
 });

--- a/build/audio/word-fragments.ts
+++ b/build/audio/word-fragments.ts
@@ -26,15 +26,40 @@ export interface WordFragmentResult {
 }
 
 /** A run of letters/numbers, allowing internal apostrophes and hyphens. */
-const WORD_PATTERN = /[\p{L}\p{N}](?:[\p{L}\p{N}'’-]*[\p{L}\p{N}])?/gu;
+const WORD_SOURCE = String.raw`[\p{L}\p{N}](?:[\p{L}\p{N}'’-]*[\p{L}\p{N}])?`;
+
+/**
+ * An HTML character reference, e.g. `&amp;`, `&#38;`, `&#x26;`. djot's HTML
+ * renderer only ever emits `&amp;`/`&lt;`/`&gt;` in text content, but this
+ * matches any well-formed reference so a future raw_inline HTML block
+ * doesn't reintroduce the bug this pattern exists to prevent: without it,
+ * the word matcher tokenizes "amp" out of "&amp;" and wraps it in a span,
+ * splitting `&amp;` into `&<span>amp</span>;` — a bare `&` that breaks XML
+ * well-formedness.
+ */
+const ENTITY_SOURCE = String.raw`&(?:#\d+|#x[0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);`;
+
+/** Entities this module knows how to decode for the narratable-text side. */
+const NAMED_ENTITIES: Record<string, string> = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" };
+
+function decodeEntity(entity: string): string {
+  const body = entity.slice(1, -1);
+  if (body.startsWith('#x') || body.startsWith('#X')) return String.fromCodePoint(parseInt(body.slice(2), 16));
+  if (body.startsWith('#')) return String.fromCodePoint(parseInt(body.slice(1), 10));
+  return NAMED_ENTITIES[body] ?? entity;
+}
+
+/** Matches a word or an HTML entity — entities must be tried first so they win the alternation. */
+const TOKEN_PATTERN = new RegExp(`${ENTITY_SOURCE}|${WORD_SOURCE}`, 'gu');
 
 /** Matches an HTML tag, so text-node content can be tokenized around it. */
 const TAG_PATTERN = /<[^>]+>/g;
 
 /**
  * Wrap each word in the text nodes of `html` with `<span id="w{n}">`,
- * leaving tags and non-word characters (whitespace, punctuation) untouched.
- * Ids are sequential within this call, starting from `startIndex`.
+ * leaving tags, entities, and other non-word characters (whitespace,
+ * punctuation) untouched. Ids are sequential within this call, starting
+ * from `startIndex`.
  */
 export function injectWordFragments(html: string, startIndex = 1): WordFragmentResult {
   const fragments: WordFragment[] = [];
@@ -43,29 +68,37 @@ export function injectWordFragments(html: string, startIndex = 1): WordFragmentR
   let outHtml = '';
   let cursor = 0;
 
-  TAG_PATTERN.lastIndex = 0;
-  let tagMatch: RegExpExecArray | null;
   const appendTextSegment = (segment: string) => {
     let lastEnd = 0;
-    WORD_PATTERN.lastIndex = 0;
-    let wordMatch: RegExpExecArray | null;
-    while ((wordMatch = WORD_PATTERN.exec(segment))) {
-      outHtml += segment.slice(lastEnd, wordMatch.index);
-      narratableText += segment.slice(lastEnd, wordMatch.index);
+    TOKEN_PATTERN.lastIndex = 0;
+    let tokenMatch: RegExpExecArray | null;
+    while ((tokenMatch = TOKEN_PATTERN.exec(segment))) {
+      outHtml += segment.slice(lastEnd, tokenMatch.index);
+      narratableText += segment.slice(lastEnd, tokenMatch.index);
 
-      const word = wordMatch[0];
-      const id = `w${nextId++}`;
-      const charStart = narratableText.length;
-      narratableText += word;
-      fragments.push({ id, text: word, charStart, charEnd: narratableText.length });
-      outHtml += `<span id="${id}">${word}</span>`;
+      const token = tokenMatch[0];
+      if (token.startsWith('&')) {
+        // Entity reference: passed through verbatim in the HTML (unwrapping
+        // it would emit invalid XML), decoded in the narratable text (an
+        // HTML entity read as its literal name would mispronounce it).
+        outHtml += token;
+        narratableText += decodeEntity(token);
+      } else {
+        const id = `w${nextId++}`;
+        const charStart = narratableText.length;
+        narratableText += token;
+        fragments.push({ id, text: token, charStart, charEnd: narratableText.length });
+        outHtml += `<span id="${id}">${token}</span>`;
+      }
 
-      lastEnd = wordMatch.index + word.length;
+      lastEnd = tokenMatch.index + token.length;
     }
     outHtml += segment.slice(lastEnd);
     narratableText += segment.slice(lastEnd);
   };
 
+  TAG_PATTERN.lastIndex = 0;
+  let tagMatch: RegExpExecArray | null;
   while ((tagMatch = TAG_PATTERN.exec(html))) {
     appendTextSegment(html.slice(cursor, tagMatch.index));
     outHtml += tagMatch[0];

--- a/build/index.ts
+++ b/build/index.ts
@@ -24,6 +24,7 @@ import { assembleEpub } from './epub/assemble.js';
 import { generateMissingArt } from './generate-art.js';
 import { BOOK_META } from './types.js';
 import { validateAccessibility, formatA11yIssues } from './validators/a11y.js';
+import { injectWordFragments } from './audio/word-fragments.js';
 
 const OUTPUT_PATH = join(ROOT, 'dist', 'majordomo.epub');
 
@@ -129,10 +130,18 @@ async function build(): Promise<void> {
   console.log('Optimizing images...');
   await optimizeImages(IMAGES_DIR, optimizedDir, 800, allBriefs);
 
+  // Word-level fragment ids for the read-along edition's Media Overlays
+  // (see #167). ePub-only — the site and PDF builds render `sorted`
+  // directly and never see these spans.
+  const narratedChapters = sorted.map((chapter) => ({
+    ...chapter,
+    html: injectWordFragments(chapter.html).html,
+  }));
+
   console.log('Assembling ePub...');
   await assembleEpub(
     BOOK_META,
-    sorted,
+    narratedChapters,
     join(STYLES_DIR, 'base.css'),
     optimizedDir,
     OUTPUT_PATH


### PR DESCRIPTION
## Summary

Continues #167. `injectWordFragments` (merged in #168) now runs on every chapter's rendered HTML right before ePub assembly, so the shipped XHTML actually carries the per-word `<span id="w{n}">` fragments SMIL will point to. ePub-only — `build/index.ts` builds a separate `narratedChapters` array for `assembleEpub`; the site and PDF builds still consume the unmodified `sorted` chapters, since fragment ids only mean anything for Media Overlays.

## A real bug, caught by actually running the full build

The prior PR smoke-tested `injectWordFragments` against one chapter (2099 words, 0 offset mismatches) but never ran it through `check:epub` against the whole book. Doing that here surfaced a genuine well-formedness bug: djot escapes literal `&` in prose (e.g. "R&D") to `&amp;` in rendered HTML, and the word tokenizer was matching `amp` inside it as a word and wrapping it — turning `&amp;` into `&<span id="wN">amp</span>;`. That's a bare `&` outside any valid entity, which is not well-formed XML. EPUBCheck caught it as 32 fatals / 116 errors, all `RSC-012 Fragment identifier is not defined` — the malformed entity corrupted parsing badly enough that later, genuinely-valid `id` attributes in the same file stopped resolving.

Fix: HTML entity references (`&amp;`, `&lt;`, `&gt;`, plus numeric `&#NNN;`/`&#xHEX;` for robustness against future `raw_inline` HTML) are now matched as a single atomic token, never split. They pass through the HTML untouched and get decoded to their literal character in the parallel `narratableText` (so `&amp;` reads as `&` for narration, not as the word "amp").

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 136/136 passing (3 new tests covering the entity-splitting bug and its fix)
- [x] `npm run build` — succeeds, `build/validators/a11y.ts`'s accessibility gate passes
- [x] `npm run check:epub` against the full built book — **0 fatals / 0 errors / 0 warnings** (previously 32 fatals / 116 errors before the entity fix)
- [x] `npm run check:a11y` (Ace by DAISY) — fails identically on unmodified `main` in this sandbox (headless browser can't launch here); confirmed not a regression from this change

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHEywCr58Nm3yAxSB4rtN9)_