### PR TITLE
build(audio): incremental hash-based narration regeneration

### DIFF
--- a/build/audio/narration-cache.test.ts
+++ b/build/audio/narration-cache.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hashNarratableText,
+  planNarrationRegeneration,
+  findStaleManifestEntries,
+  updateManifest,
+} from './narration-cache.js';
+import type { NarrationManifest } from './narration-cache.js';
+
+describe('hashNarratableText', () => {
+  it('is deterministic', () => {
+    expect(hashNarratableText('Jeeves considered the matter.')).toBe(
+      hashNarratableText('Jeeves considered the matter.'),
+    );
+  });
+
+  it('differs for different text, including a single-character edit', () => {
+    const a = hashNarratableText('Jeeves considered the matter.');
+    const b = hashNarratableText('Jeeves considered the matters.');
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('planNarrationRegeneration', () => {
+  it('marks a chapter with no manifest entry as new', () => {
+    const plan = planNarrationRegeneration([{ slug: 'ch01', narratableText: 'Hello there.' }], {});
+    expect(plan).toEqual([
+      { slug: 'ch01', hash: hashNarratableText('Hello there.'), charCount: 12, reason: 'new' },
+    ]);
+  });
+
+  it('marks a chapter as unchanged when its hash matches the manifest', () => {
+    const text = 'Hello there.';
+    const manifest: NarrationManifest = { ch01: { hash: hashNarratableText(text), audioFile: 'ch01.mp3' } };
+    const plan = planNarrationRegeneration([{ slug: 'ch01', narratableText: text }], manifest);
+    expect(plan[0].reason).toBe('unchanged');
+  });
+
+  it('marks a chapter as changed when its text no longer matches the recorded hash', () => {
+    const manifest: NarrationManifest = {
+      ch01: { hash: hashNarratableText('Hello there.'), audioFile: 'ch01.mp3' },
+    };
+    const plan = planNarrationRegeneration([{ slug: 'ch01', narratableText: 'Hello there, friend.' }], manifest);
+    expect(plan[0].reason).toBe('changed');
+  });
+
+  it('plans each chapter independently', () => {
+    const manifest: NarrationManifest = {
+      ch01: { hash: hashNarratableText('Unchanged text.'), audioFile: 'ch01.mp3' },
+      ch02: { hash: hashNarratableText('Old text.'), audioFile: 'ch02.mp3' },
+    };
+    const plan = planNarrationRegeneration(
+      [
+        { slug: 'ch01', narratableText: 'Unchanged text.' },
+        { slug: 'ch02', narratableText: 'New text.' },
+        { slug: 'ch03', narratableText: 'Brand new chapter.' },
+      ],
+      manifest,
+    );
+    expect(plan.map((p) => p.reason)).toEqual(['unchanged', 'changed', 'new']);
+  });
+});
+
+describe('findStaleManifestEntries', () => {
+  it('reports manifest entries whose chapter no longer exists', () => {
+    const manifest: NarrationManifest = {
+      ch01: { hash: 'a', audioFile: 'ch01.mp3' },
+      ch02: { hash: 'b', audioFile: 'ch02.mp3' },
+    };
+    const stale = findStaleManifestEntries([{ slug: 'ch01', narratableText: 'still here' }], manifest);
+    expect(stale).toEqual(['ch02']);
+  });
+
+  it('reports nothing stale when every manifest entry has a matching chapter', () => {
+    const manifest: NarrationManifest = { ch01: { hash: 'a', audioFile: 'ch01.mp3' } };
+    const stale = findStaleManifestEntries([{ slug: 'ch01', narratableText: 'x' }], manifest);
+    expect(stale).toEqual([]);
+  });
+});
+
+describe('updateManifest', () => {
+  it('adds a new entry without mutating the original manifest', () => {
+    const original: NarrationManifest = {};
+    const updated = updateManifest(original, 'ch01', 'hash123', 'ch01.mp3');
+    expect(original).toEqual({});
+    expect(updated).toEqual({ ch01: { hash: 'hash123', audioFile: 'ch01.mp3' } });
+  });
+
+  it('overwrites an existing entry for the same slug', () => {
+    const original: NarrationManifest = { ch01: { hash: 'old', audioFile: 'ch01.mp3' } };
+    const updated = updateManifest(original, 'ch01', 'new', 'ch01.mp3');
+    expect(updated.ch01.hash).toBe('new');
+  });
+});

--- a/build/audio/narration-cache.ts
+++ b/build/audio/narration-cache.ts
@@ -1,0 +1,80 @@
+/**
+ * Incremental, hash-based narration regeneration (see #161's cost-control
+ * section and #167). This is a living document under active revision — a
+ * full multi-hour re-render on every typo fix isn't viable, so each
+ * chapter's narratable text (the same string `injectWordFragments` returns,
+ * see `build/audio/word-fragments.ts`) is hashed and compared against the
+ * hash recorded the last time that chapter was actually synthesized.
+ *
+ * Pure planning logic only — it decides what *would* need synthesis. It
+ * does not call Azure and does not write the manifest; that's the
+ * responsibility of the synthesis step itself (deferred to #167's
+ * end-to-end pipeline wiring, which needs a live Azure resource from #161).
+ */
+
+import { createHash } from 'node:crypto';
+
+export interface NarrationManifestEntry {
+  /** SHA-256 hex digest of the narratable text last synthesized for this chapter. */
+  hash: string;
+  /** Audio file this chapter's narration was written to, e.g. "ch03.mp3". */
+  audioFile: string;
+}
+
+/** slug -> the manifest entry recorded after that chapter's last successful synthesis. */
+export type NarrationManifest = Record<string, NarrationManifestEntry>;
+
+export interface ChapterNarration {
+  slug: string;
+  narratableText: string;
+}
+
+export type RegenerationReason = 'new' | 'changed' | 'unchanged';
+
+export interface RegenerationPlanEntry {
+  slug: string;
+  hash: string;
+  charCount: number;
+  reason: RegenerationReason;
+}
+
+export function hashNarratableText(text: string): string {
+  return createHash('sha256').update(text, 'utf8').digest('hex');
+}
+
+/**
+ * Decide, for each chapter, whether its narration needs (re)synthesis:
+ * "new" (no manifest entry yet), "changed" (hash no longer matches), or
+ * "unchanged" (safe to skip — the existing audio is still current).
+ */
+export function planNarrationRegeneration(
+  chapters: ChapterNarration[],
+  manifest: NarrationManifest,
+): RegenerationPlanEntry[] {
+  return chapters.map(({ slug, narratableText }) => {
+    const hash = hashNarratableText(narratableText);
+    const existing = manifest[slug];
+    const reason: RegenerationReason = !existing ? 'new' : existing.hash !== hash ? 'changed' : 'unchanged';
+    return { slug, hash, charCount: narratableText.length, reason };
+  });
+}
+
+/**
+ * Manifest entries for chapters no longer present in the source — e.g. a
+ * chapter was deleted or renamed. Their audio files are safe to prune;
+ * this only reports the stale slugs, it doesn't delete anything.
+ */
+export function findStaleManifestEntries(chapters: ChapterNarration[], manifest: NarrationManifest): string[] {
+  const slugs = new Set(chapters.map((c) => c.slug));
+  return Object.keys(manifest).filter((slug) => !slugs.has(slug));
+}
+
+/** Record a chapter's manifest entry after it's actually been synthesized. */
+export function updateManifest(
+  manifest: NarrationManifest,
+  slug: string,
+  hash: string,
+  audioFile: string,
+): NarrationManifest {
+  return { ...manifest, [slug]: { hash, audioFile } };
+}

--- a/build/scripts/narration-plan.ts
+++ b/build/scripts/narration-plan.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * `npm run narration:plan` — report which chapters' narration would need
+ * (re)synthesis, per #161's cost-control requirement and #167's incremental
+ * regeneration item.
+ *
+ * Read-only: computes each chapter's narratable text (the same extraction
+ * `injectWordFragments` does for the ePub build), hashes it, and compares
+ * against `src/audio/manifest.json` (if present). Does not call Azure and
+ * does not write the manifest — that's the synthesis step's job, once #161's
+ * Azure resource exists. Until then, every chapter reports "new".
+ *
+ * Usage: npm run narration:plan
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import matter from 'gray-matter';
+import {
+  ROOT,
+  CONTENT_DIR,
+  IMAGES_DIR,
+  ILLUSTRATION_SPEC_DIR,
+  discoverBriefs,
+  prepareArtContext,
+  discoverChapters,
+  processChapterFromSource,
+  parseSlug,
+  buildRefRegistry,
+} from '../pipeline.js';
+import type { RefWarning } from '../pipeline.js';
+import { injectWordFragments } from '../audio/word-fragments.js';
+import { planNarrationRegeneration, findStaleManifestEntries } from '../audio/narration-cache.js';
+import type { NarrationManifest } from '../audio/narration-cache.js';
+
+const MANIFEST_PATH = join(ROOT, 'src', 'audio', 'manifest.json');
+const PRICE_PER_MILLION_CHARS = 16; // standard neural tier, per docs/superpowers/specs/2026-07-27-azure-tts-engine-design.md
+
+async function loadManifest(): Promise<NarrationManifest> {
+  try {
+    return JSON.parse(await readFile(MANIFEST_PATH, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+async function main(): Promise<void> {
+  const briefs = discoverBriefs(CONTENT_DIR);
+  const illustrationBriefs = discoverBriefs(ILLUSTRATION_SPEC_DIR);
+  const allBriefs = new Map([...briefs, ...illustrationBriefs]);
+  const artCtx = await prepareArtContext(allBriefs, IMAGES_DIR);
+
+  const files = await discoverChapters();
+  const sources = await Promise.all(
+    files.map(async (filePath) => ({ filePath, raw: await readFile(filePath, 'utf-8') })),
+  );
+
+  const refRegistry = buildRefRegistry(
+    sources.map(({ filePath, raw }) => ({ slug: parseSlug(filePath), content: matter(raw).content })),
+  );
+  const refWarnings: RefWarning[] = [];
+
+  const chapters = sources.map(({ filePath, raw }) =>
+    processChapterFromSource(filePath, raw, artCtx, { registry: refRegistry, warnings: refWarnings }),
+  );
+
+  const narrated = chapters.map((chapter) => ({
+    slug: chapter.meta.slug,
+    narratableText: injectWordFragments(chapter.html).narratableText,
+  }));
+
+  const manifest = await loadManifest();
+  const plan = planNarrationRegeneration(narrated, manifest);
+  const stale = findStaleManifestEntries(narrated, manifest);
+
+  const needsWork = plan.filter((p) => p.reason !== 'unchanged');
+  const totalChars = needsWork.reduce((sum, p) => sum + p.charCount, 0);
+
+  console.log(`${plan.length} chapter(s) checked against ${MANIFEST_PATH}\n`);
+  for (const p of plan) {
+    if (p.reason === 'unchanged') continue;
+    console.log(`  ${p.reason.padEnd(9)} ${p.slug} (${p.charCount} chars)`);
+  }
+
+  console.log(
+    `\n${needsWork.length}/${plan.length} chapter(s) need synthesis, ` +
+      `${plan.length - needsWork.length} unchanged.`,
+  );
+  if (needsWork.length > 0) {
+    const estimatedCost = (totalChars / 1_000_000) * PRICE_PER_MILLION_CHARS;
+    console.log(`${totalChars} characters, ~$${estimatedCost.toFixed(2)} at standard neural tier.`);
+  }
+  if (stale.length > 0) {
+    console.log(`\n${stale.length} stale manifest entries with no matching chapter: ${stale.join(', ')}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check:epub": "tsx build/scripts/epubcheck.ts",
     "check:a11y": "tsx build/scripts/ace.ts",
     "tts:spike": "tsx build/scripts/tts-spike.ts",
+    "narration:plan": "tsc && node dist/build/scripts/narration-plan.js",
     "dev": "npm run build:site && wrangler dev",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary

Continues #167. Per #161's cost-control section: "Regeneration must be incremental — hash each chapter's narratable text and re-synthesize only chapters whose hash changed." This implements that decision logic.

- **`build/audio/narration-cache.ts`** — pure functions: `hashNarratableText` (SHA-256 of a chapter's narratable text — the same string `injectWordFragments` extracts), `planNarrationRegeneration` (classifies each chapter as `new`/`changed`/`unchanged` against a manifest), `findStaleManifestEntries` (flags manifest entries whose chapter no longer exists), `updateManifest`. No Azure calls, no file I/O — pure decision logic.
- **`npm run narration:plan`** — read-only CLI report: runs every chapter through the real pipeline, extracts narratable text, hashes it, and compares against `src/audio/manifest.json` (absent until synthesis first runs — so today, every chapter reports `new`). Ran against the full book: **45 chapters, ~1.04M characters, ~$16.64 at standard neural tier** — lines up with #161's own ~1.05M-character estimate.

Deliberately doesn't call Azure or write the manifest — that's the synthesis step's job once #161's Azure resource exists. This PR only establishes: what gets hashed, how the hash is compared, and what the manifest schema looks like, so the future synthesis step has a decision function to call rather than reinventing one.

## Note on `narration:plan`'s script wiring

`build/pipeline.ts`'s `ROOT`/`CONTENT_DIR` constants resolve relative to the *compiled* output layout (`dist/build/pipeline.js`), not the TS source — `build/scripts/dump-golden.ts` has this same property already. So `narration:plan` runs as `tsc && node dist/build/scripts/narration-plan.js`, matching the existing `build`/`build:site`/`build:pdf` scripts, rather than a direct `tsx` invocation (confirmed the direct-`tsx` form fails identically on the pre-existing `dump-golden.ts`, so this isn't a regression — just following the working convention).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 146/146 passing (10 new: hash determinism, new/changed/unchanged classification, stale-entry detection, manifest immutability)
- [x] `npm run narration:plan` against the full book — reports 45/45 new (no manifest yet), ~1.04M chars, ~$16.64 estimate
- [x] Manually hashed one chapter's real narratable text into a manifest and reran — only that chapter dropped to "unchanged," confirming the hash comparison actually discriminates changed vs. unchanged content

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHEywCr58Nm3yAxSB4rtN9)_