### PR TITLE
fix(tts): exclude doc-backlink navigation text from narratable extraction

### DIFF
--- a/build/audio/word-fragments.test.ts
+++ b/build/audio/word-fragments.test.ts
@@ -71,4 +71,44 @@ describe('injectWordFragments', () => {
       expect(narratableText.slice(f.charStart, f.charEnd)).toBe(f.text);
     }
   });
+
+  it('excludes endnote backlink glyphs from narration but leaves the visible HTML intact', () => {
+    // The endnotes epubOverride appends a `↩` backlink anchor to each note
+    // (see build/filters/endnotes.ts renderNotesSection). It's navigation
+    // chrome, not content — it must not be synthesized or given a word span.
+    const backlink =
+      '<a epub:type="backlink" role="doc-backlink" class="endnote-backlink" ' +
+      'href="#fnref-note1" aria-label="Back to reference 1">↩</a>';
+    const html =
+      `<li epub:type="endnote" id="en-note1" class="endnote">\n` +
+      `<p><span class="endnote-num">[1]</span> A note about Jeeves. ${backlink}</p></li>`;
+
+    const { html: outHtml, narratableText, fragments } = injectWordFragments(html);
+
+    expect(narratableText).not.toContain('↩');
+    expect(outHtml).toContain('>↩</a>');
+    expect(fragments.map((f) => f.text)).toEqual(['1', 'A', 'note', 'about', 'Jeeves']);
+    for (const f of fragments) {
+      expect(narratableText.slice(f.charStart, f.charEnd)).toBe(f.text);
+    }
+  });
+
+  it('excludes glossary backlinks and any words inside a backlink from narration', () => {
+    // The glossary backlink carries the same doc-backlink role; if its text
+    // ever becomes words instead of a glyph, it must still stay out of the
+    // narration stream.
+    const html =
+      '<p>Term — definition ' +
+      '<a epub:type="backlink" role="doc-backlink" class="gloss-backlink" ' +
+      'href="#gloss-1-ref" aria-label="Back to text">Back to text</a></p>';
+
+    const { html: outHtml, narratableText, fragments } = injectWordFragments(html);
+
+    expect(narratableText).not.toContain('Back to text');
+    expect(outHtml).toContain('>Back to text</a>');
+    expect(fragments.map((f) => f.text)).toEqual(['Term', 'definition']);
+    for (const f of fragments) {
+      expect(narratableText.slice(f.charStart, f.charEnd)).toBe(f.text);
+    }
+  });
 });

--- a/build/audio/word-fragments.ts
+++ b/build/audio/word-fragments.ts
@@ -56,6 +56,18 @@ const TOKEN_PATTERN = new RegExp(`${ENTITY_SOURCE}|${WORD_SOURCE}`, 'gu');
 const TAG_PATTERN = /<[^>]+>/g;
 
 /**
+ * Opening tags of navigation-only elements whose text must not be narrated:
+ * the `↩` backlink anchors the endnotes/glossary overrides append to each
+ * note (`role="doc-backlink"` / `epub:type="backlink"`). Their text stays in
+ * the visible HTML but is excluded from the narratable text — it would
+ * otherwise be synthesized aloud and assigned a word boundary.
+ */
+const NON_NARRATED_TAG = /^<[a-zA-Z][^>]*(?:role="doc-backlink"|epub:type="backlink")/;
+
+/** Extracts the element name from a tag, e.g. `</a>` → `a`. */
+const TAG_NAME = /^<\/?([a-zA-Z][a-zA-Z0-9-]*)/;
+
+/**
  * Wrap each word in the text nodes of `html` with `<span id="w{n}">`,
  * leaving tags, entities, and other non-word characters (whitespace,
  * punctuation) untouched. Ids are sequential within this call, starting
@@ -97,12 +109,40 @@ export function injectWordFragments(html: string, startIndex = 1): WordFragmentR
     narratableText += segment.slice(lastEnd);
   };
 
+  // While non-null, the walker is inside a navigation-only element (e.g. a
+  // doc-backlink anchor): text passes through to the HTML verbatim but is
+  // withheld from the narratable text and gets no fragment spans.
+  let suppressTagName: string | null = null;
+  let suppressDepth = 0;
+
   TAG_PATTERN.lastIndex = 0;
   let tagMatch: RegExpExecArray | null;
   while ((tagMatch = TAG_PATTERN.exec(html))) {
-    appendTextSegment(html.slice(cursor, tagMatch.index));
-    outHtml += tagMatch[0];
-    cursor = tagMatch.index + tagMatch[0].length;
+    const text = html.slice(cursor, tagMatch.index);
+    if (suppressTagName) {
+      outHtml += text;
+    } else {
+      appendTextSegment(text);
+    }
+
+    const tag = tagMatch[0];
+    outHtml += tag;
+    cursor = tagMatch.index + tag.length;
+
+    const name = TAG_NAME.exec(tag)?.[1];
+    if (suppressTagName) {
+      // Track nesting of same-named tags until the suppressed element closes.
+      if (name === suppressTagName) {
+        if (tag.startsWith('</')) {
+          if (--suppressDepth === 0) suppressTagName = null;
+        } else if (!tag.endsWith('/>')) {
+          suppressDepth++;
+        }
+      }
+    } else if (name && !tag.startsWith('</') && !tag.endsWith('/>') && NON_NARRATED_TAG.test(tag)) {
+      suppressTagName = name;
+      suppressDepth = 1;
+    }
   }
   appendTextSegment(html.slice(cursor));
 


### PR DESCRIPTION
## What changed

`injectWordFragments()` in `build/audio/word-fragments.ts` now suppresses the text content of navigation-only elements — anchors carrying `role="doc-backlink"` / `epub:type="backlink"` — from the narratable text and from word-fragment spans, while passing the visible XHTML through byte-identical.

## Why

The endnote and glossary backlink anchors (`↩`) rendered by the endnotes epubOverride (`build/filters/endnotes.ts`) are navigation chrome, not content, but they flowed into the TTS narration stream: synthesized aloud and each assigned a word boundary (14 in the `02-field-guide/04-home` chapter alone, verified in the AVSpeech spike full-chapter run on 2026-07-30).

## Notes for review

- The filter keys off the DPUB-ARIA role rather than the `↩` glyph, so if the backlink text ever changes to words it stays excluded — a unit test covers that case explicitly.
- Offset consistency is preserved: `narratableText` and `fragments[].charStart/charEnd` are built in the same pass, so WordBoundary/marker events still reconcile. Verified end-to-end by rendering every chapter: 322 backlinks remain in the visible HTML, 0 in the narratable text, 0 fragment-offset mismatches book-wide (04-home: 14 → 0 with 7,618 fragments intact).
- New tests in `build/audio/word-fragments.test.ts`: an endnote `<li>` with a `↩` backlink, and a glossary backlink whose text is words. Both were watched to fail before the fix (TDD).
- Pre-existing, unrelated failures in `tts-spike.test.ts` / `sqlite-source.test.ts` (missing optional deps) fail identically on a clean tree.
- The `[1]` endnote number labels are still narrated intentionally — a listener needs to hear which note they're on. The same mechanism extends to `class="endnote-num"` if suppressing those is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)