### PR TITLE
fix(tts): fix avspeech-spike deadlock and word-boundary ceiling

### DIFF
--- a/scripts/avspeech-spike/README.md
+++ b/scripts/avspeech-spike/README.md
@@ -9,10 +9,65 @@ of information Azure's `WordBoundary` event provides — if it holds up in
 practice, it removes both the per-character Azure cost and the forced-alignment
 risk that ruled out Piper in the original engine-choice writeup.
 
-This has not been run yet — it needs a Mac to build and execute. Treat a
-"PASS" as a necessary, not sufficient, signal: it confirms the mechanism
-works and stays in bounds, not that the voice quality or timing granularity
-is good enough to ship.
+Treat a "PASS" as a necessary, not sufficient, signal: it confirms the
+mechanism works and stays in bounds, not that the voice quality or timing
+granularity is good enough to ship.
+
+## Results
+
+Run on macOS 26, Apple Silicon, with the default `en-US` compact voice
+(Samantha):
+
+- **Granularity is per-word.** The built-in sample (44 words) produced 40
+  boundaries, all in range and sequential — this is the shape the book's
+  read-along goal needs.
+- **`willSpeakRangeOfSpeechString` silently stops firing above ~2000 UTF-16
+  units of utterance text.** Not degraded, not slow — zero callbacks, while
+  the audio still writes successfully. Bisected on this machine: 2000 UTF-16
+  units passes, 2003 fails. This is undocumented by Apple and did not surface
+  in the 44-word sample; it only showed up testing against real chapter-length
+  text. **Worked around** by chunking: the script now splits input at
+  whitespace boundaries into pieces safely under the ceiling (1800 units),
+  synthesizes each in sequence into the same output file, and shifts each
+  chunk's boundary ranges back into the full text's coordinate space so the
+  reported boundaries read as one continuous set. Confirmed against a
+  373-word real chapter excerpt (371/373 boundaries, no gaps or overlap across
+  the chunk seam).
+- **The original blocking-wait implementation deadlocked outright** — it used
+  a raw `DispatchSemaphore.wait()` on the main thread, but
+  `write(_:toBufferCallback:)` and the delegate callback are delivered as
+  run-loop sources (XPC replies from the system speech-synthesis service). A
+  kernel-level semaphore wait never pumps the run loop, so those replies queue
+  up and are never delivered — a permanent hang, not a slow run. Fixed by
+  spinning `RunLoop.current` with a timeout instead of blocking.
+- **A full ~47k-character chapter (27 chunks) still fails the overlap check —
+  20 overlaps out of 7,437 boundaries (~0.3%).** Chunking fixed the
+  zero-boundary ceiling, but two independent, unfixed issues remain, both
+  inherent to `willSpeakRangeOfSpeechString` itself rather than to this
+  script's chunking:
+  - **Punctuation/number-adjacent duplicate ranges** — most of the 20: a
+    citation, footnote marker, phone number, or trailing-punctuation token
+    gets reported twice with overlapping bounds (e.g. `credit cards,` then a
+    second, shorter range for `credit cards`; `(1-800` then a separate,
+    overlapping `1-800-669-9777)`). Looks like AVSpeechSynthesizer's own
+    text normalization (phone numbers, dates-in-parens, footnote refs)
+    reporting boundaries against more than one internal tokenization of the
+    same span.
+  - **At least one genuinely out-of-order callback**, not just an
+    overlapping range: a boundary for a word from ~1,500 characters earlier
+    in the same chunk arrived after several later boundaries had already
+    been delivered and printed in sequence — confirmed via manual chunk-range
+    reconstruction that both boundaries belong to the *same* chunk, so it
+    isn't a chunk-seam artifact. `willSpeakRangeOfSpeechString` is not a
+    strictly-ordered stream in practice.
+
+  Neither issue is something this script can paper over without weakening
+  the checks it exists to enforce (sorting boundaries before the overlap
+  check would hide the out-of-order delivery, which is itself the finding).
+  This is the load-bearing result for a ship/no-ship call: on real
+  chapter-length text, ~0.3% of reported word positions can't be trusted at
+  face value, which matters directly for the book's "words highlight as
+  they're spoken" goal.
 
 ## Build & run
 
