### PR TITLE
chore: ignore narration cache, sync README with package.json scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 .wrangler/
 scripts/avspeech-spike/.build/
 scripts/avspeech-spike/dist/
+.cache/

--- a/README.md
+++ b/README.md
@@ -13,11 +13,24 @@ This book is a practical guide to using AI agents to navigate the systems that g
 ```bash
 npm install
 npm run build        # tsc + generate ePub
+npm run build:site   # tsc + generate the companion website
+npm run build:pdf    # tsc + generate the print PDF
+npm run build:all    # ePub + website in one pass
 npm run build:check  # type-check only
 npm test             # vitest
 ```
 
-The output is `dist/majordomo.epub`.
+The ePub output is `dist/majordomo.epub`.
+
+### Other scripts
+
+```bash
+npm run tts:spike        # exploratory TTS spike script
+npm run narration:plan   # plan narration work for the read-along audiobook
+npm run sync:notes       # sync Apple Books highlights/annotations to GitHub Issues
+```
+
+See `npm run sync:notes:install` / `sync:notes:uninstall` / `sync:notes:status` for managing the Apple Books sync as a scheduled job.
 
 ## Illustrations
 


### PR DESCRIPTION
## Summary
- Add `.cache/` (the incremental narration cache) to `.gitignore` — it was untracked and showing up as noise in `git status`.
- Document `build:site`, `build:pdf`, `build:all`, and the narration/Apple-Books-sync tooling scripts in the README, which previously only covered `build`/`build:check`/`test`.

## Related cleanup (already done directly on GitHub, no code changes)
While auditing for doc/issue drift, also reconciled a few stale open issues against actual repo state — mentioned here for context, not part of this diff:
- Closed #161 and #167 (both resolved by #178's AVSpeech pipeline; PR body never used an auto-close keyword).
- Updated #140's title/count from 19 → 23 missing illustrations (4 new art briefs added since it was filed).

## Test plan
- [x] `npm run build:check` passes
- [x] `npm test` passes (206/206)
- [x] `git status` is clean with `.cache/` present but ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)