### PR TITLE
feat(tts): AVSpeech marker-API migration with reconciliation and acronym lexicon (#173)

### DIFF
--- a/build/audio/ssml-lexicon.test.ts
+++ b/build/audio/ssml-lexicon.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { findLexiconMatches, applySsmlLexicon } from './ssml-lexicon.js';
+import { findLexiconMatches, applySsmlLexicon, findIpaMatches } from './ssml-lexicon.js';
 
 describe('findLexiconMatches', () => {
   it('finds the proper-noun aliases from the design spec', () => {
@@ -67,5 +67,65 @@ describe('applySsmlLexicon', () => {
 
   it('round-trips text with no lexicon matches unchanged (aside from escaping)', () => {
     expect(applySsmlLexicon('nothing special here')).toBe('nothing special here');
+  });
+});
+
+describe('acronym rules', () => {
+  it('substitutes word-read acronyms for the Azure path', () => {
+    const text = 'File with HUD, then check FEMA and OSHA guidance on SNAP benefits.';
+    const matches = findLexiconMatches(text);
+    expect(matches.map((m) => [m.original, m.alias])).toEqual([
+      ['HUD', 'hud'],
+      ['FEMA', 'fema'],
+      ['OSHA', 'osha'],
+      ['SNAP', 'snap'],
+    ]);
+  });
+
+  it('renders an acronym as a sub alias in SSML', () => {
+    expect(applySsmlLexicon('File with HUD promptly.')).toBe(
+      'File with <sub alias="hud">HUD</sub> promptly.',
+    );
+  });
+
+  it('leaves spelled-out acronyms alone', () => {
+    // These are conventionally read letter-by-letter — no entry, no match.
+    expect(findLexiconMatches('The IRS, CFPB, and VA disagree about AI.')).toEqual([]);
+  });
+
+  it('does not match lowercase or partial-word occurrences', () => {
+    expect(findLexiconMatches('a hudson snapshot of osha-like rules')).toEqual([]);
+  });
+});
+
+describe('findIpaMatches', () => {
+  it('reports IPA notations with offsets that slice back to the original text', () => {
+    const text = 'File with HUD, then check FEMA and OSHA guidance on SNAP benefits.';
+    const matches = findIpaMatches(text);
+    expect(matches.map((m) => [m.original, m.ipa])).toEqual([
+      ['HUD', 'hʌd'],
+      ['FEMA', 'ˈfimə'],
+      ['OSHA', 'ˈoʊʃə'],
+      ['SNAP', 'snæp'],
+    ]);
+    for (const match of matches) {
+      expect(text.slice(match.charStart, match.charEnd)).toBe(match.original);
+    }
+  });
+
+  it('returns matches sorted by position', () => {
+    const matches = findIpaMatches('OSHA first, HUD second.');
+    expect(matches.map((m) => m.original)).toEqual(['OSHA', 'HUD']);
+  });
+
+  it('ignores proper nouns and episode citations — IPA is acronyms-only for now', () => {
+    // Djot/ePub/Jeeves realizations for the AVSpeech path are deliberately
+    // deferred until that engine path graduates from spike to pipeline
+    // (design doc §5).
+    expect(findIpaMatches('Jeeves read the Djot source of Seinfeld:S3E3.')).toEqual([]);
+  });
+
+  it('finds nothing in text without acronyms', () => {
+    expect(findIpaMatches('a perfectly ordinary sentence')).toEqual([]);
   });
 });

--- a/build/audio/ssml-lexicon.ts
+++ b/build/audio/ssml-lexicon.ts
@@ -31,6 +31,37 @@ const PROPER_NOUN_RULES: LexiconRule[] = [
 ];
 
 /**
+ * Acronyms conventionally read as words that at least one target engine
+ * spells out letter-by-letter (AVSpeechSynthesizer reads "HUD" as
+ * "H-U-D" — measured in #173). Engine-neutral table, realized two ways:
+ * `alias` feeds the Azure `<sub>` path via RULES below; `ipa` feeds the
+ * AVSpeech path via `findIpaMatches` (applied as
+ * AVSpeechSynthesisIPANotationAttribute ranges, which leave the source
+ * text — and therefore every boundary offset — untouched).
+ *
+ * Spelled-out acronyms (IRS, CFPB, VA, AI…) are correct as-is and must
+ * NOT get entries.
+ */
+interface AcronymEntry {
+  /** Must include the global flag. */
+  pattern: RegExp;
+  alias: string;
+  ipa: string;
+}
+
+const ACRONYM_ENTRIES: AcronymEntry[] = [
+  { pattern: /\bHUD\b/g, alias: 'hud', ipa: 'hʌd' },
+  { pattern: /\bFEMA\b/g, alias: 'fema', ipa: 'ˈfimə' },
+  { pattern: /\bOSHA\b/g, alias: 'osha', ipa: 'ˈoʊʃə' },
+  { pattern: /\bSNAP\b/g, alias: 'snap', ipa: 'snæp' },
+];
+
+const ACRONYM_RULES: LexiconRule[] = ACRONYM_ENTRIES.map((entry) => ({
+  pattern: entry.pattern,
+  alias: () => entry.alias,
+}));
+
+/**
  * The book's episode-citation format (`spec/outline.md`: `[Show:SxEy
  * "Title"](wikipedia-url), Year`) renders as literal link text, e.g.
  * "Seinfeld:S3E3" — read verbatim, a TTS engine says "Seinfeld colon S
@@ -42,7 +73,7 @@ const EPISODE_REFERENCE_RULE: LexiconRule = {
   alias: (match) => `${match[1]}, season ${Number(match[2])}, episode ${Number(match[3])}`,
 };
 
-const RULES: LexiconRule[] = [...PROPER_NOUN_RULES, EPISODE_REFERENCE_RULE];
+const RULES: LexiconRule[] = [...PROPER_NOUN_RULES, ...ACRONYM_RULES, EPISODE_REFERENCE_RULE];
 
 /**
  * Find every lexicon match in `text`, left to right. Rules are tried in
@@ -65,6 +96,37 @@ export function findLexiconMatches(text: string): LexiconMatch[] {
     }
   }
 
+  return matches.sort((a, b) => a.charStart - b.charStart);
+}
+
+export interface IpaMatch {
+  /** Character offsets into the source text, [charStart, charEnd). */
+  charStart: number;
+  charEnd: number;
+  original: string;
+  /** IPA notation for AVSpeechSynthesisIPANotationAttribute. */
+  ipa: string;
+}
+
+/**
+ * Find every acronym occurrence in `text` for the AVSpeech path, left to
+ * right. Acronym patterns are mutually exclusive by construction, so no
+ * claimed-span bookkeeping is needed here.
+ */
+export function findIpaMatches(text: string): IpaMatch[] {
+  const matches: IpaMatch[] = [];
+  for (const entry of ACRONYM_ENTRIES) {
+    const re = new RegExp(entry.pattern.source, entry.pattern.flags);
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(text))) {
+      matches.push({
+        charStart: match.index,
+        charEnd: match.index + match[0].length,
+        original: match[0],
+        ipa: entry.ipa,
+      });
+    }
+  }
   return matches.sort((a, b) => a.charStart - b.charStart);
 }
 

--- a/docs/superpowers/plans/2026-07-29-avspeech-marker-migration.md
+++ b/docs/superpowers/plans/2026-07-29-avspeech-marker-migration.md
@@ -1,0 +1,1042 @@
+# AVSpeech Marker API Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `scripts/avspeech-spike` from the `willSpeakRangeOfSpeechString` delegate to the macOS 13+ marker API with a three-rule reconciliation pass, and widen `build/audio/ssml-lexicon.ts` with an engine-neutral acronym table (issue #173).
+
+**Architecture:** The Swift spike package splits into a testable `SpikeCore` library (chunking + reconciliation, pure logic) and the `avspeech-spike` executable (synthesis + I/O, not unit-testable because it talks to the system speech XPC service — verified by running it). The TypeScript lexicon gains acronym rules realized two ways: `<sub alias>` for Azure (existing mechanism) and a new IPA-match export for AVSpeech.
+
+**Tech Stack:** Swift 5.9 / SwiftPM / XCTest / AVFoundation (macOS 13+); TypeScript / vitest (`npm test`).
+
+**Spec:** `docs/superpowers/specs/2026-07-29-avspeech-marker-migration-design.md`
+
+## Global Constraints
+
+- Swift package platform floor stays `.macOS(.v13)` (marker API availability), swift-tools-version 5.9.
+- ES modules only in TypeScript; vanilla — no new dependencies on either side.
+- Conventional commits; commit at the end of every task.
+- `byteSampleOffset` is **bytes** (empirically confirmed): seconds = `byteOffset ÷ bytesPerFrame ÷ sampleRate`.
+- The reconciliation rule order is load-bearing: duplicate-collapse, then regression-drop, then forward-merge (a regressing start also satisfies the forward-overlap predicate, so regression must be checked first).
+- The delegate path is deleted, not kept as a fallback — it cannot produce audio offsets and has no remaining role (spec §1).
+- All spike commands run from `scripts/avspeech-spike/`.
+
+---
+
+### Task 1: Split the package and extract chunking into SpikeCore
+
+**Files:**
+- Modify: `scripts/avspeech-spike/Package.swift`
+- Create: `scripts/avspeech-spike/Sources/SpikeCore/Chunking.swift`
+- Modify: `scripts/avspeech-spike/Sources/avspeech-spike/main.swift` (remove `TextChunk`/`chunkText`, lines 102–160; add `import SpikeCore`)
+- Test: `scripts/avspeech-spike/Tests/SpikeCoreTests/ChunkingTests.swift`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: `public struct TextChunk { public let startOffset: Int; public let text: String }` and `public func chunkText(_ text: String, maxUTF16Length: Int) -> [TextChunk]` in module `SpikeCore`. Task 2 adds to the same module; Task 3's executable imports it.
+
+- [ ] **Step 1: Rewrite Package.swift with library + executable + test targets**
+
+```swift
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "avspeech-spike",
+    platforms: [.macOS(.v13)],
+    targets: [
+        .target(name: "SpikeCore", path: "Sources/SpikeCore"),
+        .executableTarget(
+            name: "avspeech-spike",
+            dependencies: ["SpikeCore"],
+            path: "Sources/avspeech-spike"),
+        .testTarget(
+            name: "SpikeCoreTests",
+            dependencies: ["SpikeCore"],
+            path: "Tests/SpikeCoreTests"),
+    ]
+)
+```
+
+- [ ] **Step 2: Write the failing chunking tests**
+
+Create `Tests/SpikeCoreTests/ChunkingTests.swift`:
+
+```swift
+import XCTest
+@testable import SpikeCore
+
+final class ChunkingTests: XCTestCase {
+    func testShortTextIsASingleChunk() {
+        let chunks = chunkText("hello world", maxUTF16Length: 1800)
+        XCTAssertEqual(chunks.count, 1)
+        XCTAssertEqual(chunks[0].startOffset, 0)
+        XCTAssertEqual(chunks[0].text, "hello world")
+    }
+
+    func testEmptyTextYieldsNoChunks() {
+        XCTAssertTrue(chunkText("", maxUTF16Length: 1800).isEmpty)
+    }
+
+    func testSplitsAtWhitespaceUnderTheCeiling() {
+        let text = Array(repeating: "word", count: 100).joined(separator: " ") // 499 units
+        let chunks = chunkText(text, maxUTF16Length: 100)
+        XCTAssertGreaterThan(chunks.count, 1)
+        for chunk in chunks {
+            XCTAssertLessThanOrEqual(chunk.text.utf16.count, 100)
+            XCTAssertFalse(chunk.text.hasPrefix(" "))
+            XCTAssertFalse(chunk.text.hasSuffix(" "))
+        }
+    }
+
+    func testChunkOffsetsSliceBackToTheSourceText() {
+        let text = Array(repeating: "word", count: 100).joined(separator: " ")
+        let nsText = text as NSString
+        for chunk in chunkText(text, maxUTF16Length: 100) {
+            let slice = nsText.substring(
+                with: NSRange(location: chunk.startOffset, length: chunk.text.utf16.count))
+            XCTAssertEqual(slice, chunk.text)
+        }
+    }
+
+    func testOneVeryLongTokenGetsAHardCut() {
+        let text = String(repeating: "x", count: 250)
+        let chunks = chunkText(text, maxUTF16Length: 100)
+        XCTAssertEqual(chunks.count, 3)
+        XCTAssertEqual(chunks.map { $0.text.utf16.count }, [100, 100, 50])
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail to compile**
+
+Run: `cd scripts/avspeech-spike && swift test`
+Expected: build error — `SpikeCore` has no `Chunking.swift` yet (`cannot find 'chunkText' in scope` or missing module).
+
+- [ ] **Step 4: Move chunking into SpikeCore**
+
+Create `Sources/SpikeCore/Chunking.swift` with the code currently at `main.swift:102-160`, made public. The body of `chunkText` is **moved verbatim** — only the access modifiers and the doc comment location change:
+
+```swift
+import Foundation
+
+public struct TextChunk {
+    // UTF-16 offset into the original source text — lets a chunk's own
+    // word-marker ranges (reported relative to the chunk's utterance
+    // string) be translated back into the caller's coordinate space.
+    public let startOffset: Int
+    public let text: String
+
+    public init(startOffset: Int, text: String) {
+        self.startOffset = startOffset
+        self.text = text
+    }
+}
+
+// AVSpeechSynthesizer silently stops reporting word boundaries altogether
+// above ~2000 UTF-16 units of utterance text (measured: 2000 passes, 2003
+// fails, on this machine/voice) — confirmed for both the delegate and the
+// marker callback, so the ceiling is in the synthesis service itself.
+// Splitting on whitespace keeps each chunk under that ceiling without
+// cutting a word in half.
+public func chunkText(_ text: String, maxUTF16Length: Int) -> [TextChunk] {
+    let nsText = text as NSString
+    let length = nsText.length
+    guard length > 0 else { return [] }
+
+    func isWhitespace(_ unit: unichar) -> Bool {
+        guard let scalar = Unicode.Scalar(unit) else { return false }
+        return CharacterSet.whitespacesAndNewlines.contains(scalar)
+    }
+
+    var chunks: [TextChunk] = []
+    var start = 0
+    while start < length {
+        let remaining = length - start
+        if remaining <= maxUTF16Length {
+            chunks.append(TextChunk(startOffset: start, text: nsText.substring(from: start)))
+            break
+        }
+
+        // Walk back from the window's edge to the nearest whitespace so the
+        // split falls between words, not inside one.
+        var splitAt = start + maxUTF16Length
+        var search = splitAt
+        while search > start && !isWhitespace(nsText.character(at: search)) {
+            search -= 1
+        }
+        if search > start {
+            splitAt = search
+        }
+        // else: no whitespace anywhere in the window (one very long token) —
+        // fall back to a hard cut at the window edge.
+
+        chunks.append(
+            TextChunk(startOffset: start, text: nsText.substring(with: NSRange(location: start, length: splitAt - start))))
+
+        // Skip the whitespace run so the next chunk doesn't start with
+        // leading space (which would shift its own word boundaries by one).
+        var nextStart = splitAt
+        while nextStart < length && isWhitespace(nsText.character(at: nextStart)) {
+            nextStart += 1
+        }
+        start = nextStart
+    }
+    return chunks
+}
+```
+
+In `main.swift`, delete the `TextChunk` struct and `chunkText` function (lines 102–160) and add `import SpikeCore` after `import Foundation`.
+
+- [ ] **Step 5: Run tests and the executable build**
+
+Run: `cd scripts/avspeech-spike && swift test && swift build`
+Expected: all 5 tests PASS; executable still builds (it still uses the delegate at this point — that changes in Task 3).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/avspeech-spike
+git commit -m "refactor(tts): extract spike chunking into testable SpikeCore target (#173)"
+```
+
+---
+
+### Task 2: Reconciliation pass in SpikeCore (TDD)
+
+**Files:**
+- Create: `scripts/avspeech-spike/Sources/SpikeCore/Reconcile.swift`
+- Test: `scripts/avspeech-spike/Tests/SpikeCoreTests/ReconcileTests.swift`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (independent module file, same target).
+- Produces (used by Task 3):
+
+```swift
+public struct SpokenWordBoundary: Equatable {
+    public let range: NSRange   // UTF-16 units into the source text
+    public let byteOffset: Int  // bytes into the output audio stream
+    public init(range: NSRange, byteOffset: Int)
+}
+public struct ReconcileResult: Equatable {
+    public let boundaries: [SpokenWordBoundary]
+    public let duplicatesCollapsed: Int
+    public let overlapsMerged: Int
+    public let regressionsDropped: Int
+}
+public func reconcile(_ markers: [SpokenWordBoundary]) -> ReconcileResult
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/SpikeCoreTests/ReconcileTests.swift`. The fixture values are the actual marker sequences observed in the #173 investigation (compact Samantha, macOS 26):
+
+```swift
+import XCTest
+@testable import SpikeCore
+
+final class ReconcileTests: XCTestCase {
+    private func b(_ location: Int, _ length: Int, _ offset: Int) -> SpokenWordBoundary {
+        SpokenWordBoundary(range: NSRange(location: location, length: length), byteOffset: offset)
+    }
+
+    func testCleanBoundariesPassThroughUntouched() {
+        let markers = [b(0, 4, 0), b(5, 4, 20240), b(10, 8, 51920)]
+        let result = reconcile(markers)
+        XCTAssertEqual(result.boundaries, markers)
+        XCTAssertEqual(result.duplicatesCollapsed, 0)
+        XCTAssertEqual(result.overlapsMerged, 0)
+        XCTAssertEqual(result.regressionsDropped, 0)
+    }
+
+    func testCollapsesSameStartSameOffsetDuplicateToTheUnionSpan() {
+        // Observed: "credit cards" [52,64) then "credit cards," [52,65),
+        // both at byte offset 292600 — one audio moment, two tokenizations.
+        let result = reconcile([b(41, 10, 216920), b(52, 12, 292600), b(52, 13, 292600), b(66, 4, 400400)])
+        XCTAssertEqual(result.boundaries, [b(41, 10, 216920), b(52, 13, 292600), b(66, 4, 400400)])
+        XCTAssertEqual(result.duplicatesCollapsed, 1)
+        XCTAssertEqual(result.overlapsMerged, 0)
+        XCTAssertEqual(result.regressionsDropped, 0)
+    }
+
+    func testDuplicateKeepsTheLongerSpanWhenTheFirstReportIsLonger() {
+        // Observed: "request," [35,43) then "request" [35,42), same offset.
+        let result = reconcile([b(35, 8, 162800), b(35, 7, 162800)])
+        XCTAssertEqual(result.boundaries, [b(35, 8, 162800)])
+        XCTAssertEqual(result.duplicatesCollapsed, 1)
+    }
+
+    func testMergesForwardOverlapKeepingTheEarlierOffset() {
+        // Observed: "(1-800" [58,64) at 375320, then "1-800-669-9777)"
+        // [59,74) at 428120 — the normalizer re-reads the phone number.
+        let result = reconcile([b(49, 4, 270160), b(58, 6, 375320), b(59, 15, 428120), b(75, 2, 759000)])
+        XCTAssertEqual(result.boundaries, [b(49, 4, 270160), b(58, 16, 375320), b(75, 2, 759000)])
+        XCTAssertEqual(result.overlapsMerged, 1)
+        XCTAssertEqual(result.duplicatesCollapsed, 0)
+        XCTAssertEqual(result.regressionsDropped, 0)
+    }
+
+    func testDropsARegressingMarkerAsASpuriousRereport() {
+        // Observed: after "with" [45993,45997), a marker for "reva"
+        // [45116,45120) arrived with a *later* audio offset — audio
+        // monotonicity proves the speech never went backwards.
+        let result = reconcile([b(45993, 4, 1000), b(45116, 4, 2000), b(46060, 1, 3000)])
+        XCTAssertEqual(result.boundaries, [b(45993, 4, 1000), b(46060, 1, 3000)])
+        XCTAssertEqual(result.regressionsDropped, 1)
+        XCTAssertEqual(result.overlapsMerged, 0)
+    }
+
+    func testEmptyInputYieldsEmptyResult() {
+        let result = reconcile([])
+        XCTAssertTrue(result.boundaries.isEmpty)
+    }
+
+    func testReconciledOutputIsAlwaysNonOverlappingAndAudioMonotonic() {
+        // Mixed stream exercising all three rules together.
+        let markers = [
+            b(0, 4, 0),
+            b(5, 4, 100), b(5, 5, 100),    // dupe
+            b(12, 6, 200), b(13, 10, 250), // forward overlap
+            b(3, 2, 300),                  // regression
+            b(30, 4, 400),
+        ]
+        let result = reconcile(markers)
+        var prevEnd = 0
+        var prevOffset = -1
+        for m in result.boundaries {
+            XCTAssertGreaterThanOrEqual(m.range.location, prevEnd)
+            XCTAssertGreaterThanOrEqual(m.byteOffset, prevOffset)
+            prevEnd = m.range.location + m.range.length
+            prevOffset = m.byteOffset
+        }
+        XCTAssertEqual(result.duplicatesCollapsed, 1)
+        XCTAssertEqual(result.overlapsMerged, 1)
+        XCTAssertEqual(result.regressionsDropped, 1)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd scripts/avspeech-spike && swift test`
+Expected: build error — `cannot find 'reconcile' in scope` / `SpokenWordBoundary` undefined.
+
+- [ ] **Step 3: Implement Reconcile.swift**
+
+Create `Sources/SpikeCore/Reconcile.swift`:
+
+```swift
+import Foundation
+
+/// One word boundary from the marker callback, shifted into whole-text
+/// (range) and whole-stream (byteOffset) coordinates.
+public struct SpokenWordBoundary: Equatable {
+    public let range: NSRange
+    public let byteOffset: Int
+
+    public init(range: NSRange, byteOffset: Int) {
+        self.range = range
+        self.byteOffset = byteOffset
+    }
+}
+
+public struct ReconcileResult: Equatable {
+    public let boundaries: [SpokenWordBoundary]
+    public let duplicatesCollapsed: Int
+    public let overlapsMerged: Int
+    public let regressionsDropped: Int
+
+    public init(
+        boundaries: [SpokenWordBoundary], duplicatesCollapsed: Int,
+        overlapsMerged: Int, regressionsDropped: Int
+    ) {
+        self.boundaries = boundaries
+        self.duplicatesCollapsed = duplicatesCollapsed
+        self.overlapsMerged = overlapsMerged
+        self.regressionsDropped = regressionsDropped
+    }
+}
+
+/// Reconcile raw word markers into a non-overlapping, text- and
+/// audio-monotonic boundary list.
+///
+/// AVSpeechSynthesizer's internal text normalization re-reports some spans
+/// against more than one tokenization (Apple-acknowledged; see #173). The
+/// audio offsets, however, are strictly monotonic in practice — the speech
+/// itself never goes backwards — which is what makes each anomaly
+/// classifiable rather than papered over:
+///
+/// 1. Same text start, same audio offset → the same moment tokenized twice;
+///    collapse to the union span.
+/// 2. Text start regressing behind the previous boundary's *start* while
+///    audio advances → spurious re-report of earlier text; drop it.
+/// 3. Text start inside the previous span (but not regressing) → the
+///    normalizer split one utterance token in two (phone numbers); merge to
+///    the union span, keeping the earlier offset.
+///
+/// Rule order is load-bearing: a regressing start also satisfies rule 3's
+/// predicate, so rule 2 must be checked first.
+public func reconcile(_ markers: [SpokenWordBoundary]) -> ReconcileResult {
+    var out: [SpokenWordBoundary] = []
+    var duplicates = 0
+    var merges = 0
+    var drops = 0
+
+    for marker in markers {
+        guard let last = out.last else {
+            out.append(marker)
+            continue
+        }
+        let lastEnd = last.range.location + last.range.length
+
+        if marker.range.location == last.range.location && marker.byteOffset == last.byteOffset {
+            duplicates += 1
+            let end = max(lastEnd, marker.range.location + marker.range.length)
+            out[out.count - 1] = SpokenWordBoundary(
+                range: NSRange(location: last.range.location, length: end - last.range.location),
+                byteOffset: last.byteOffset)
+            continue
+        }
+        if marker.range.location < last.range.location {
+            drops += 1
+            continue
+        }
+        if marker.range.location < lastEnd {
+            merges += 1
+            let end = max(lastEnd, marker.range.location + marker.range.length)
+            out[out.count - 1] = SpokenWordBoundary(
+                range: NSRange(location: last.range.location, length: end - last.range.location),
+                byteOffset: min(last.byteOffset, marker.byteOffset))
+            continue
+        }
+        out.append(marker)
+    }
+
+    return ReconcileResult(
+        boundaries: out, duplicatesCollapsed: duplicates,
+        overlapsMerged: merges, regressionsDropped: drops)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd scripts/avspeech-spike && swift test`
+Expected: all ChunkingTests + ReconcileTests PASS (12 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/avspeech-spike
+git commit -m "feat(tts): three-rule marker reconciliation pass in SpikeCore (#173)"
+```
+
+---
+
+### Task 3: Migrate the executable to the marker API
+
+**Files:**
+- Modify: `scripts/avspeech-spike/Sources/avspeech-spike/main.swift` (full rewrite below)
+- Create: `scripts/avspeech-spike/fixtures/credit-cards.txt`
+- Create: `scripts/avspeech-spike/fixtures/hud-phone.txt`
+
+**Interfaces:**
+- Consumes: `chunkText(_:maxUTF16Length:) -> [TextChunk]`, `reconcile(_:) -> ReconcileResult`, `SpokenWordBoundary` from `SpikeCore` (Tasks 1–2).
+- Produces: `dist/tts-spike/avspeech-spike.caf` (audio) and `dist/tts-spike/avspeech-boundaries.json` — an array of `{ "text": String, "textOffset": Int, "wordLength": Int, "clipBeginSeconds": Double }`, offsets in UTF-16 units into the input text, sorted ascending. This JSON shape is what a future `smil.ts` adapter consumes (`audioOffsetTicks = clipBeginSeconds × 10⁷`; `durationTicks` from the next record's `clipBegin`).
+
+- [ ] **Step 1: Create the reproduction fixtures**
+
+`fixtures/credit-cards.txt` (one line, no trailing newline needed):
+
+```
+This caps interest on pre-service debts, mortgages, credit cards, auto loans, at 6% with written notice to the creditor.
+```
+
+`fixtures/hud-phone.txt`:
+
+```
+...service animal or accommodation request, file with HUD (1-800-669-9777) or your local fair housing office.
+```
+
+- [ ] **Step 2: Replace main.swift**
+
+Full replacement (keeps `sampleText`, voice resolution, and arg parsing; replaces the delegate/synthesis/verification sections):
+
+```swift
+// AVSpeechSynthesizer word-marker spike — the local-TTS counterpart to
+// build/scripts/tts-spike.ts (Azure). Uses the macOS 13+
+// write(_:toBufferCallback:toMarkerCallback:) API rather than the
+// willSpeakRangeOfSpeechString delegate: markers carry a byteSampleOffset
+// into the audio stream (empirically bytes — see #173), which is the
+// timing data ePub Media Overlays need and the delegate never provided.
+// The ~2000-UTF-16-unit ceiling on word reporting is in the synthesis
+// service itself (delegate AND markers, multiple engines), so input is
+// chunked below it; raw markers are then reconciled by SpikeCore's
+// three-rule pass (duplicates, regressions, forward overlaps — see
+// Reconcile.swift for why that isn't papering over the findings).
+// See docs/superpowers/specs/2026-07-29-avspeech-marker-migration-design.md.
+
+import AVFoundation
+import Foundation
+import SpikeCore
+
+// Mirrors build/scripts/tts-spike.ts's SAMPLE_TEXT so the two spikes run
+// against identical text.
+let sampleText =
+    "Jeeves considered the matter. \u{201C}It is, if I may say so, a delicate "
+    + "situation\u{201D}\u{2014}the sort that wants patience, not haste. The Skill itself is "
+    + "well-formed; it\u{2019}s the ePub\u{2019}s Djot source that needs a second look\u{2026} "
+    + "three passes, minimum\u{2014}maybe four."
+
+func eprint(_ message: String) {
+    FileHandle.standardError.write((message + "\n").data(using: .utf8)!)
+}
+
+func qualityLabel(_ quality: AVSpeechSynthesisVoiceQuality) -> String {
+    switch quality {
+    case .premium: return "premium"
+    case .enhanced: return "enhanced"
+    case .default: return "default"
+    @unknown default: return "unknown"
+    }
+}
+
+func bestAvailableVoice() -> AVSpeechSynthesisVoice? {
+    func rank(_ quality: AVSpeechSynthesisVoiceQuality) -> Int {
+        switch quality {
+        case .premium: return 3
+        case .enhanced: return 2
+        case .default: return 1
+        @unknown default: return 0
+        }
+    }
+
+    return AVSpeechSynthesisVoice.speechVoices()
+        .filter { $0.language.hasPrefix("en-US") }
+        .max { rank($0.quality) < rank($1.quality) }
+        ?? AVSpeechSynthesisVoice(language: "en-US")
+}
+
+func resolveVoice(named identifier: String?) -> AVSpeechSynthesisVoice? {
+    guard let identifier else { return bestAvailableVoice() }
+    if let voice = AVSpeechSynthesisVoice(identifier: identifier) { return voice }
+    if let voice = AVSpeechSynthesisVoice.speechVoices().first(where: { $0.name == identifier }) {
+        return voice
+    }
+    eprint("No voice matches \"\(identifier)\" — falling back to the best available en-US voice.")
+    return bestAvailableVoice()
+}
+
+// MARK: - Argument parsing
+//
+// Usage:
+//   swift run avspeech-spike                       # built-in smart-typography sample
+//   swift run avspeech-spike path/to/text.txt       # check a real chapter excerpt
+//   swift run avspeech-spike --voice <identifier>   # audition a specific voice
+//   swift run avspeech-spike --list-voices          # print installed voice identifiers
+
+var textPath: String?
+var voiceIdentifier: String?
+var listVoices = false
+
+var args = Array(CommandLine.arguments.dropFirst())
+while !args.isEmpty {
+    let arg = args.removeFirst()
+    switch arg {
+    case "--voice":
+        voiceIdentifier = args.first
+        if !args.isEmpty { args.removeFirst() }
+    case "--list-voices":
+        listVoices = true
+    default:
+        textPath = arg
+    }
+}
+
+if listVoices {
+    for voice in AVSpeechSynthesisVoice.speechVoices().sorted(by: { $0.identifier < $1.identifier }) {
+        print("\(voice.identifier)  \(voice.name)  \(voice.language)  quality=\(qualityLabel(voice.quality))")
+    }
+    exit(0)
+}
+
+let text: String
+if let textPath {
+    do {
+        let fileURL = URL(fileURLWithPath: textPath)
+        text = try String(contentsOf: fileURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    } catch {
+        eprint("Could not read \(textPath): \(error.localizedDescription)")
+        exit(1)
+    }
+} else {
+    text = sampleText
+}
+
+guard let voice = resolveVoice(named: voiceIdentifier) else {
+    eprint("No en-US voice available on this system.")
+    exit(1)
+}
+
+print("Voice: \(voice.identifier) (\(voice.name), quality=\(qualityLabel(voice.quality)))")
+let preview = text.count > 80 ? "\(text.prefix(80))…" : text
+print("Text (\(text.utf16.count) UTF-16 units): \(preview)")
+
+// MARK: - Synthesis
+
+let synthesizer = AVSpeechSynthesizer()
+
+let outputDir = URL(fileURLWithPath: "dist/tts-spike", isDirectory: true)
+try? FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+let audioURL = outputDir.appendingPathComponent("avspeech-spike.caf")
+let jsonURL = outputDir.appendingPathComponent("avspeech-boundaries.json")
+
+// Stay comfortably under the ~2000 UTF-16-unit ceiling where the service
+// stops reporting word boundaries (see chunkText's doc comment).
+let maxChunkLength = 1800
+let chunks = chunkText(text, maxUTF16Length: maxChunkLength)
+if chunks.count > 1 {
+    print(
+        "Splitting into \(chunks.count) chunks (~\(maxChunkLength) UTF-16 units each) to stay under "
+            + "the synthesis service's word-marker ceiling.")
+}
+
+var audioFile: AVAudioFile?
+var writeError: Error?
+var rawMarkers: [SpokenWordBoundary] = []
+var totalFrames = 0
+var bytesPerFrame = 0
+var sampleRate = 0.0
+
+for chunk in chunks {
+    let utterance = AVSpeechUtterance(string: chunk.text)
+    utterance.voice = voice
+
+    // Bytes written before this chunk — shifts marker offsets into
+    // whole-stream coordinates, mirroring startOffset for text ranges.
+    let byteBase = totalFrames * bytesPerFrame
+
+    var chunkMarkers: [SpokenWordBoundary] = []
+    var finished = false
+    synthesizer.write(utterance, toBufferCallback: { buffer in
+        guard let pcmBuffer = buffer as? AVAudioPCMBuffer else {
+            writeError = NSError(
+                domain: "avspeech-spike", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Unexpected buffer type from write(_:toBufferCallback:)"])
+            finished = true
+            return
+        }
+        // A zero-length buffer signals the end of synthesis for this utterance.
+        if pcmBuffer.frameLength == 0 {
+            finished = true
+            return
+        }
+        totalFrames += Int(pcmBuffer.frameLength)
+        sampleRate = pcmBuffer.format.sampleRate
+        bytesPerFrame = Int(pcmBuffer.format.streamDescription.pointee.mBytesPerFrame)
+        do {
+            if audioFile == nil {
+                audioFile = try AVAudioFile(forWriting: audioURL, settings: pcmBuffer.format.settings)
+            }
+            // Every chunk shares one voice, so format stays consistent —
+            // appending keeps the whole chapter as a single playable file.
+            try audioFile?.write(from: pcmBuffer)
+        } catch {
+            writeError = error
+            finished = true
+        }
+    }, toMarkerCallback: { markers in
+        for marker in markers where marker.mark == .word {
+            guard marker.textRange.location != NSNotFound else { continue }
+            chunkMarkers.append(
+                SpokenWordBoundary(
+                    range: NSRange(
+                        location: marker.textRange.location + chunk.startOffset,
+                        length: marker.textRange.length),
+                    byteOffset: marker.byteSampleOffset + byteBase))
+        }
+    })
+
+    // Both callbacks are delivered as run-loop sources (XPC replies from the
+    // system speech-synthesis service). Blocking the thread on a semaphore
+    // would deadlock (see #174) — spinning the run loop lets them arrive.
+    let deadline = Date().addingTimeInterval(30)
+    while !finished && Date() < deadline {
+        RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+    }
+    if !finished {
+        eprint("Timed out waiting for synthesis to complete after 30s (chunk at offset \(chunk.startOffset)).")
+        exit(1)
+    }
+    if writeError != nil {
+        break
+    }
+
+    // Ceiling canary: a chunk with zero word markers means the undocumented
+    // ceiling moved under us (OS update, different voice). The failure mode
+    // is silent by design, so make it loud.
+    if chunkMarkers.isEmpty {
+        eprint(
+            "FAIL: chunk at offset \(chunk.startOffset) (\(chunk.text.utf16.count) UTF-16 units) "
+                + "produced zero word markers — the word-reporting ceiling may have shifted below "
+                + "\(maxChunkLength) units on this OS/voice.")
+        exit(1)
+    }
+    rawMarkers.append(contentsOf: chunkMarkers)
+}
+
+if let writeError {
+    eprint("Audio write failed: \(writeError.localizedDescription)")
+    exit(1)
+}
+
+// MARK: - Reconcile & verify
+
+let result = reconcile(rawMarkers)
+let boundaries = result.boundaries
+let nsText = text as NSString
+let wordCount = text.split(whereSeparator: { !$0.isLetter && !$0.isNumber }).filter { !$0.isEmpty }.count
+
+print("\n\(rawMarkers.count) raw word markers → \(boundaries.count) reconciled boundaries (~\(wordCount) words in source text).")
+print(
+    "reconciliation: \(result.duplicatesCollapsed) duplicate tokenizations collapsed, "
+        + "\(result.overlapsMerged) split tokens merged, \(result.regressionsDropped) regressing re-reports dropped.")
+for boundary in boundaries {
+    let end = boundary.range.location + boundary.range.length
+    guard end <= nsText.length else { continue }
+    let seconds = Double(boundary.byteOffset) / Double(max(bytesPerFrame, 1)) / max(sampleRate, 1)
+    print(String(format: "  [%d, %d) %8.3fs %@", boundary.range.location, end, seconds, nsText.substring(with: boundary.range)))
+}
+
+var outOfBounds = 0
+var overlaps = 0
+var audioRegressions = 0
+var previousEnd = 0
+var previousOffset = -1
+for boundary in boundaries {
+    let start = boundary.range.location
+    let end = start + boundary.range.length
+    if end > nsText.length { outOfBounds += 1 }
+    if start < previousEnd { overlaps += 1 }
+    if boundary.byteOffset < previousOffset { audioRegressions += 1 }
+    previousEnd = max(previousEnd, end)
+    previousOffset = boundary.byteOffset
+}
+
+// MARK: - JSON dump (the shape a smil.ts adapter consumes)
+
+struct BoundaryRecord: Codable {
+    let text: String
+    let textOffset: Int
+    let wordLength: Int
+    let clipBeginSeconds: Double
+}
+
+let records = boundaries.compactMap { boundary -> BoundaryRecord? in
+    let end = boundary.range.location + boundary.range.length
+    guard end <= nsText.length else { return nil }
+    return BoundaryRecord(
+        text: nsText.substring(with: boundary.range),
+        textOffset: boundary.range.location,
+        wordLength: boundary.range.length,
+        clipBeginSeconds: Double(boundary.byteOffset) / Double(max(bytesPerFrame, 1)) / max(sampleRate, 1))
+}
+do {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    try encoder.encode(records).write(to: jsonURL)
+} catch {
+    eprint("Could not write \(jsonURL.path): \(error.localizedDescription)")
+    exit(1)
+}
+
+print("\nAudio written to \(audioURL.path)")
+print("Boundaries written to \(jsonURL.path)")
+
+var failed = false
+if boundaries.isEmpty {
+    print("FAIL: no word markers were delivered for this voice.")
+    failed = true
+} else if Double(boundaries.count) < Double(wordCount) * 0.5 {
+    print(
+        "FAIL: only \(boundaries.count) boundaries for ~\(wordCount) words — looks like "
+            + "sentence-level, not word-level, granularity.")
+    failed = true
+}
+if outOfBounds > 0 {
+    print("FAIL: \(outOfBounds) boundary range(s) extend past the end of the source text.")
+    failed = true
+}
+if overlaps > 0 {
+    print("FAIL: \(overlaps) reconciled boundary range(s) still overlap the previous one.")
+    failed = true
+}
+if audioRegressions > 0 {
+    print("FAIL: \(audioRegressions) reconciled boundary audio offset(s) go backwards.")
+    failed = true
+}
+
+if failed {
+    exit(1)
+}
+print("\nPASS: reconciled word boundaries are in range, non-overlapping, and audio-monotonic.")
+```
+
+- [ ] **Step 3: Verify against the built-in sample**
+
+Run: `cd scripts/avspeech-spike && swift run avspeech-spike`
+Expected: PASS; ~40 boundaries; reconciliation counts `0 duplicate tokenizations collapsed, 0 split tokens merged, 0 regressing re-reports dropped`; `dist/tts-spike/avspeech-boundaries.json` exists and its `textOffset` values slice the sample text to the printed words.
+
+- [ ] **Step 4: Verify against both reproduction fixtures**
+
+Run: `swift run avspeech-spike fixtures/credit-cards.txt`
+Expected: PASS with `1 duplicate tokenizations collapsed` (the `credit cards,` double-report).
+
+Run: `swift run avspeech-spike fixtures/hud-phone.txt`
+Expected: PASS with `1 duplicate tokenizations collapsed, 1 split tokens merged` (the `request,` duplicate and the `(1-800` / `1-800-669-9777)` phone split).
+
+These previously FAILED the delegate spike's overlap check — that flip is the point of the migration.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/avspeech-spike
+git commit -m "feat(tts): migrate spike to marker API with reconciliation and JSON output (#173)"
+```
+
+---
+
+### Task 4: Full-chapter verification and README rewrite
+
+**Files:**
+- Modify: `scripts/avspeech-spike/README.md`
+
+**Interfaces:**
+- Consumes: the Task 3 executable and its printed reconciliation counts.
+- Produces: documentation only.
+
+- [ ] **Step 1: Run the slow full-chapter check**
+
+Export the chapter as plain text and run the spike over it:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+node -e "
+const { parse, renderHTML } = require('@djot/djot');
+const fs = require('fs');
+const src = fs.readFileSync('src/content/02-field-guide/04-home/index.dj', 'utf8');
+const html = renderHTML(parse(src.replace(/^---\n[\s\S]*?\n---\n/, '')));
+fs.mkdirSync('dist/tts-spike', { recursive: true });
+fs.writeFileSync('dist/tts-spike/chapter-home.txt', html
+  .replace(/<[^>]+>/g, ' ')
+  .replace(/&quot;/g, '\"').replace(/&#39;/g, \"'\").replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+  .replace(/[ \t]+/g, ' ').replace(/\s*\n\s*/g, '\n').replace(/\n{2,}/g, '\n').trim());
+"
+cd scripts/avspeech-spike && swift run -c release avspeech-spike ../../dist/tts-spike/chapter-home.txt
+```
+
+Expected: PASS in ~2 minutes of synthesis. Reconciliation counts in the measured neighborhood of the #173 investigation (7 duplicates / ~55 merges / ~2 drops for ~7,500 words — counts drifting by an order of magnitude mean the OS changed underneath us and warrant a fresh look, not a shrug). Note: the merge count is inflated by endnote backlink `↩` glyphs this crude export keeps; that's expected.
+
+- [ ] **Step 2: Rewrite the README's Results, "What it checks", and "Known gaps" sections**
+
+Replace the delegate-era prose so the README reflects: the marker API and why (byte offsets → SMIL clip times, which the delegate never provided); the service-level ceiling (delegate AND markers, multiple engines) and the chunking workaround with the zero-marker canary; the three-rule reconciliation and why it is not papering over findings (audio monotonicity as ground truth); the IPA-attribute acronym result; the JSON output shape and path; updated build/run examples including the fixtures; and the still-open gaps (enhanced/premium voice marker support untested — no such voice installed; ceiling stability across OS versions; CI/reproducibility story). Keep the existing tone and the "necessary, not sufficient" framing. Cite #173 and the design doc rather than restating every measurement.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/avspeech-spike/README.md
+git commit -m "docs(tts): document the marker-API spike results and reconciliation (#173)"
+```
+
+---
+
+### Task 5: Acronym table and IPA export in the SSML lexicon (TDD)
+
+**Files:**
+- Modify: `build/audio/ssml-lexicon.ts`
+- Test: `build/audio/ssml-lexicon.test.ts`
+
+**Interfaces:**
+- Consumes: existing `LexiconRule`, `RULES`, `findLexiconMatches`, `applySsmlLexicon` internals of `ssml-lexicon.ts`.
+- Produces:
+
+```ts
+export interface IpaMatch {
+  charStart: number;  // [charStart, charEnd) into the source text
+  charEnd: number;
+  original: string;
+  ipa: string;        // for AVSpeechSynthesisIPANotationAttribute
+}
+export function findIpaMatches(text: string): IpaMatch[];
+```
+
+Azure consumers are unchanged: acronyms flow into `findLexiconMatches`/`applySsmlLexicon` as ordinary `<sub alias>` rules.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `build/audio/ssml-lexicon.test.ts` (and add `findIpaMatches` to the import from `./ssml-lexicon.js`):
+
+```ts
+describe('acronym rules', () => {
+  it('substitutes word-read acronyms for the Azure path', () => {
+    const text = 'File with HUD, then check FEMA and OSHA guidance on SNAP benefits.';
+    const matches = findLexiconMatches(text);
+    expect(matches.map((m) => [m.original, m.alias])).toEqual([
+      ['HUD', 'hud'],
+      ['FEMA', 'fema'],
+      ['OSHA', 'osha'],
+      ['SNAP', 'snap'],
+    ]);
+  });
+
+  it('renders an acronym as a sub alias in SSML', () => {
+    expect(applySsmlLexicon('File with HUD promptly.')).toBe(
+      'File with <sub alias="hud">HUD</sub> promptly.',
+    );
+  });
+
+  it('leaves spelled-out acronyms alone', () => {
+    // These are conventionally read letter-by-letter — no entry, no match.
+    expect(findLexiconMatches('The IRS, CFPB, and VA disagree about AI.')).toEqual([]);
+  });
+
+  it('does not match lowercase or partial-word occurrences', () => {
+    expect(findLexiconMatches('a hudson snapshot of osha-like rules')).toEqual([]);
+  });
+});
+
+describe('findIpaMatches', () => {
+  it('reports IPA notations with offsets that slice back to the original text', () => {
+    const text = 'File with HUD, then check FEMA and OSHA guidance on SNAP benefits.';
+    const matches = findIpaMatches(text);
+    expect(matches.map((m) => [m.original, m.ipa])).toEqual([
+      ['HUD', 'hʌd'],
+      ['FEMA', 'ˈfimə'],
+      ['OSHA', 'ˈoʊʃə'],
+      ['SNAP', 'snæp'],
+    ]);
+    for (const match of matches) {
+      expect(text.slice(match.charStart, match.charEnd)).toBe(match.original);
+    }
+  });
+
+  it('returns matches sorted by position', () => {
+    const matches = findIpaMatches('OSHA first, HUD second.');
+    expect(matches.map((m) => m.original)).toEqual(['OSHA', 'HUD']);
+  });
+
+  it('ignores proper nouns and episode citations — IPA is acronyms-only for now', () => {
+    // Djot/ePub/Jeeves realizations for the AVSpeech path are deliberately
+    // deferred until that engine path graduates from spike to pipeline
+    // (design doc §5).
+    expect(findIpaMatches('Jeeves read the Djot source of Seinfeld:S3E3.')).toEqual([]);
+  });
+
+  it('finds nothing in text without acronyms', () => {
+    expect(findIpaMatches('a perfectly ordinary sentence')).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- build/audio/ssml-lexicon.test.ts`
+Expected: FAIL — `findIpaMatches` is not exported; acronym alias assertions fail.
+
+- [ ] **Step 3: Implement the acronym table and findIpaMatches**
+
+In `build/audio/ssml-lexicon.ts`, after `PROPER_NOUN_RULES`, add:
+
+```ts
+/**
+ * Acronyms conventionally read as words that at least one target engine
+ * spells out letter-by-letter (AVSpeechSynthesizer reads "HUD" as
+ * "H-U-D" — measured in #173). Engine-neutral table, realized two ways:
+ * `alias` feeds the Azure `<sub>` path via RULES below; `ipa` feeds the
+ * AVSpeech path via `findIpaMatches` (applied as
+ * AVSpeechSynthesisIPANotationAttribute ranges, which leave the source
+ * text — and therefore every boundary offset — untouched).
+ *
+ * Spelled-out acronyms (IRS, CFPB, VA, AI…) are correct as-is and must
+ * NOT get entries.
+ */
+interface AcronymEntry {
+  /** Must include the global flag. */
+  pattern: RegExp;
+  alias: string;
+  ipa: string;
+}
+
+const ACRONYM_ENTRIES: AcronymEntry[] = [
+  { pattern: /\bHUD\b/g, alias: 'hud', ipa: 'hʌd' },
+  { pattern: /\bFEMA\b/g, alias: 'fema', ipa: 'ˈfimə' },
+  { pattern: /\bOSHA\b/g, alias: 'osha', ipa: 'ˈoʊʃə' },
+  { pattern: /\bSNAP\b/g, alias: 'snap', ipa: 'snæp' },
+];
+
+const ACRONYM_RULES: LexiconRule[] = ACRONYM_ENTRIES.map((entry) => ({
+  pattern: entry.pattern,
+  alias: () => entry.alias,
+}));
+```
+
+Change the `RULES` assembly to include them:
+
+```ts
+const RULES: LexiconRule[] = [...PROPER_NOUN_RULES, ...ACRONYM_RULES, EPISODE_REFERENCE_RULE];
+```
+
+Add the IPA export after `findLexiconMatches`:
+
+```ts
+export interface IpaMatch {
+  /** Character offsets into the source text, [charStart, charEnd). */
+  charStart: number;
+  charEnd: number;
+  original: string;
+  /** IPA notation for AVSpeechSynthesisIPANotationAttribute. */
+  ipa: string;
+}
+
+/**
+ * Find every acronym occurrence in `text` for the AVSpeech path, left to
+ * right. Acronym patterns are mutually exclusive by construction, so no
+ * claimed-span bookkeeping is needed here.
+ */
+export function findIpaMatches(text: string): IpaMatch[] {
+  const matches: IpaMatch[] = [];
+  for (const entry of ACRONYM_ENTRIES) {
+    const re = new RegExp(entry.pattern.source, entry.pattern.flags);
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(text))) {
+      matches.push({
+        charStart: match.index,
+        charEnd: match.index + match[0].length,
+        original: match[0],
+        ipa: entry.ipa,
+      });
+    }
+  }
+  return matches.sort((a, b) => a.charStart - b.charStart);
+}
+```
+
+- [ ] **Step 4: Run the full TypeScript test suite**
+
+Run: `npm test`
+Expected: all tests PASS, including the pre-existing lexicon tests (the acronym rules must not disturb proper-noun or episode matching).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add build/audio/ssml-lexicon.ts build/audio/ssml-lexicon.test.ts
+git commit -m "feat(audio): engine-neutral acronym lexicon with IPA export (#173)"
+```
+
+---
+
+## Out of scope (tracked in the design doc)
+
+- Enhanced/premium voice marker check (blocked on a manual voice download).
+- Azure "HUD" default-behavior test (blocked on `SPEECH_KEY`).
+- Apple Feedback filing for the ceiling.
+- A `smil.ts` adapter for `avspeech-boundaries.json` (pipeline integration, #167) and IPA realizations for proper nouns/episode citations.

--- a/docs/superpowers/specs/2026-07-29-avspeech-marker-migration-design.md
+++ b/docs/superpowers/specs/2026-07-29-avspeech-marker-migration-design.md
@@ -129,3 +129,7 @@ graduates from spike to pipeline, not now.
   (Azure documents `<say-as>`/lexicon overrides either way).
 - **Apple Feedback** for the ceiling, with the bisected 2000/2003 repro.
 - Engine decision and pipeline integration (#161, #167).
+- The manuscript acronym audit found further word-read candidates without
+  entries (ERISA, SAMHSA, POLST, WARN), and the FEMA/OSHA/SNAP entries are
+  presumptive (only HUD was measured mis-read in #173) — both to be resolved
+  in a listening pass when the AVSpeech path graduates to the pipeline.

--- a/docs/superpowers/specs/2026-07-29-avspeech-marker-migration-design.md
+++ b/docs/superpowers/specs/2026-07-29-avspeech-marker-migration-design.md
@@ -1,0 +1,131 @@
+# AVSpeechSynthesizer Marker API Migration — Spike Upgrade
+
+**Issue:** [#173](https://github.com/davidwkeith/Majordomo-epub/issues/173)
+**Date:** 2026-07-29
+
+## Scope
+
+This upgrades `scripts/avspeech-spike` from the `willSpeakRangeOfSpeechString`
+delegate to the macOS 13+ marker API, adds a deterministic boundary
+reconciliation pass, and widens `build/audio/ssml-lexicon.ts` with an
+engine-neutral acronym table. It does **not** decide AVSpeech vs Azure — it
+removes boundary reliability as a factor in that decision, so the engine call
+(still open from #161) can be made on voice quality and CI story alone.
+
+## Evidence base
+
+All measurements from #173's investigation (macOS 26, Apple Silicon, compact
+Samantha unless noted), reproduced with a standalone harness against the two
+reproduction snippets and a full ~46k-character chapter export:
+
+| Finding | Result |
+|---|---|
+| ~2000-unit callback ceiling | Applies to markers too, and to the Eloquence engine — it's in the synthesis service. Chunking stays. |
+| Marker audio offsets | Strictly monotonic across all 7,530 word markers of a full chapter. `byteSampleOffset` is **bytes** (verified against total audio duration twice). |
+| Overlapping/duplicate ranges | Same raw noise as the delegate, but every anomaly is classifiable against the monotonic audio axis; three rules reconcile a full chapter to 0 overlaps, 0 ordering violations (7,466 boundaries / ~7,516 words). |
+| Out-of-order delivery | 2 occurrences per chapter, detectable as text-range regressions while audio advances — droppable without masking anything. |
+| Acronyms | `AVSpeechSynthesisIPANotationAttribute` works on macOS 26 (FB9298976's macOS breakage is fixed): "HUD" spoken as one syllable, text range unchanged at `[31,34)`. |
+| Throughput | ~29× realtime (49.5 min of audio in ~104s), free, on-device. |
+
+Apple has acknowledged the underlying range-noise mechanism on its developer
+forums (internal text normalization re-reporting ranges against rewritten
+text); defensive merging is the community-endorsed practice. The ceiling
+itself appears publicly unreported.
+
+## Design
+
+### 1. Marker-based synthesis (spike, `main.swift`)
+
+Replace the delegate with `write(_:toBufferCallback:toMarkerCallback:)`.
+Chunking (`chunkText`, 1800-unit ceiling margin) is retained unchanged. Per
+chunk, word markers are shifted into whole-text coordinates on both axes:
+
+- text: `range.location + chunk.startOffset` (as today)
+- audio: `byteSampleOffset + bytesWrittenBeforeChunk`, where
+  `bytesWrittenBeforeChunk = totalFramesSoFar × bytesPerFrame`
+
+Only `.word` marks are consumed; other mark types are counted and reported
+for information. The delegate path is deleted, not kept as a fallback — it
+cannot produce audio offsets, so it has no remaining role.
+
+### 2. Reconciliation pass
+
+A pure function over the shifted marker list, applying three ordered rules
+per marker against the previously accepted one:
+
+1. **Duplicate tokenization** (same text start *and* same audio offset):
+   collapse into the union span. Covers the `credit cards,` /
+   `credit cards` class.
+2. **Forward overlap** (starts inside the previous span, audio advanced):
+   merge into the union span, keeping the earlier audio offset. Covers the
+   `(1-800` / `1-800-669-9777)` class.
+3. **Regression** (starts before the previous span's start while audio
+   advanced): drop the marker as a spurious re-report. Audio monotonicity is
+   ground truth that the speech never went backwards, so this hides no
+   ordering defect — unlike sorting delegate ranges, which the spike
+   rightly refused to do.
+
+The pass reports counts per rule. The spike's PASS/FAIL checks then run on
+the reconciled list: in-range, non-overlapping, text- and audio-monotonic.
+
+### 3. Output shape
+
+The spike gains a JSON dump (`dist/tts-spike/avspeech-boundaries.json`) of
+reconciled boundaries as `{ text, textOffset, wordLength, clipBeginSeconds }`,
+where `clipBeginSeconds = byteOffset ÷ bytesPerFrame ÷ sampleRate`. This is
+convertible to `smil.ts`'s `WordBoundaryRecord` (`audioOffsetTicks` =
+seconds × 10⁷; `durationTicks` derived from the next word's `clipBegin`,
+last word ends at audio end). Markers carry no durations; contiguous
+`clipEnd = next clipBegin` is what read-along SMIL wants anyway.
+
+### 4. Ceiling canary
+
+Any chunk yielding **zero** word markers fails the run loudly, naming the
+chunk offset and length. This is the guard against the undocumented ceiling
+shifting under an OS update or a different voice — the failure mode is
+silent by design, so the pipeline must make it loud.
+
+### 5. Lexicon: engine-neutral acronym table (`build/audio/ssml-lexicon.ts`)
+
+Add an acronym rule class alongside `PROPER_NOUN_RULES`, starting with the
+occurrences the chapter run surfaced (`HUD`; audit the manuscript for
+others). Each entry carries both realizations:
+
+- **Azure:** existing `<sub alias>` mechanism, unchanged.
+- **AVSpeech:** a new export mapping matches to IPA strings (e.g. `HUD` →
+  `hʌd`), applied as `AVSpeechSynthesisIPANotationAttribute` ranges on an
+  `NSAttributedString` — source text and therefore all boundary offsets
+  stay untouched.
+
+Existing rules (`Djot`, `ePub`, `Jeeves`, episode citations) are unchanged;
+whether they also need IPA realizations is decided when the AVSpeech path
+graduates from spike to pipeline, not now.
+
+## Error handling
+
+- Synthesis timeout, write errors, zero-marker chunks: fail the run with
+  the chunk identified (existing spike behavior, extended to the canary).
+- Reconciliation never throws; pathological inputs (e.g. all markers
+  regressing) surface as FAIL via the post-reconciliation checks.
+
+## Testing
+
+- The two #173 reproduction snippets and the built-in smart-typography
+  sample stay as the fast checks; the full-chapter export is the slow one.
+- Expected results are pinned: snippets reconcile with rules 1–2 only; the
+  chapter run must end at 0 overlaps / 0 violations with rule counts in the
+  measured neighborhood (7 dupes / ~55 merges / ~2 drops — drift beyond an
+  order of magnitude means the OS changed underneath us).
+- Lexicon: unit tests in `ssml-lexicon.test.ts` extend to the acronym rules
+  and the IPA export (offset invariance is the key property).
+
+## Out of scope / follow-ups
+
+- **Enhanced/premium voice marker check** — blocked on a manual voice
+  download (System Settings → Accessibility → Spoken Content); the biggest
+  remaining AVSpeech ship-risk, since marker emission is documented as
+  per-voice optional.
+- **Azure "HUD" default behavior** — blocked on `SPEECH_KEY`; low-risk
+  (Azure documents `<say-as>`/lexicon overrides either way).
+- **Apple Feedback** for the ceiling, with the bisected 2000/2003 repro.
+- Engine decision and pipeline integration (#161, #167).

--- a/scripts/avspeech-spike/Package.swift
+++ b/scripts/avspeech-spike/Package.swift
@@ -5,6 +5,14 @@ let package = Package(
     name: "avspeech-spike",
     platforms: [.macOS(.v13)],
     targets: [
-        .executableTarget(name: "avspeech-spike", path: "Sources/avspeech-spike")
+        .target(name: "SpikeCore", path: "Sources/SpikeCore"),
+        .executableTarget(
+            name: "avspeech-spike",
+            dependencies: ["SpikeCore"],
+            path: "Sources/avspeech-spike"),
+        .testTarget(
+            name: "SpikeCoreTests",
+            dependencies: ["SpikeCore"],
+            path: "Tests/SpikeCoreTests"),
     ]
 )

--- a/scripts/avspeech-spike/README.md
+++ b/scripts/avspeech-spike/README.md
@@ -130,3 +130,8 @@ Exits non-zero if any of those fail.
   (pitch, rate ramping) at every seam — acceptable for this spike's pass/fail
   checks, but a real narration pipeline would want to confirm that doesn't
   read as choppy over a full chapter.
+- When input text begins with punctuation (e.g. a literal `...`), the
+  engine's first word marker starts at offset 1 rather than 0 — a future
+  SMIL adapter consuming `avspeech-boundaries.json` will see a one-character
+  gap at the very start. (This is observed engine behavior; the
+  `fixtures/hud-phone.txt` run exercises it.)

--- a/scripts/avspeech-spike/README.md
+++ b/scripts/avspeech-spike/README.md
@@ -2,12 +2,14 @@
 
 Local counterpart to `build/scripts/tts-spike.ts`, evaluating `AVSpeechSynthesizer`
 (free, on-device, macOS) as a possible substitute for Azure Neural TTS — see
-"Could I use my Mac Studio" discussion on #161. `AVSpeechSynthesizer`'s
-`willSpeakRangeOfSpeechString` delegate callback fires per word with a
-character range into the exact string handed to it, which is the same shape
-of information Azure's `WordBoundary` event provides — if it holds up in
-practice, it removes both the per-character Azure cost and the forced-alignment
-risk that ruled out Piper in the original engine-choice writeup.
+"Could I use my Mac Studio" discussion on #161. The spike drives
+`write(_:toBufferCallback:toMarkerCallback:)`, the macOS 13+ marker API, rather
+than the older `willSpeakRangeOfSpeechString` delegate: markers carry a
+`byteSampleOffset` into the audio stream alongside the text range, which is
+audio-timing data the delegate never provided and which ePub Media Overlays
+(SMIL clip times) need. If it holds up in practice, AVSpeech removes both the
+per-character Azure cost and the forced-alignment risk that ruled out Piper in
+the original engine-choice writeup.
 
 Treat a "PASS" as a necessary, not sufficient, signal: it confirms the
 mechanism works and stays in bounds, not that the voice quality or timing
@@ -15,105 +17,115 @@ granularity is good enough to ship.
 
 ## Results
 
-Run on macOS 26, Apple Silicon, with the default `en-US` compact voice
-(Samantha):
+Full findings, evidence, and rule-by-rule rationale live in
+[#173](https://github.com/davidwkeith/Majordomo-epub/issues/173) and
+[`docs/superpowers/specs/2026-07-29-avspeech-marker-migration-design.md`](../../docs/superpowers/specs/2026-07-29-avspeech-marker-migration-design.md).
+Summary, not a restatement:
 
-- **Granularity is per-word.** The built-in sample (44 words) produced 40
-  boundaries, all in range and sequential — this is the shape the book's
-  read-along goal needs.
-- **`willSpeakRangeOfSpeechString` silently stops firing above ~2000 UTF-16
-  units of utterance text.** Not degraded, not slow — zero callbacks, while
-  the audio still writes successfully. Bisected on this machine: 2000 UTF-16
-  units passes, 2003 fails. This is undocumented by Apple and did not surface
-  in the 44-word sample; it only showed up testing against real chapter-length
-  text. **Worked around** by chunking: the script now splits input at
-  whitespace boundaries into pieces safely under the ceiling (1800 units),
-  synthesizes each in sequence into the same output file, and shifts each
-  chunk's boundary ranges back into the full text's coordinate space so the
-  reported boundaries read as one continuous set. Confirmed against a
-  373-word real chapter excerpt (371/373 boundaries, no gaps or overlap across
-  the chunk seam).
-- **The original blocking-wait implementation deadlocked outright** — it used
-  a raw `DispatchSemaphore.wait()` on the main thread, but
-  `write(_:toBufferCallback:)` and the delegate callback are delivered as
-  run-loop sources (XPC replies from the system speech-synthesis service). A
-  kernel-level semaphore wait never pumps the run loop, so those replies queue
-  up and are never delivered — a permanent hang, not a slow run. Fixed by
-  spinning `RunLoop.current` with a timeout instead of blocking.
-- **A full ~47k-character chapter (27 chunks) still fails the overlap check —
-  20 overlaps out of 7,437 boundaries (~0.3%).** Chunking fixed the
-  zero-boundary ceiling, but two independent, unfixed issues remain, both
-  inherent to `willSpeakRangeOfSpeechString` itself rather than to this
-  script's chunking:
-  - **Punctuation/number-adjacent duplicate ranges** — most of the 20: a
-    citation, footnote marker, phone number, or trailing-punctuation token
-    gets reported twice with overlapping bounds (e.g. `credit cards,` then a
-    second, shorter range for `credit cards`; `(1-800` then a separate,
-    overlapping `1-800-669-9777)`). Looks like AVSpeechSynthesizer's own
-    text normalization (phone numbers, dates-in-parens, footnote refs)
-    reporting boundaries against more than one internal tokenization of the
-    same span.
-  - **At least one genuinely out-of-order callback**, not just an
-    overlapping range: a boundary for a word from ~1,500 characters earlier
-    in the same chunk arrived after several later boundaries had already
-    been delivered and printed in sequence — confirmed via manual chunk-range
-    reconstruction that both boundaries belong to the *same* chunk, so it
-    isn't a chunk-seam artifact. `willSpeakRangeOfSpeechString` is not a
-    strictly-ordered stream in practice.
-
-  Neither issue is something this script can paper over without weakening
-  the checks it exists to enforce (sorting boundaries before the overlap
-  check would hide the out-of-order delivery, which is itself the finding).
-  This is the load-bearing result for a ship/no-ship call: on real
-  chapter-length text, ~0.3% of reported word positions can't be trusted at
-  face value, which matters directly for the book's "words highlight as
-  they're spoken" goal.
+- **The ~2000-UTF-16-unit word-marker ceiling is service-level, not
+  API-level.** It affects the marker callback the same as the old delegate,
+  and reproduces on the Eloquence engine family as well as the default
+  voice — this lives below both public APIs, in the synthesis service
+  itself. Chunking (1800-unit safety margin) stays as the workaround. A
+  chunk that yields zero word markers now fails the run loudly (a canary
+  check) instead of silently under-reporting, since the ceiling shifting
+  under an OS or voice change would otherwise fail silently by design.
+- **A three-rule reconciliation pass** (`Sources/SpikeCore/Reconcile.swift`)
+  resolves the same tokenization noise the delegate exhibited — duplicate
+  tokenizations collapsed, split tokens merged, regressing re-reports
+  dropped — using audio-offset monotonicity as ground truth: the speech
+  itself never goes backwards, so classifying each anomaly against that axis
+  doesn't paper over anything (unlike sorting delegate ranges, which the
+  original spike rightly refused to do). Audio offsets were strictly
+  monotonic across all 7,530 markers of the full-chapter investigation run.
+- **Full-chapter verification** (this task, macOS 26, Apple Silicon, compact
+  Samantha), exporting `src/content/02-field-guide/04-home/index.dj` to
+  plain text (~7,484 words / 46,273 UTF-16 units, 26 chunks): 7,534 raw word
+  markers reconciled to 7,470 boundaries — 7 duplicate tokenizations
+  collapsed, 55 split tokens merged, 2 regressing re-reports dropped.
+  **PASS** in well under the ~2-minute synthesis budget. The merge count is
+  inflated by endnote-backlink `↩` glyphs this crude export keeps; that's
+  expected, not a regression. Counts land in the same neighborhood as the
+  #173 investigation run, which is the point — an order-of-magnitude drift
+  here would mean the OS changed underneath us.
+- **Fixtures pin the two reconciliation classes independently of the slow
+  full-chapter run**: `fixtures/credit-cards.txt` (duplicate tokenization,
+  e.g. `credit cards,` / `credit cards`) reconciles at 1 duplicate / 0
+  merges / 0 drops; `fixtures/hud-phone.txt` (split-token merge, e.g.
+  `(1-800` / `1-800-669-9777)`) reconciles at 1 duplicate / 1 merge / 0
+  drops. Both PASS.
+- **The IPA attribute fixes acronym reading.**
+  `AVSpeechSynthesisIPANotationAttribute` (applied via `NSAttributedString`)
+  is verified working on macOS 26 — "HUD" is spoken as one syllable instead
+  of three letters, with the underlying text range unchanged. This is what
+  lets the acronym lexicon apply a pronunciation override without touching
+  boundary offsets.
+- **byteSampleOffset is bytes**, not frames or samples — confirmed
+  empirically against total audio duration (seconds = bytes ÷ bytesPerFrame
+  ÷ sampleRate). Synthesis ran at roughly 29× realtime on this machine.
+- **JSON output**: reconciled boundaries are dumped to
+  `dist/tts-spike/avspeech-boundaries.json` as an array of
+  `{ text, textOffset, wordLength, clipBeginSeconds }` records — the shape a
+  `smil.ts` adapter would consume directly for read-along clip times.
 
 ## Build & run
 
 ```sh
 cd scripts/avspeech-spike
-swift run                                            # built-in smart-typography sample
-swift run avspeech-spike path/to/chapter-excerpt.txt  # check real book text
-swift run avspeech-spike --list-voices                # see installed voice identifiers
+swift run                                             # built-in smart-typography sample
+swift run avspeech-spike fixtures/credit-cards.txt     # duplicate-tokenization fixture
+swift run avspeech-spike fixtures/hud-phone.txt        # split-token / acronym fixture
+swift run avspeech-spike path/to/chapter-excerpt.txt   # check real book text
+swift run avspeech-spike --list-voices                 # see installed voice identifiers
 swift run avspeech-spike --voice com.apple.voice.enhanced.en-US.Ava
 ```
 
 Writes synthesized audio to `dist/tts-spike/avspeech-spike.caf` (relative to
-wherever you run it from) for a listening check, alongside a dump of every
-captured word boundary.
+wherever you run it from) for a listening check, alongside
+`dist/tts-spike/avspeech-boundaries.json` (the reconciled word boundaries) and
+a console dump of every boundary with its text range and `clipBeginSeconds`.
 
 ## What it checks
 
-Unlike Azure's `WordBoundary`, `willSpeakRangeOfSpeechString` can't drift
-against a separately-encoded source string — there's only one `String`
-object involved, so it always indexes into it correctly by construction.
-What's actually unverified is:
+Unlike Azure's `WordBoundary`, the marker callback can't drift against a
+separately-encoded source string — there's only one `String` object involved,
+so text ranges always index into it correctly by construction. What's
+actually unverified is:
 
 1. **Granularity** — does the callback fire per word, or per sentence/utterance?
    The book's stated goal ("words highlight as they're spoken") needs the
    former.
 2. **Robustness around Djot's smart typography** — curly quotes, em/en dashes,
    ellipses — the same risk class the Azure spike checks for.
-3. **Range validity** — every boundary's range should stay within the source
-   text and not overlap the previous one.
+3. **Range validity** — every reconciled boundary's text range should stay
+   within the source text and not overlap the previous one.
+4. **Audio monotonicity** — reconciled boundaries' `byteSampleOffset` values
+   must never go backwards; this is also the ground truth the reconciliation
+   pass itself relies on.
+5. **Ceiling canary** — any chunk producing zero word markers is a hard
+   failure, not a silent gap, since the undocumented ~2000-unit ceiling
+   shifting under an OS or voice change would otherwise be invisible.
 
 Exits non-zero if any of those fail.
 
 ## Known gaps
 
-- No cost/CI-reproducibility story yet: this only runs on macOS with a human
-  present (or a self-hosted runner), which is a different shape than Azure's
-  "call an API from any GitHub Actions runner." Worth resolving before this
-  goes further than a spike.
+- **Enhanced/premium `en-US` voice marker support is untested.** No such
+  voice is installed on this machine (requires a manual download via System
+  Settings → Accessibility → Spoken Content), and marker emission is
+  documented as per-voice optional — this is the biggest remaining
+  ship-risk for AVSpeech.
+- **Ceiling stability across macOS versions is unconfirmed.** The
+  ~2000-unit cutoff (1800-unit chunk margin) is only measured on this
+  machine/OS; Apple documents neither the limit nor the chunking workaround.
+- **No cost/CI-reproducibility story yet**: this only runs on macOS with a
+  human present (or a self-hosted runner), which is a different shape than
+  Azure's "call an API from any GitHub Actions runner." Worth resolving
+  before this goes further than a spike.
 - Chunking splits purely on whitespace, not sentence or clause boundaries, so
   a chunk seam can fall mid-sentence — worth checking whether that produces
   an audible prosody glitch (a flattened pitch reset) at the join, not just
   whether the audio and boundaries are technically continuous.
-- The 1800-unit chunk ceiling was chosen as a safety margin under the
-  measured ~2000-unit cutoff on this machine/OS/voice; it isn't confirmed
-  stable across macOS versions or other voices, and Apple documents neither
-  the limit nor this workaround.
 - Each chunk starts a fresh `AVSpeechUtterance`, which resets prosody state
   (pitch, rate ramping) at every seam — acceptable for this spike's pass/fail
   checks, but a real narration pipeline would want to confirm that doesn't

--- a/scripts/avspeech-spike/Sources/SpikeCore/Chunking.swift
+++ b/scripts/avspeech-spike/Sources/SpikeCore/Chunking.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+public struct TextChunk {
+    // UTF-16 offset into the original source text — lets a chunk's own
+    // word-marker ranges (reported relative to the chunk's utterance
+    // string) be translated back into the caller's coordinate space.
+    public let startOffset: Int
+    public let text: String
+
+    public init(startOffset: Int, text: String) {
+        self.startOffset = startOffset
+        self.text = text
+    }
+}
+
+// AVSpeechSynthesizer silently stops reporting word boundaries altogether
+// above ~2000 UTF-16 units of utterance text (measured: 2000 passes, 2003
+// fails, on this machine/voice) — confirmed for both the delegate and the
+// marker callback, so the ceiling is in the synthesis service itself.
+// Splitting on whitespace keeps each chunk under that ceiling without
+// cutting a word in half.
+public func chunkText(_ text: String, maxUTF16Length: Int) -> [TextChunk] {
+    let nsText = text as NSString
+    let length = nsText.length
+    guard length > 0 else { return [] }
+
+    func isWhitespace(_ unit: unichar) -> Bool {
+        guard let scalar = Unicode.Scalar(unit) else { return false }
+        return CharacterSet.whitespacesAndNewlines.contains(scalar)
+    }
+
+    var chunks: [TextChunk] = []
+    var start = 0
+    while start < length {
+        let remaining = length - start
+        if remaining <= maxUTF16Length {
+            chunks.append(TextChunk(startOffset: start, text: nsText.substring(from: start)))
+            break
+        }
+
+        // Walk back from the window's edge to the nearest whitespace so the
+        // split falls between words, not inside one.
+        var splitAt = start + maxUTF16Length
+        var search = splitAt
+        while search > start && !isWhitespace(nsText.character(at: search)) {
+            search -= 1
+        }
+        if search > start {
+            splitAt = search
+        }
+        // else: no whitespace anywhere in the window (one very long token) —
+        // fall back to a hard cut at the window edge.
+
+        chunks.append(
+            TextChunk(startOffset: start, text: nsText.substring(with: NSRange(location: start, length: splitAt - start))))
+
+        // Skip the whitespace run so the next chunk doesn't start with
+        // leading space (which would shift its own word boundaries by one).
+        var nextStart = splitAt
+        while nextStart < length && isWhitespace(nsText.character(at: nextStart)) {
+            nextStart += 1
+        }
+        start = nextStart
+    }
+    return chunks
+}

--- a/scripts/avspeech-spike/Sources/SpikeCore/Reconcile.swift
+++ b/scripts/avspeech-spike/Sources/SpikeCore/Reconcile.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// One word boundary from the marker callback, shifted into whole-text
+/// (range) and whole-stream (byteOffset) coordinates.
+public struct SpokenWordBoundary: Equatable {
+    public let range: NSRange
+    public let byteOffset: Int
+
+    public init(range: NSRange, byteOffset: Int) {
+        self.range = range
+        self.byteOffset = byteOffset
+    }
+}
+
+public struct ReconcileResult: Equatable {
+    public let boundaries: [SpokenWordBoundary]
+    public let duplicatesCollapsed: Int
+    public let overlapsMerged: Int
+    public let regressionsDropped: Int
+
+    public init(
+        boundaries: [SpokenWordBoundary], duplicatesCollapsed: Int,
+        overlapsMerged: Int, regressionsDropped: Int
+    ) {
+        self.boundaries = boundaries
+        self.duplicatesCollapsed = duplicatesCollapsed
+        self.overlapsMerged = overlapsMerged
+        self.regressionsDropped = regressionsDropped
+    }
+}
+
+/// Reconcile raw word markers into a non-overlapping, text- and
+/// audio-monotonic boundary list.
+///
+/// AVSpeechSynthesizer's internal text normalization re-reports some spans
+/// against more than one tokenization (Apple-acknowledged; see #173). The
+/// audio offsets, however, are strictly monotonic in practice — the speech
+/// itself never goes backwards — which is what makes each anomaly
+/// classifiable rather than papered over:
+///
+/// 1. Same text start, same audio offset → the same moment tokenized twice;
+///    collapse to the union span.
+/// 2. Text start regressing behind the previous boundary's *start* while
+///    audio advances → spurious re-report of earlier text; drop it.
+/// 3. Text start inside the previous span (but not regressing) → the
+///    normalizer split one utterance token in two (phone numbers); merge to
+///    the union span, keeping the earlier offset.
+///
+/// Rule order is load-bearing: a regressing start also satisfies rule 3's
+/// predicate, so rule 2 must be checked first.
+public func reconcile(_ markers: [SpokenWordBoundary]) -> ReconcileResult {
+    var out: [SpokenWordBoundary] = []
+    var duplicates = 0
+    var merges = 0
+    var drops = 0
+
+    for marker in markers {
+        guard let last = out.last else {
+            out.append(marker)
+            continue
+        }
+        let lastEnd = last.range.location + last.range.length
+
+        if marker.range.location == last.range.location && marker.byteOffset == last.byteOffset {
+            duplicates += 1
+            let end = max(lastEnd, marker.range.location + marker.range.length)
+            out[out.count - 1] = SpokenWordBoundary(
+                range: NSRange(location: last.range.location, length: end - last.range.location),
+                byteOffset: last.byteOffset)
+            continue
+        }
+        if marker.range.location < last.range.location {
+            drops += 1
+            continue
+        }
+        if marker.range.location < lastEnd {
+            merges += 1
+            let end = max(lastEnd, marker.range.location + marker.range.length)
+            out[out.count - 1] = SpokenWordBoundary(
+                range: NSRange(location: last.range.location, length: end - last.range.location),
+                byteOffset: min(last.byteOffset, marker.byteOffset))
+            continue
+        }
+        out.append(marker)
+    }
+
+    return ReconcileResult(
+        boundaries: out, duplicatesCollapsed: duplicates,
+        overlapsMerged: merges, regressionsDropped: drops)
+}

--- a/scripts/avspeech-spike/Sources/avspeech-spike/main.swift
+++ b/scripts/avspeech-spike/Sources/avspeech-spike/main.swift
@@ -1,18 +1,15 @@
-// AVSpeechSynthesizer word-boundary spike — the local-TTS counterpart to
-// build/scripts/tts-spike.ts (Azure). Where the Azure spike checks that
-// `WordBoundary`'s reported offset lines up with the source string it was
-// given, `AVSpeechSynthesizer` has no separate wire encoding to drift
-// against: `willSpeakRangeOfSpeechString` always indexes into the exact
-// `String` handed to `AVSpeechUtterance`. Confirmed: the callback fires per
-// word (not per sentence) and holds up against Djot's smart-typography
-// substitutions (curly quotes, em/en dash, ellipsis). Also confirmed, on
-// real chapter-length text: it stops firing altogether above ~2000 UTF-16
-// units per utterance (worked around below via chunkText), and even within
-// a single chunk it occasionally reports overlapping or out-of-order
-// ranges around punctuation-heavy text (citations, phone numbers, footnote
-// markers) — see the README's Results section for the full breakdown.
-// See docs/superpowers/specs/2026-07-27-azure-tts-engine-design.md for why
-// this mattered enough to spike in the first place.
+// AVSpeechSynthesizer word-marker spike — the local-TTS counterpart to
+// build/scripts/tts-spike.ts (Azure). Uses the macOS 13+
+// write(_:toBufferCallback:toMarkerCallback:) API rather than the
+// willSpeakRangeOfSpeechString delegate: markers carry a byteSampleOffset
+// into the audio stream (empirically bytes — see #173), which is the
+// timing data ePub Media Overlays need and the delegate never provided.
+// The ~2000-UTF-16-unit ceiling on word reporting is in the synthesis
+// service itself (delegate AND markers, multiple engines), so input is
+// chunked below it; raw markers are then reconciled by SpikeCore's
+// three-rule pass (duplicates, regressions, forward overlaps — see
+// Reconcile.swift for why that isn't papering over the findings).
+// See docs/superpowers/specs/2026-07-29-avspeech-marker-migration-design.md.
 
 import AVFoundation
 import Foundation
@@ -25,41 +22,6 @@ let sampleText =
     + "situation\u{201D}\u{2014}the sort that wants patience, not haste. The Skill itself is "
     + "well-formed; it\u{2019}s the ePub\u{2019}s Djot source that needs a second look\u{2026} "
     + "three passes, minimum\u{2014}maybe four."
-
-struct WordBoundary {
-    let range: NSRange
-    let text: String
-}
-
-final class SpikeDelegate: NSObject, AVSpeechSynthesizerDelegate {
-    private let lock = NSLock()
-    private var collected: [WordBoundary] = []
-    private let sourceText: NSString
-
-    init(sourceText: String) {
-        self.sourceText = sourceText as NSString
-    }
-
-    var boundaries: [WordBoundary] {
-        lock.lock()
-        defer { lock.unlock() }
-        return collected
-    }
-
-    func speechSynthesizer(
-        _ synthesizer: AVSpeechSynthesizer,
-        willSpeakRangeOfSpeechString characterRange: NSRange,
-        utterance: AVSpeechUtterance
-    ) {
-        guard characterRange.location != NSNotFound,
-            characterRange.location + characterRange.length <= sourceText.length
-        else { return }
-        let word = sourceText.substring(with: characterRange)
-        lock.lock()
-        collected.append(WordBoundary(range: characterRange, text: word))
-        lock.unlock()
-    }
-}
 
 func eprint(_ message: String) {
     FileHandle.standardError.write((message + "\n").data(using: .utf8)!)
@@ -99,7 +61,6 @@ func resolveVoice(named identifier: String?) -> AVSpeechSynthesisVoice? {
     eprint("No voice matches \"\(identifier)\" — falling back to the best available en-US voice.")
     return bestAvailableVoice()
 }
-
 
 // MARK: - Argument parsing
 //
@@ -157,35 +118,43 @@ print("Voice: \(voice.identifier) (\(voice.name), quality=\(qualityLabel(voice.q
 let preview = text.count > 80 ? "\(text.prefix(80))…" : text
 print("Text (\(text.utf16.count) UTF-16 units): \(preview)")
 
+// MARK: - Synthesis
+
 let synthesizer = AVSpeechSynthesizer()
 
 let outputDir = URL(fileURLWithPath: "dist/tts-spike", isDirectory: true)
 try? FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
-let outputURL = outputDir.appendingPathComponent("avspeech-spike.caf")
+let audioURL = outputDir.appendingPathComponent("avspeech-spike.caf")
+let jsonURL = outputDir.appendingPathComponent("avspeech-boundaries.json")
 
-// Stay comfortably under the ~2000 UTF-16-unit ceiling where
-// willSpeakRangeOfSpeechString stops firing (see chunkText's doc comment).
+// Stay comfortably under the ~2000 UTF-16-unit ceiling where the service
+// stops reporting word boundaries (see chunkText's doc comment).
 let maxChunkLength = 1800
 let chunks = chunkText(text, maxUTF16Length: maxChunkLength)
 if chunks.count > 1 {
     print(
         "Splitting into \(chunks.count) chunks (~\(maxChunkLength) UTF-16 units each) to stay under "
-            + "AVSpeechSynthesizer's word-boundary ceiling.")
+            + "the synthesis service's word-marker ceiling.")
 }
 
 var audioFile: AVAudioFile?
 var writeError: Error?
-var boundaries: [WordBoundary] = []
+var rawMarkers: [SpokenWordBoundary] = []
+var totalFrames = 0
+var bytesPerFrame = 0
+var sampleRate = 0.0
 
 for chunk in chunks {
     let utterance = AVSpeechUtterance(string: chunk.text)
     utterance.voice = voice
 
-    let delegate = SpikeDelegate(sourceText: chunk.text)
-    synthesizer.delegate = delegate
+    // Bytes written before this chunk — shifts marker offsets into
+    // whole-stream coordinates, mirroring startOffset for text ranges.
+    let byteBase = totalFrames * bytesPerFrame
 
+    var chunkMarkers: [SpokenWordBoundary] = []
     var finished = false
-    synthesizer.write(utterance) { buffer in
+    synthesizer.write(utterance, toBufferCallback: { buffer in
         guard let pcmBuffer = buffer as? AVAudioPCMBuffer else {
             writeError = NSError(
                 domain: "avspeech-spike", code: 1,
@@ -198,9 +167,12 @@ for chunk in chunks {
             finished = true
             return
         }
+        totalFrames += Int(pcmBuffer.frameLength)
+        sampleRate = pcmBuffer.format.sampleRate
+        bytesPerFrame = Int(pcmBuffer.format.streamDescription.pointee.mBytesPerFrame)
         do {
             if audioFile == nil {
-                audioFile = try AVAudioFile(forWriting: outputURL, settings: pcmBuffer.format.settings)
+                audioFile = try AVAudioFile(forWriting: audioURL, settings: pcmBuffer.format.settings)
             }
             // Every chunk shares one voice, so format stays consistent —
             // appending keeps the whole chapter as a single playable file.
@@ -209,16 +181,21 @@ for chunk in chunks {
             writeError = error
             finished = true
         }
-    }
+    }, toMarkerCallback: { markers in
+        for marker in markers where marker.mark == .word {
+            guard marker.textRange.location != NSNotFound else { continue }
+            chunkMarkers.append(
+                SpokenWordBoundary(
+                    range: NSRange(
+                        location: marker.textRange.location + chunk.startOffset,
+                        length: marker.textRange.length),
+                    byteOffset: marker.byteSampleOffset + byteBase))
+        }
+    })
 
-    // `write(_:toBufferCallback:)` and `willSpeakRangeOfSpeechString` deliver
-    // their results as run-loop sources (XPC replies from the system
-    // speech-synthesis service), not raw GCD callbacks. Blocking the main
-    // thread on a DispatchSemaphore — as an earlier version of this script
-    // did — parks the thread in a kernel-level semaphore_wait_trap that never
-    // pumps the run loop, so those replies queue up and are never delivered:
-    // a permanent deadlock, not a slow synthesis. Spinning the run loop here
-    // is what lets them arrive.
+    // Both callbacks are delivered as run-loop sources (XPC replies from the
+    // system speech-synthesis service). Blocking the thread on a semaphore
+    // would deadlock (see #174) — spinning the run loop lets them arrive.
     let deadline = Date().addingTimeInterval(30)
     while !finished && Date() < deadline {
         RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
@@ -231,13 +208,17 @@ for chunk in chunks {
         break
     }
 
-    // Translate this chunk's self-relative ranges back into the full
-    // source text's coordinate space so downstream checks (and callers)
-    // see one continuous set of boundaries, as if chunking never happened.
-    for boundary in delegate.boundaries {
-        let shifted = NSRange(location: boundary.range.location + chunk.startOffset, length: boundary.range.length)
-        boundaries.append(WordBoundary(range: shifted, text: boundary.text))
+    // Ceiling canary: a chunk with zero word markers means the undocumented
+    // ceiling moved under us (OS update, different voice). The failure mode
+    // is silent by design, so make it loud.
+    if chunkMarkers.isEmpty {
+        eprint(
+            "FAIL: chunk at offset \(chunk.startOffset) (\(chunk.text.utf16.count) UTF-16 units) "
+                + "produced zero word markers — the word-reporting ceiling may have shifted below "
+                + "\(maxChunkLength) units on this OS/voice.")
+        exit(1)
     }
+    rawMarkers.append(contentsOf: chunkMarkers)
 }
 
 if let writeError {
@@ -245,33 +226,72 @@ if let writeError {
     exit(1)
 }
 
-// MARK: - Verify boundaries
+// MARK: - Reconcile & verify
 
+let result = reconcile(rawMarkers)
+let boundaries = result.boundaries
 let nsText = text as NSString
 let wordCount = text.split(whereSeparator: { !$0.isLetter && !$0.isNumber }).filter { !$0.isEmpty }.count
 
-print("\n\(boundaries.count) word boundaries captured (~\(wordCount) words in source text).")
+print("\n\(rawMarkers.count) raw word markers → \(boundaries.count) reconciled boundaries (~\(wordCount) words in source text).")
+print(
+    "reconciliation: \(result.duplicatesCollapsed) duplicate tokenizations collapsed, "
+        + "\(result.overlapsMerged) split tokens merged, \(result.regressionsDropped) regressing re-reports dropped.")
 for boundary in boundaries {
     let end = boundary.range.location + boundary.range.length
-    print("  [\(boundary.range.location), \(end)) \(boundary.text)")
+    guard end <= nsText.length else { continue }
+    let seconds = Double(boundary.byteOffset) / Double(max(bytesPerFrame, 1)) / max(sampleRate, 1)
+    print(String(format: "  [%d, %d) %8.3fs %@", boundary.range.location, end, seconds, nsText.substring(with: boundary.range)))
 }
 
 var outOfBounds = 0
 var overlaps = 0
+var audioRegressions = 0
 var previousEnd = 0
+var previousOffset = -1
 for boundary in boundaries {
     let start = boundary.range.location
     let end = start + boundary.range.length
     if end > nsText.length { outOfBounds += 1 }
     if start < previousEnd { overlaps += 1 }
+    if boundary.byteOffset < previousOffset { audioRegressions += 1 }
     previousEnd = max(previousEnd, end)
+    previousOffset = boundary.byteOffset
 }
 
-print("\nAudio written to \(outputURL.path)")
+// MARK: - JSON dump (the shape a smil.ts adapter consumes)
+
+struct BoundaryRecord: Codable {
+    let text: String
+    let textOffset: Int
+    let wordLength: Int
+    let clipBeginSeconds: Double
+}
+
+let records = boundaries.compactMap { boundary -> BoundaryRecord? in
+    let end = boundary.range.location + boundary.range.length
+    guard end <= nsText.length else { return nil }
+    return BoundaryRecord(
+        text: nsText.substring(with: boundary.range),
+        textOffset: boundary.range.location,
+        wordLength: boundary.range.length,
+        clipBeginSeconds: Double(boundary.byteOffset) / Double(max(bytesPerFrame, 1)) / max(sampleRate, 1))
+}
+do {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    try encoder.encode(records).write(to: jsonURL)
+} catch {
+    eprint("Could not write \(jsonURL.path): \(error.localizedDescription)")
+    exit(1)
+}
+
+print("\nAudio written to \(audioURL.path)")
+print("Boundaries written to \(jsonURL.path)")
 
 var failed = false
 if boundaries.isEmpty {
-    print("FAIL: no willSpeakRangeOfSpeechString callbacks fired for this voice.")
+    print("FAIL: no word markers were delivered for this voice.")
     failed = true
 } else if Double(boundaries.count) < Double(wordCount) * 0.5 {
     print(
@@ -284,11 +304,15 @@ if outOfBounds > 0 {
     failed = true
 }
 if overlaps > 0 {
-    print("FAIL: \(overlaps) boundary range(s) overlap the previous one.")
+    print("FAIL: \(overlaps) reconciled boundary range(s) still overlap the previous one.")
+    failed = true
+}
+if audioRegressions > 0 {
+    print("FAIL: \(audioRegressions) reconciled boundary audio offset(s) go backwards.")
     failed = true
 }
 
 if failed {
     exit(1)
 }
-print("\nPASS: word-level boundaries are in range and sequential against the source text.")
+print("\nPASS: reconciled word boundaries are in range, non-overlapping, and audio-monotonic.")

--- a/scripts/avspeech-spike/Sources/avspeech-spike/main.swift
+++ b/scripts/avspeech-spike/Sources/avspeech-spike/main.swift
@@ -16,6 +16,7 @@
 
 import AVFoundation
 import Foundation
+import SpikeCore
 
 // Mirrors build/scripts/tts-spike.ts's SAMPLE_TEXT so the two spikes run
 // against identical text.
@@ -99,65 +100,6 @@ func resolveVoice(named identifier: String?) -> AVSpeechSynthesisVoice? {
     return bestAvailableVoice()
 }
 
-struct TextChunk {
-    // UTF-16 offset into the original source text — lets a chunk's own
-    // word-boundary ranges (which `willSpeakRangeOfSpeechString` reports
-    // relative to the chunk's utterance string) be translated back into the
-    // caller's coordinate space.
-    let startOffset: Int
-    let text: String
-}
-
-// AVSpeechSynthesizer silently stops firing `willSpeakRangeOfSpeechString`
-// altogether above ~2000 UTF-16 units of utterance text (measured: 2000
-// passes, 2003 fails, on this machine/voice) — it doesn't degrade or error,
-// the callback just never comes. Splitting on whitespace keeps each chunk
-// under that ceiling without cutting a word in half.
-func chunkText(_ text: String, maxUTF16Length: Int) -> [TextChunk] {
-    let nsText = text as NSString
-    let length = nsText.length
-    guard length > 0 else { return [] }
-
-    func isWhitespace(_ unit: unichar) -> Bool {
-        guard let scalar = Unicode.Scalar(unit) else { return false }
-        return CharacterSet.whitespacesAndNewlines.contains(scalar)
-    }
-
-    var chunks: [TextChunk] = []
-    var start = 0
-    while start < length {
-        let remaining = length - start
-        if remaining <= maxUTF16Length {
-            chunks.append(TextChunk(startOffset: start, text: nsText.substring(from: start)))
-            break
-        }
-
-        // Walk back from the window's edge to the nearest whitespace so the
-        // split falls between words, not inside one.
-        var splitAt = start + maxUTF16Length
-        var search = splitAt
-        while search > start && !isWhitespace(nsText.character(at: search)) {
-            search -= 1
-        }
-        if search > start {
-            splitAt = search
-        }
-        // else: no whitespace anywhere in the window (one very long token) —
-        // fall back to a hard cut at the window edge.
-
-        chunks.append(
-            TextChunk(startOffset: start, text: nsText.substring(with: NSRange(location: start, length: splitAt - start))))
-
-        // Skip the whitespace run so the next chunk doesn't start with
-        // leading space (which would shift its own word boundaries by one).
-        var nextStart = splitAt
-        while nextStart < length && isWhitespace(nsText.character(at: nextStart)) {
-            nextStart += 1
-        }
-        start = nextStart
-    }
-    return chunks
-}
 
 // MARK: - Argument parsing
 //

--- a/scripts/avspeech-spike/Sources/avspeech-spike/main.swift
+++ b/scripts/avspeech-spike/Sources/avspeech-spike/main.swift
@@ -140,6 +140,7 @@ if chunks.count > 1 {
 var audioFile: AVAudioFile?
 var writeError: Error?
 var rawMarkers: [SpokenWordBoundary] = []
+var nonWordMarkCount = 0
 var totalFrames = 0
 var bytesPerFrame = 0
 var sampleRate = 0.0
@@ -182,7 +183,11 @@ for chunk in chunks {
             finished = true
         }
     }, toMarkerCallback: { markers in
-        for marker in markers where marker.mark == .word {
+        for marker in markers {
+            guard marker.mark == .word else {
+                nonWordMarkCount += 1
+                continue
+            }
             guard marker.textRange.location != NSNotFound else { continue }
             chunkMarkers.append(
                 SpokenWordBoundary(
@@ -228,12 +233,34 @@ if let writeError {
 
 // MARK: - Reconcile & verify
 
+// Raw-marker audio-monotonicity canary: the entire three-rule reconciliation
+// pass rests on the empirical claim that raw marker audio offsets never
+// regress (text ranges get noisy; audio does not — see Reconcile.swift). A
+// raw audio regression has never been observed across any measured run; if
+// one shows up here, that assumption is falsified and reconciliation would
+// be silently laundering a real ordering defect instead of resolving noise.
+// So this must fail loudly, not be reconciled away.
+for index in rawMarkers.indices.dropFirst() {
+    let previous = rawMarkers[index - 1]
+    let current = rawMarkers[index]
+    if current.byteOffset < previous.byteOffset {
+        eprint(
+            "FAIL: raw marker \(index) audio offset regressed (previous byteOffset "
+                + "\(previous.byteOffset) at range \(previous.range) → marker \(index) byteOffset "
+                + "\(current.byteOffset) at range \(current.range)). Raw audio offsets have never "
+                + "regressed in any measured run; this falsifies the assumption the reconciliation "
+                + "pass relies on.")
+        exit(1)
+    }
+}
+
 let result = reconcile(rawMarkers)
 let boundaries = result.boundaries
 let nsText = text as NSString
 let wordCount = text.split(whereSeparator: { !$0.isLetter && !$0.isNumber }).filter { !$0.isEmpty }.count
 
 print("\n\(rawMarkers.count) raw word markers → \(boundaries.count) reconciled boundaries (~\(wordCount) words in source text).")
+print("\(nonWordMarkCount) non-word markers ignored (sentence/paragraph/phoneme).")
 print(
     "reconciliation: \(result.duplicatesCollapsed) duplicate tokenizations collapsed, "
         + "\(result.overlapsMerged) split tokens merged, \(result.regressionsDropped) regressing re-reports dropped.")

--- a/scripts/avspeech-spike/Tests/SpikeCoreTests/ChunkingTests.swift
+++ b/scripts/avspeech-spike/Tests/SpikeCoreTests/ChunkingTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import SpikeCore
+
+final class ChunkingTests: XCTestCase {
+    func testShortTextIsASingleChunk() {
+        let chunks = chunkText("hello world", maxUTF16Length: 1800)
+        XCTAssertEqual(chunks.count, 1)
+        XCTAssertEqual(chunks[0].startOffset, 0)
+        XCTAssertEqual(chunks[0].text, "hello world")
+    }
+
+    func testEmptyTextYieldsNoChunks() {
+        XCTAssertTrue(chunkText("", maxUTF16Length: 1800).isEmpty)
+    }
+
+    func testSplitsAtWhitespaceUnderTheCeiling() {
+        let text = Array(repeating: "word", count: 100).joined(separator: " ") // 499 units
+        let chunks = chunkText(text, maxUTF16Length: 100)
+        XCTAssertGreaterThan(chunks.count, 1)
+        for chunk in chunks {
+            XCTAssertLessThanOrEqual(chunk.text.utf16.count, 100)
+            XCTAssertFalse(chunk.text.hasPrefix(" "))
+            XCTAssertFalse(chunk.text.hasSuffix(" "))
+        }
+    }
+
+    func testChunkOffsetsSliceBackToTheSourceText() {
+        let text = Array(repeating: "word", count: 100).joined(separator: " ")
+        let nsText = text as NSString
+        for chunk in chunkText(text, maxUTF16Length: 100) {
+            let slice = nsText.substring(
+                with: NSRange(location: chunk.startOffset, length: chunk.text.utf16.count))
+            XCTAssertEqual(slice, chunk.text)
+        }
+    }
+
+    func testOneVeryLongTokenGetsAHardCut() {
+        let text = String(repeating: "x", count: 250)
+        let chunks = chunkText(text, maxUTF16Length: 100)
+        XCTAssertEqual(chunks.count, 3)
+        XCTAssertEqual(chunks.map { $0.text.utf16.count }, [100, 100, 50])
+    }
+}

--- a/scripts/avspeech-spike/Tests/SpikeCoreTests/ReconcileTests.swift
+++ b/scripts/avspeech-spike/Tests/SpikeCoreTests/ReconcileTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import SpikeCore
+
+final class ReconcileTests: XCTestCase {
+    private func b(_ location: Int, _ length: Int, _ offset: Int) -> SpokenWordBoundary {
+        SpokenWordBoundary(range: NSRange(location: location, length: length), byteOffset: offset)
+    }
+
+    func testCleanBoundariesPassThroughUntouched() {
+        let markers = [b(0, 4, 0), b(5, 4, 20240), b(10, 8, 51920)]
+        let result = reconcile(markers)
+        XCTAssertEqual(result.boundaries, markers)
+        XCTAssertEqual(result.duplicatesCollapsed, 0)
+        XCTAssertEqual(result.overlapsMerged, 0)
+        XCTAssertEqual(result.regressionsDropped, 0)
+    }
+
+    func testCollapsesSameStartSameOffsetDuplicateToTheUnionSpan() {
+        // Observed: "credit cards" [52,64) then "credit cards," [52,65),
+        // both at byte offset 292600 — one audio moment, two tokenizations.
+        let result = reconcile([b(41, 10, 216920), b(52, 12, 292600), b(52, 13, 292600), b(66, 4, 400400)])
+        XCTAssertEqual(result.boundaries, [b(41, 10, 216920), b(52, 13, 292600), b(66, 4, 400400)])
+        XCTAssertEqual(result.duplicatesCollapsed, 1)
+        XCTAssertEqual(result.overlapsMerged, 0)
+        XCTAssertEqual(result.regressionsDropped, 0)
+    }
+
+    func testDuplicateKeepsTheLongerSpanWhenTheFirstReportIsLonger() {
+        // Observed: "request," [35,43) then "request" [35,42), same offset.
+        let result = reconcile([b(35, 8, 162800), b(35, 7, 162800)])
+        XCTAssertEqual(result.boundaries, [b(35, 8, 162800)])
+        XCTAssertEqual(result.duplicatesCollapsed, 1)
+    }
+
+    func testMergesForwardOverlapKeepingTheEarlierOffset() {
+        // Observed: "(1-800" [58,64) at 375320, then "1-800-669-9777)"
+        // [59,74) at 428120 — the normalizer re-reads the phone number.
+        let result = reconcile([b(49, 4, 270160), b(58, 6, 375320), b(59, 15, 428120), b(75, 2, 759000)])
+        XCTAssertEqual(result.boundaries, [b(49, 4, 270160), b(58, 16, 375320), b(75, 2, 759000)])
+        XCTAssertEqual(result.overlapsMerged, 1)
+        XCTAssertEqual(result.duplicatesCollapsed, 0)
+        XCTAssertEqual(result.regressionsDropped, 0)
+    }
+
+    func testDropsARegressingMarkerAsASpuriousRereport() {
+        // Observed: after "with" [45993,45997), a marker for "reva"
+        // [45116,45120) arrived with a *later* audio offset — audio
+        // monotonicity proves the speech never went backwards.
+        let result = reconcile([b(45993, 4, 1000), b(45116, 4, 2000), b(46060, 1, 3000)])
+        XCTAssertEqual(result.boundaries, [b(45993, 4, 1000), b(46060, 1, 3000)])
+        XCTAssertEqual(result.regressionsDropped, 1)
+        XCTAssertEqual(result.overlapsMerged, 0)
+    }
+
+    func testEmptyInputYieldsEmptyResult() {
+        let result = reconcile([])
+        XCTAssertTrue(result.boundaries.isEmpty)
+    }
+
+    func testReconciledOutputIsAlwaysNonOverlappingAndAudioMonotonic() {
+        // Mixed stream exercising all three rules together.
+        let markers = [
+            b(0, 4, 0),
+            b(5, 4, 100), b(5, 5, 100),    // dupe
+            b(12, 6, 200), b(13, 10, 250), // forward overlap
+            b(3, 2, 300),                  // regression
+            b(30, 4, 400),
+        ]
+        let result = reconcile(markers)
+        var prevEnd = 0
+        var prevOffset = -1
+        for m in result.boundaries {
+            XCTAssertGreaterThanOrEqual(m.range.location, prevEnd)
+            XCTAssertGreaterThanOrEqual(m.byteOffset, prevOffset)
+            prevEnd = m.range.location + m.range.length
+            prevOffset = m.byteOffset
+        }
+        XCTAssertEqual(result.duplicatesCollapsed, 1)
+        XCTAssertEqual(result.overlapsMerged, 1)
+        XCTAssertEqual(result.regressionsDropped, 1)
+    }
+}

--- a/scripts/avspeech-spike/fixtures/credit-cards.txt
+++ b/scripts/avspeech-spike/fixtures/credit-cards.txt
@@ -1,0 +1,1 @@
+This caps interest on pre-service debts, mortgages, credit cards, auto loans, at 6% with written notice to the creditor.

--- a/scripts/avspeech-spike/fixtures/hud-phone.txt
+++ b/scripts/avspeech-spike/fixtures/hud-phone.txt
@@ -1,0 +1,1 @@
+...service animal or accommodation request, file with HUD (1-800-669-9777) or your local fair housing office.


### PR DESCRIPTION
## Summary

Resolves the solutions investigation for #173: migrates `scripts/avspeech-spike` from the `willSpeakRangeOfSpeechString` delegate to the macOS 13+ marker API (`write(_:toBufferCallback:toMarkerCallback:)`) and widens the SSML lexicon with an engine-neutral acronym table. Design doc and implementation plan are included in the branch.

- **SpikeCore library** (new SwiftPM target): `chunkText` extracted and a three-rule marker reconciliation pass (duplicate-tokenization collapse, split-token merge, regressing-re-report drop), XCTest-covered with fixtures taken from the actual marker sequences observed in the #173 investigation.
- **Marker-API executable**: byte-accurate audio offsets per word (which the delegate never provided — the data ePub Media Overlays need), zero-marker ceiling canary, raw-marker audio-monotonicity canary, non-word mark reporting, and a JSON boundary dump (`dist/tts-spike/avspeech-boundaries.json`) shaped for a future `smil.ts` adapter.
- **Fixtures**: the two #173 reproduction snippets now PASS (previously failed the delegate spike's overlap check) — credit-cards reconciles 1 duplicate, hud-phone 1 duplicate + 1 merge.
- **README** rewritten for the marker era, citing #173 and the design doc.
- **Lexicon**: `ACRONYM_ENTRIES` (HUD/FEMA/OSHA/SNAP) feeding both the Azure `<sub alias>` path and a new `findIpaMatches` export for AVSpeech IPA attributes (source text and boundary offsets untouched).

## Verification

- Swift: 12/12 XCTests; sample run PASS (40 boundaries, 0/0/0 reconciliation); both fixtures PASS with the predicted counts.
- Full chapter (`02-field-guide/04-home`, 7,484 words): 7,534 raw markers → 7,470 reconciled, 0 overlaps, 0 ordering violations, PASS in ~47s.
- TypeScript: 182/182 vitest.
- Reviewed per-task and whole-branch (subagent-driven); final-review findings fixed in 374dc93 and re-approved.

## Follow-ups (tracked in the design doc)

Enhanced/premium voice marker check (needs a manual voice download), Azure "HUD" default-behavior test (needs `SPEECH_KEY`), Apple Feedback for the undocumented ~2000-unit ceiling, and the presumptive acronym entries' listening pass.

Closes #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