@@ -47,12 +102,19 @@ Exits non-zero if any of those fail.
 
 ## Known gaps
 
-- Delegate callbacks and `write(_:toBufferCallback:)` are exercised together
-  here on the assumption that `willSpeakRangeOfSpeechString` still fires
-  during offline (file) synthesis, not just live playback. That assumption
-  is exactly what this spike tests — if boundaries come back empty, that's
-  the answer, not a bug in this script.
 - No cost/CI-reproducibility story yet: this only runs on macOS with a human
   present (or a self-hosted runner), which is a different shape than Azure's
   "call an API from any GitHub Actions runner." Worth resolving before this
   goes further than a spike.
+- Chunking splits purely on whitespace, not sentence or clause boundaries, so
+  a chunk seam can fall mid-sentence — worth checking whether that produces
+  an audible prosody glitch (a flattened pitch reset) at the join, not just
+  whether the audio and boundaries are technically continuous.
+- The 1800-unit chunk ceiling was chosen as a safety margin under the
+  measured ~2000-unit cutoff on this machine/OS/voice; it isn't confirmed
+  stable across macOS versions or other voices, and Apple documents neither
+  the limit nor this workaround.
+- Each chunk starts a fresh `AVSpeechUtterance`, which resets prosody state
+  (pitch, rate ramping) at every seam — acceptable for this spike's pass/fail
+  checks, but a real narration pipeline would want to confirm that doesn't
+  read as choppy over a full chapter.

--- a/scripts/avspeech-spike/Sources/avspeech-spike/main.swift
+++ b/scripts/avspeech-spike/Sources/avspeech-spike/main.swift
@@ -3,11 +3,16 @@
 // `WordBoundary`'s reported offset lines up with the source string it was
 // given, `AVSpeechSynthesizer` has no separate wire encoding to drift
 // against: `willSpeakRangeOfSpeechString` always indexes into the exact
-// `String` handed to `AVSpeechUtterance`. What's actually unverified here is
-// whether the callback fires per word (not per sentence) and holds up
-// against Djot's smart-typography substitutions (curly quotes, em/en dash,
-// ellipsis) — see docs/superpowers/specs/2026-07-27-azure-tts-engine-design.md
-// for why that mattered enough to spike in the first place.
+// `String` handed to `AVSpeechUtterance`. Confirmed: the callback fires per
+// word (not per sentence) and holds up against Djot's smart-typography
+// substitutions (curly quotes, em/en dash, ellipsis). Also confirmed, on
+// real chapter-length text: it stops firing altogether above ~2000 UTF-16
+// units per utterance (worked around below via chunkText), and even within
+// a single chunk it occasionally reports overlapping or out-of-order
+// ranges around punctuation-heavy text (citations, phone numbers, footnote
+// markers) — see the README's Results section for the full breakdown.
+// See docs/superpowers/specs/2026-07-27-azure-tts-engine-design.md for why
+// this mattered enough to spike in the first place.
 
 import AVFoundation
 import Foundation
@@ -94,6 +99,66 @@ func resolveVoice(named identifier: String?) -> AVSpeechSynthesisVoice? {
     return bestAvailableVoice()
 }
 
+struct TextChunk {
+    // UTF-16 offset into the original source text — lets a chunk's own
+    // word-boundary ranges (which `willSpeakRangeOfSpeechString` reports
+    // relative to the chunk's utterance string) be translated back into the
+    // caller's coordinate space.
+    let startOffset: Int
+    let text: String
+}
+
+// AVSpeechSynthesizer silently stops firing `willSpeakRangeOfSpeechString`
+// altogether above ~2000 UTF-16 units of utterance text (measured: 2000
+// passes, 2003 fails, on this machine/voice) — it doesn't degrade or error,
+// the callback just never comes. Splitting on whitespace keeps each chunk
+// under that ceiling without cutting a word in half.
+func chunkText(_ text: String, maxUTF16Length: Int) -> [TextChunk] {
+    let nsText = text as NSString
+    let length = nsText.length
+    guard length > 0 else { return [] }
+
+    func isWhitespace(_ unit: unichar) -> Bool {
+        guard let scalar = Unicode.Scalar(unit) else { return false }
+        return CharacterSet.whitespacesAndNewlines.contains(scalar)
+    }
+
+    var chunks: [TextChunk] = []
+    var start = 0
+    while start < length {
+        let remaining = length - start
+        if remaining <= maxUTF16Length {
+            chunks.append(TextChunk(startOffset: start, text: nsText.substring(from: start)))
+            break
+        }
+
+        // Walk back from the window's edge to the nearest whitespace so the
+        // split falls between words, not inside one.
+        var splitAt = start + maxUTF16Length
+        var search = splitAt
+        while search > start && !isWhitespace(nsText.character(at: search)) {
+            search -= 1
+        }
+        if search > start {
+            splitAt = search
+        }
+        // else: no whitespace anywhere in the window (one very long token) —
+        // fall back to a hard cut at the window edge.
+
+        chunks.append(
+            TextChunk(startOffset: start, text: nsText.substring(with: NSRange(location: start, length: splitAt - start))))
+
+        // Skip the whitespace run so the next chunk doesn't start with
+        // leading space (which would shift its own word boundaries by one).
+        var nextStart = splitAt
+        while nextStart < length && isWhitespace(nsText.character(at: nextStart)) {
+            nextStart += 1
+        }
+        start = nextStart
+    }
+    return chunks
+}
+
 // MARK: - Argument parsing
 //
 // Usage:
@@ -150,46 +215,88 @@ print("Voice: \(voice.identifier) (\(voice.name), quality=\(qualityLabel(voice.q
 let preview = text.count > 80 ? "\(text.prefix(80))…" : text
 print("Text (\(text.utf16.count) UTF-16 units): \(preview)")
 
-let utterance = AVSpeechUtterance(string: text)
-utterance.voice = voice
-
-let delegate = SpikeDelegate(sourceText: text)
 let synthesizer = AVSpeechSynthesizer()
-synthesizer.delegate = delegate
 
 let outputDir = URL(fileURLWithPath: "dist/tts-spike", isDirectory: true)
 try? FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
 let outputURL = outputDir.appendingPathComponent("avspeech-spike.caf")
 
-var audioFile: AVAudioFile?
-var writeError: Error?
-let semaphore = DispatchSemaphore(value: 0)
-
-synthesizer.write(utterance) { buffer in
-    guard let pcmBuffer = buffer as? AVAudioPCMBuffer else {
-        writeError = NSError(
-            domain: "avspeech-spike", code: 1,
-            userInfo: [NSLocalizedDescriptionKey: "Unexpected buffer type from write(_:toBufferCallback:)"])
-        semaphore.signal()
-        return
-    }
-    // A zero-length buffer signals the end of synthesis for this utterance.
-    if pcmBuffer.frameLength == 0 {
-        semaphore.signal()
-        return
-    }
-    do {
-        if audioFile == nil {
-            audioFile = try AVAudioFile(forWriting: outputURL, settings: pcmBuffer.format.settings)
-        }
-        try audioFile?.write(from: pcmBuffer)
-    } catch {
-        writeError = error
-        semaphore.signal()
-    }
+// Stay comfortably under the ~2000 UTF-16-unit ceiling where
+// willSpeakRangeOfSpeechString stops firing (see chunkText's doc comment).
+let maxChunkLength = 1800
+let chunks = chunkText(text, maxUTF16Length: maxChunkLength)
+if chunks.count > 1 {
+    print(
+        "Splitting into \(chunks.count) chunks (~\(maxChunkLength) UTF-16 units each) to stay under "
+            + "AVSpeechSynthesizer's word-boundary ceiling.")
 }
 
-semaphore.wait()
+var audioFile: AVAudioFile?
+var writeError: Error?
+var boundaries: [WordBoundary] = []
+
+for chunk in chunks {
+    let utterance = AVSpeechUtterance(string: chunk.text)
+    utterance.voice = voice
+
+    let delegate = SpikeDelegate(sourceText: chunk.text)
+    synthesizer.delegate = delegate
+
+    var finished = false
+    synthesizer.write(utterance) { buffer in
+        guard let pcmBuffer = buffer as? AVAudioPCMBuffer else {
+            writeError = NSError(
+                domain: "avspeech-spike", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Unexpected buffer type from write(_:toBufferCallback:)"])
+            finished = true
+            return
+        }
+        // A zero-length buffer signals the end of synthesis for this utterance.
+        if pcmBuffer.frameLength == 0 {
+            finished = true
+            return
+        }
+        do {
+            if audioFile == nil {
+                audioFile = try AVAudioFile(forWriting: outputURL, settings: pcmBuffer.format.settings)
+            }
+            // Every chunk shares one voice, so format stays consistent —
+            // appending keeps the whole chapter as a single playable file.
+            try audioFile?.write(from: pcmBuffer)
+        } catch {
+            writeError = error
+            finished = true
+        }
+    }
+
+    // `write(_:toBufferCallback:)` and `willSpeakRangeOfSpeechString` deliver
+    // their results as run-loop sources (XPC replies from the system
+    // speech-synthesis service), not raw GCD callbacks. Blocking the main
+    // thread on a DispatchSemaphore — as an earlier version of this script
+    // did — parks the thread in a kernel-level semaphore_wait_trap that never
+    // pumps the run loop, so those replies queue up and are never delivered:
+    // a permanent deadlock, not a slow synthesis. Spinning the run loop here
+    // is what lets them arrive.
+    let deadline = Date().addingTimeInterval(30)
+    while !finished && Date() < deadline {
+        RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+    }
+    if !finished {
+        eprint("Timed out waiting for synthesis to complete after 30s (chunk at offset \(chunk.startOffset)).")
+        exit(1)
+    }
+    if writeError != nil {
+        break
+    }
+
+    // Translate this chunk's self-relative ranges back into the full
+    // source text's coordinate space so downstream checks (and callers)
+    // see one continuous set of boundaries, as if chunking never happened.
+    for boundary in delegate.boundaries {
+        let shifted = NSRange(location: boundary.range.location + chunk.startOffset, length: boundary.range.length)
+        boundaries.append(WordBoundary(range: shifted, text: boundary.text))
+    }
+}
 
 if let writeError {
     eprint("Audio write failed: \(writeError.localizedDescription)")
@@ -198,7 +305,6 @@ if let writeError {
 
 // MARK: - Verify boundaries
 
-let boundaries = delegate.boundaries
 let nsText = text as NSString
 let wordCount = text.split(whereSeparator: { !$0.isLetter && !$0.isNumber }).filter { !$0.isEmpty }.count
 


### PR DESCRIPTION
## Summary

- `scripts/avspeech-spike` had never actually been run (per its own README). Running it surfaced a real deadlock: it blocked the main thread on a raw `DispatchSemaphore` while `willSpeakRangeOfSpeechString`/`write(_:toBufferCallback:)` deliver via run-loop sources, so the callback that would signal the semaphore never arrived. Fixed by spinning `RunLoop.current` instead of blocking.
- With that fixed, testing against real chapter-length text (not just the 44-word built-in sample) surfaced an undocumented ceiling: `willSpeakRangeOfSpeechString` stops firing entirely above ~2000 UTF-16 units per utterance. Worked around by chunking input on whitespace boundaries and stitching each chunk's audio + shifted word-boundary ranges back into one continuous result.
- A full ~47k-character chapter (27 chunks) still fails the spike's own overlap check (~0.3% of boundaries overlap or arrive out of order). That's tracked separately as #173 rather than papered over here — the remaining defects are inherent to `AVSpeechSynthesizer` itself, not this script.
- README rewritten with a Results section documenting all of the above plus expanded Known gaps.

## Test plan

- [x] `swift build` succeeds
- [x] `swift run avspeech-spike` (built-in 44-word sample) passes: 40/44 word boundaries, in range, sequential
- [x] `swift run avspeech-spike <373-word chapter excerpt>` passes across 2 chunks: 371/373 boundaries, no gaps/overlap at the chunk seam
- [x] `swift run avspeech-spike <~47k-char full chapter>` runs to completion across 27 chunks without hanging (previously would have deadlocked); documented remaining overlap failures in #173 rather than silencing them

🤖 Generated with [Claude Code](https://claude.com/claude-code)